### PR TITLE
Feat/create providers user pool

### DIFF
--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -89,7 +89,7 @@ class UserPool(CdkUserPool):
         """
         Creates an app client for the UI to authenticate with the user pool.
 
-        :param callback_urls: The URLs that Cognito will redirect to after authentication.
+        :param callback_urls: The URLs that Cognito allows the UI to redirect to after authentication.
         :param read_attributes: The attributes that the UI can read.
         :param write_attributes: The attributes that the UI can write.
         :param ui_scopes: OAuth scopes that are allowed with this client

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -3,7 +3,7 @@ from typing import List
 from aws_cdk import CfnOutput, Duration, RemovalPolicy
 from aws_cdk.aws_cognito import UserPool as CdkUserPool, UserPoolEmail, AccountRecovery, AutoVerifiedAttrs, \
     AdvancedSecurityMode, DeviceTracking, Mfa, MfaSecondFactor, PasswordPolicy, StandardAttributes, \
-    StandardAttribute, CognitoDomainOptions, AuthFlow, OAuthSettings, OAuthFlows, ClientAttributes, \
+    CognitoDomainOptions, AuthFlow, OAuthSettings, OAuthFlows, ClientAttributes, \
     CfnUserPoolRiskConfigurationAttachment, OAuthScope
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -81,7 +81,19 @@ class UserPool(CdkUserPool):
             ]
         )
 
-    def add_ui_client(self, callback_urls: List[str], ui_scopes: List[OAuthScope] = None):
+    def add_ui_client(self,
+                      callback_urls: List[str],
+                      read_attributes: ClientAttributes,
+                      write_attributes: ClientAttributes,
+                      ui_scopes: List[OAuthScope] = None):
+        """
+        Creates an app client for the UI to authenticate with the user pool.
+
+        :param callback_urls: The URLs that Cognito will redirect to after authentication.
+        :param read_attributes: The attributes that the UI can read.
+        :param write_attributes: The attributes that the UI can write.
+        :param ui_scopes: OAuth scopes that are allowed with this client
+        """
         return self.add_client(
             'UIClient',
             auth_flows=AuthFlow(
@@ -103,11 +115,8 @@ class UserPool(CdkUserPool):
             enable_token_revocation=True,
             generate_secret=False,
             refresh_token_validity=Duration.days(30),
-            # If you provide no attributes at all here, it will default
-            # to making _all_ attributes writeable, so if we want to limit writes,
-            # we have to provide at least _one_ that the client _can_ write.
-            write_attributes=ClientAttributes().with_standard_attributes(email=True),
-            read_attributes=ClientAttributes().with_standard_attributes(email=True)
+            read_attributes=read_attributes,
+            write_attributes=write_attributes,
         )
 
     def _add_risk_configuration(self):

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -17,6 +17,7 @@ class UserPool(CdkUserPool):
             environment_name: str,
             encryption_key: IKey,
             email: UserPoolEmail,
+            standard_attributes: StandardAttributes,
             removal_policy,
             **kwargs
     ):
@@ -42,12 +43,7 @@ class UserPool(CdkUserPool):
             self_sign_up_enabled=False,
             sign_in_aliases=None,
             sign_in_case_sensitive=False,
-            standard_attributes=StandardAttributes(
-                email=StandardAttribute(
-                    mutable=False,
-                    required=True
-                )
-            ),
+            standard_attributes=standard_attributes,
             **kwargs
         )
 

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -1,10 +1,10 @@
-from typing import List
+from typing import List, Optional, Mapping
 
 from aws_cdk import CfnOutput, Duration, RemovalPolicy
 from aws_cdk.aws_cognito import UserPool as CdkUserPool, UserPoolEmail, AccountRecovery, AutoVerifiedAttrs, \
     AdvancedSecurityMode, DeviceTracking, Mfa, MfaSecondFactor, PasswordPolicy, StandardAttributes, \
     CognitoDomainOptions, AuthFlow, OAuthSettings, OAuthFlows, ClientAttributes, \
-    CfnUserPoolRiskConfigurationAttachment, OAuthScope
+    CfnUserPoolRiskConfigurationAttachment, OAuthScope, ICustomAttribute
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -19,6 +19,7 @@ class UserPool(CdkUserPool):
             email: UserPoolEmail,
             standard_attributes: StandardAttributes,
             removal_policy,
+            custom_attributes: Optional[Mapping[str, ICustomAttribute]] = None,
             **kwargs
     ):
         super().__init__(
@@ -44,6 +45,7 @@ class UserPool(CdkUserPool):
             sign_in_aliases=None,
             sign_in_case_sensitive=False,
             standard_attributes=standard_attributes,
+            custom_attributes=custom_attributes,
             **kwargs
         )
 

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -12,6 +12,7 @@ from stacks.persistent_stack.license_table import LicenseTable
 from stacks.persistent_stack.event_bus import EventBus
 from stacks.persistent_stack.provider_table import ProviderTable
 from stacks.persistent_stack.staff_users import StaffUsers
+from stacks.persistent_stack.provider_users import ProviderUsers
 from stacks.persistent_stack.user_email_notifications import UserEmailNotifications
 
 # cdk leverages instance attributes to make resource exports accessible to other stacks
@@ -90,11 +91,25 @@ class PersistentStack(AppStack):
             user_pool_email=user_pool_email_settings,
             removal_policy=removal_policy
         )
+
+        provider_prefix = f'{app_name}-provider'
+        self.provider_users = ProviderUsers(
+            self, 'ProviderUsers',
+            cognito_domain_prefix=provider_prefix if environment_name == 'prod'
+            else f'{provider_prefix}-{environment_name}',
+            environment_name=environment_name,
+            environment_context=environment_context,
+            encryption_key=self.shared_encryption_key,
+            user_pool_email=user_pool_email_settings,
+            removal_policy=removal_policy
+        )
+
         if self.hosted_zone:
-            # The SES email identity needs to be created before the user pool
+            # The SES email identity needs to be created before the user pools
             # so that the domain address will be verified before being referenced
             # by the user pool email settings
             self.staff_users.node.add_dependency(self.user_email_notifications)
+            self.provider_users.node.add_dependency(self.user_email_notifications)
 
     def _add_mock_data_resources(self):
         self.mock_bulk_uploads_bucket = BulkUploadsBucket(

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -32,8 +32,10 @@ class ProviderUsers(UserPool):
             email=user_pool_email,
             standard_attributes=_configure_user_pool_standard_attributes(),
             custom_attributes={
-                # once the providerId is set, it cannot be changed
-                "providerId": StringAttribute(mutable=False)
+                # these fields are required in order for the provider to be able to query
+                # for their personal profile information. Once these fields are set, they cannot be changed.
+                "providerId": StringAttribute(mutable=False),
+                "compact": StringAttribute(mutable=False)
             },
             **kwargs
         )
@@ -56,10 +58,10 @@ class ProviderUsers(UserPool):
         self.ui_client = self.add_ui_client(
             callback_urls=callback_urls,
             # For now, we are allowing the user to read and update their email, given name, and family name.
-            # we only allow the user to be able to see their providerId, which is a custom attribute.
+            # we only allow the user to be able to see their providerId and compact, which are custom attributes.
             # If we ever want other attributes to be read or written, they must be added here.
             read_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True)
-                                              .with_custom_attributes("providerId"),
+                                              .with_custom_attributes("providerId", "compact"),
             write_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True)
         )
 

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aws_cdk.aws_cognito import UserPoolEmail, StandardAttributes, StandardAttribute, ClientAttributes
+from aws_cdk.aws_cognito import UserPoolEmail, StandardAttributes, StandardAttribute, ClientAttributes, StringAttribute
 from aws_cdk.aws_kms import IKey
 from constructs import Construct
 
@@ -31,6 +31,10 @@ class ProviderUsers(UserPool):
             removal_policy=removal_policy,
             email=user_pool_email,
             standard_attributes=_configure_user_pool_standard_attributes(),
+            custom_attributes={
+                # once the providerId is set, it cannot be changed
+                "providerId": StringAttribute(mutable=False)
+            },
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)
@@ -52,8 +56,10 @@ class ProviderUsers(UserPool):
         self.ui_client = self.add_ui_client(
             callback_urls=callback_urls,
             # For now, we are allowing the user to read and update their email, given name, and family name.
+            # we only allow the user to be able to see their providerId, which is a custom attribute.
             # If we ever want other attributes to be read or written, they must be added here.
-            read_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True),
+            read_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True)
+                                              .with_custom_attributes("providerId"),
             write_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True)
         )
 

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from aws_cdk.aws_cognito import UserPoolEmail
+from aws_cdk.aws_kms import IKey
+from constructs import Construct
+
+from common_constructs.user_pool import UserPool
+from stacks import persistent_stack as ps
+
+
+class ProviderUsers(UserPool):
+    """
+    User pool for medical providers (aka Licensees)
+    """
+    def __init__(
+            self, scope: Construct, construct_id: str, *,
+            cognito_domain_prefix: str,
+            environment_name: str,
+            environment_context: dict,
+            encryption_key: IKey,
+            user_pool_email: UserPoolEmail,
+            removal_policy,
+            **kwargs
+    ):
+        super().__init__(
+            scope, construct_id,
+            cognito_domain_prefix=cognito_domain_prefix,
+            environment_name=environment_name,
+            encryption_key=encryption_key,
+            removal_policy=removal_policy,
+            email=user_pool_email,
+            **kwargs
+        )
+        stack: ps.PersistentStack = ps.PersistentStack.of(self)
+
+        callback_urls = []
+        if stack.ui_domain_name is not None:
+            callback_urls.append(f'https://{stack.ui_domain_name}/auth/callback')
+        # This toggle will allow front-end devs to point their local UI at this environment's user pool to support
+        # authenticated actions.
+        if environment_context.get('allow_local_ui', False):
+            local_ui_port = environment_context.get('local_ui_port', '3018')
+            callback_urls.append(f'http://localhost:{local_ui_port}/auth/callback')
+        if not callback_urls:
+            raise ValueError(
+                "This app requires a callback url for its authentication path. Either provide 'domain_name' or set "
+                "'allow_local_ui' to true in this environment's context.")
+
+        # Create an app client to allow the front-end to authenticate.
+        self.ui_client = self.add_ui_client(callback_urls=callback_urls)

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -12,6 +12,7 @@ class ProviderUsers(UserPool):
     """
     User pool for medical providers (aka Licensees)
     """
+
     def __init__(
             self, scope: Construct, construct_id: str, *,
             cognito_domain_prefix: str,

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aws_cdk.aws_cognito import UserPoolEmail
+from aws_cdk.aws_cognito import UserPoolEmail, StandardAttributes, StandardAttribute
 from aws_cdk.aws_kms import IKey
 from constructs import Construct
 
@@ -29,6 +29,12 @@ class ProviderUsers(UserPool):
             encryption_key=encryption_key,
             removal_policy=removal_policy,
             email=user_pool_email,
+            standard_attributes=StandardAttributes(
+                email=StandardAttribute(
+                    mutable=False,
+                    required=True
+                )
+            ),
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -64,14 +64,14 @@ def _configure_user_pool_standard_attributes() -> StandardAttributes:
 
         Note that these values can never change! If you need to make other attributes
         required in the future, you must create an entirely new user pool and migrate
-        existing users to the new pool. see https://repost.aws/knowledge-center/cognito-change-user-pool-attributes
+        existing users to the new pool. See https://repost.aws/knowledge-center/cognito-change-user-pool-attributes
 
         These attributes are used to display on a provider's profile page. We do not
         intend to use them for authentication purposes or for back-end processing.
     """
     return StandardAttributes(
         # We are requiring the following attributes for all users
-        # that are registered in the provider user pool
+        # that are registered in the provider user pool.
         email=StandardAttribute(
             mutable=True,
             required=True
@@ -84,7 +84,7 @@ def _configure_user_pool_standard_attributes() -> StandardAttributes:
             mutable=True,
             required=True
         ),
-        # the following attributes are not required, but we are including them because
+        # The following attributes are not required, but we are including them because
         # Cognito does not allow you to add them after the user pool is created, and we
         # may want to use them in the future.
         address=StandardAttribute(

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -29,12 +29,7 @@ class ProviderUsers(UserPool):
             encryption_key=encryption_key,
             removal_policy=removal_policy,
             email=user_pool_email,
-            standard_attributes=StandardAttributes(
-                email=StandardAttribute(
-                    mutable=False,
-                    required=True
-                )
-            ),
+            standard_attributes=_configure_user_pool_standard_attributes(),
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)
@@ -54,3 +49,88 @@ class ProviderUsers(UserPool):
 
         # Create an app client to allow the front-end to authenticate.
         self.ui_client = self.add_ui_client(callback_urls=callback_urls)
+
+
+def _configure_user_pool_standard_attributes() -> StandardAttributes:
+    """
+        The provider user pool standard attributes.
+
+        These attributes are used to display on a provider's profile page. We do not
+        intend to use them for authentication purposes or for back-end processing.
+    """
+    return StandardAttributes(
+        # We are requiring the following attributes for all users
+        # that are registered in the provider user pool
+        email=StandardAttribute(
+            mutable=True,
+            required=True
+        ),
+        given_name=StandardAttribute(
+            mutable=True,
+            required=True
+        ),
+        family_name=StandardAttribute(
+            mutable=True,
+            required=True
+        ),
+        # the following attributes are not required, but we are including them because
+        # Cognito does not allow you to add them after the user pool is created, and we
+        # may want to use them in the future.
+        # see https://repost.aws/knowledge-center/cognito-change-user-pool-attributes
+        address=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        birthdate=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        fullname=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        gender=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        last_update_time=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        locale=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        middle_name=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        nickname=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        phone_number=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        preferred_username=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        profile_page=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        profile_picture=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        timezone=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        website=StandardAttribute(
+            mutable=True,
+            required=False
+        )
+    )

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -142,7 +142,7 @@ class StaffUsers(UserPool):
             suppressions=[{
                 'id': 'AwsSolutions-IAM5',
                 'reason': 'This lambda role policy contains wildcards in its statements, but all of its actions are '
-                          'limited specifically to the actions and the Table it needs read access to.'
+                'limited specifically to the actions and the Table it needs read access to.'
             }]
         )
         self.add_trigger(

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 import json
 import os
 
-from aws_cdk.aws_cognito import (ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail,
-                                 StandardAttributes, StandardAttribute)
+from aws_cdk.aws_cognito import ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail, \
+    StandardAttributes, StandardAttribute
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -18,6 +18,7 @@ class StaffUsers(UserPool):
     """
     User pool for Compact, Board, and CSG staff
     """
+
     def __init__(
             self, scope: Construct, construct_id: str, *,
             cognito_domain_prefix: str,
@@ -136,7 +137,7 @@ class StaffUsers(UserPool):
             suppressions=[{
                 'id': 'AwsSolutions-IAM5',
                 'reason': 'This lambda role policy contains wildcards in its statements, but all of its actions are '
-                'limited specifically to the actions and the Table it needs read access to.'
+                          'limited specifically to the actions and the Table it needs read access to.'
             }]
         )
         self.add_trigger(

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -3,7 +3,7 @@ import json
 import os
 
 from aws_cdk.aws_cognito import ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail, \
-    StandardAttributes, StandardAttribute
+    StandardAttributes, StandardAttribute, ClientAttributes
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -70,7 +70,12 @@ class StaffUsers(UserPool):
 
         # Do not allow resource server scopes via the client - they are assigned via token customization
         # to allow for user attribute-based access
-        self.ui_client = self.add_ui_client(callback_urls=callback_urls)
+        self.ui_client = self.add_ui_client(
+            callback_urls=callback_urls,
+            # We want to limit the attributes that this app can read and write so only email is visible.
+            read_attributes=ClientAttributes().with_standard_attributes(email=True),
+            write_attributes=ClientAttributes().with_standard_attributes(email=True)
+        )
 
     def _add_resource_servers(self):
         """

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import json
 import os
 
-from aws_cdk.aws_cognito import ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail
+from aws_cdk.aws_cognito import (ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail,
+                                 StandardAttributes, StandardAttribute)
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -34,6 +35,12 @@ class StaffUsers(UserPool):
             encryption_key=encryption_key,
             removal_policy=removal_policy,
             email=user_pool_email,
+            standard_attributes=StandardAttributes(
+                email=StandardAttribute(
+                    mutable=False,
+                    required=True
+                )
+            ),
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)

--- a/backend/compact-connect/tests/unit/test_app.py
+++ b/backend/compact-connect/tests/unit/test_app.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from aws_cdk import Stack
 from aws_cdk.assertions import Annotations, Match, Template
 from aws_cdk.aws_apigateway import CfnMethod
-from aws_cdk.aws_cognito import CfnUserPoolClient
+from aws_cdk.aws_cognito import CfnUserPoolClient, CfnUserPool
 
 from app import CompactConnectApp
 from stacks.api_stack import ApiStack
@@ -14,6 +14,28 @@ from stacks.persistent_stack import PersistentStack
 
 
 class TestApp(TestCase):
+
+    def _when_testing_production_stack_synth(self):
+        with open('cdk.json', 'r') as f:
+            context = json.load(f)['context']
+        with open('cdk.context.production-example.json', 'r') as f:
+            context['ssm_context'] = json.load(f)['ssm_context']
+
+        # Suppresses lambda bundling for tests
+        context['aws:cdk:bundling-stacks'] = []
+
+        return context
+
+    def _when_testing_sandbox_stack_synth(self):
+        with open('cdk.json', 'r') as f:
+            context = json.load(f)['context']
+        with open('cdk.context.sandbox-example.json', 'r') as f:
+            context.update(json.load(f))
+
+        # Suppresses lambda bundling for tests
+        context['aws:cdk:bundling-stacks'] = []
+
+        return context
 
     def test_no_compact_jurisdiction_name_clash(self):
         """
@@ -42,13 +64,7 @@ class TestApp(TestCase):
         """
         Test infrastructure as deployed via the pipeline
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.production-example.json', 'r') as f:
-            context['ssm_context'] = json.load(f)['ssm_context']
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
+        context = self._when_testing_production_stack_synth()
 
         app = CompactConnectApp(context=context)
 
@@ -86,13 +102,7 @@ class TestApp(TestCase):
         """
         Test infrastructure as deployed in a developer's sandbox
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.sandbox-example.json', 'r') as f:
-            context.update(json.load(f))
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
+        context = self._when_testing_sandbox_stack_synth()
 
         app = CompactConnectApp(context=context)
 
@@ -115,15 +125,9 @@ class TestApp(TestCase):
         In the case where they opt _not_ to set up a hosted zone and domain name for their sandbox,
         we will skip setting up domain names and DNS records for the API and UI.
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.sandbox-example.json', 'r') as f:
-            context.update(json.load(f))
+        context = self._when_testing_sandbox_stack_synth()
         # Drop domain name to ensure we still handle the optional DNS setup
         del context['ssm_context']['environments'][context['environment_name']]['domain_name']
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
 
         app = CompactConnectApp(context=context)
 
@@ -144,15 +148,10 @@ class TestApp(TestCase):
         If a developer tries to deploy this app without either a domain name or allowing a local UI, the app
         should fail to synthesize.
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.sandbox-example.json', 'r') as f:
-            context.update(json.load(f))
+        context = self._when_testing_sandbox_stack_synth()
+
         del context['ssm_context']['environments'][context['environment_name']]['domain_name']
         del context['ssm_context']['environments'][context['environment_name']]['allow_local_ui']
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
 
         with self.assertRaises(ValueError):
             CompactConnectApp(context=context)
@@ -161,16 +160,10 @@ class TestApp(TestCase):
         """
         Test infrastructure as deployed in a developer's sandbox
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.sandbox-example.json', 'r') as f:
-            context.update(json.load(f))
+        context = self._when_testing_sandbox_stack_synth()
 
         del context['ssm_context']['environments'][context['environment_name']]['domain_name']
         context['ssm_context']['environments'][context['environment_name']]['local_ui_port'] = '5432'
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
 
         app = CompactConnectApp(context=context)
 
@@ -186,6 +179,33 @@ class TestApp(TestCase):
             local_ui_port='5432'
         )
         self._inspect_api_stack(app.sandbox_stage.api_stack)
+
+    def test_synth_generates_provider_user_pool_with_expected_custom_attributes(self):
+        """
+        Test infrastructure as deployed in a developer's sandbox
+        """
+        context = self._when_testing_sandbox_stack_synth()
+
+        app = CompactConnectApp(context=context)
+        persistent_stack_template = Template.from_stack(app.sandbox_stage.persistent_stack)
+
+        # Ensure our Staff user pool is created
+        persistent_stack_template.has_resource_properties(
+            type=CfnUserPool.CFN_RESOURCE_TYPE_NAME,
+            props={
+                "Schema": Match.array_with([
+                    {
+                        "Name": "providerId",
+                        "AttributeDataType": "String",
+                        "Mutable": False
+                    },
+                    {
+                        "Name": "compact",
+                        "AttributeDataType": "String",
+                        "Mutable": False
+                    }
+                ]
+        )})
 
     def _inspect_persistent_stack(
             self,
@@ -205,15 +225,39 @@ class TestApp(TestCase):
             local_ui_port = '3018' if not local_ui_port else local_ui_port
             callbacks.append(f'http://localhost:{local_ui_port}/auth/callback')
 
-        # Ensure our Staff user pool is configured with the expected callbacks
+        # ensure we have two user pools, one for staff users and one for providers
+        persistent_stack_template.resource_count_is(CfnUserPool.CFN_RESOURCE_TYPE_NAME, 2)
+
+        # Ensure our Staff user pool is configured with the expected callbacks and read/write attributes
         persistent_stack_template.has_resource(
             type=CfnUserPoolClient.CFN_RESOURCE_TYPE_NAME,
             props={
                 'Properties': {
-                    'CallbackURLs': callbacks
+                    'CallbackURLs': callbacks,
+                    "ReadAttributes": ["email"],
+                    "WriteAttributes": ["email"],
                 }
             }
         )
+
+        # Ensure our Provider user pool is created with expected values
+        persistent_stack_template.has_resource_properties(
+            type=CfnUserPoolClient.CFN_RESOURCE_TYPE_NAME,
+            props={
+                "ReadAttributes": Match.array_equals([
+                    "custom:compact",
+                    "custom:providerId",
+                    "email",
+                    "family_name",
+                    "given_name"
+                ]),
+                "WriteAttributes": Match.array_equals([
+                    "email",
+                    "family_name",
+                    "given_name"
+                ]),
+                "CallbackURLs": callbacks
+            })
 
     def _inspect_api_stack(self, api_stack: ApiStack):
         api_template = Template.from_stack(api_stack)

--- a/backend/compact-connect/tests/unit/test_app.py
+++ b/backend/compact-connect/tests/unit/test_app.py
@@ -189,7 +189,7 @@ class TestApp(TestCase):
         app = CompactConnectApp(context=context)
         persistent_stack_template = Template.from_stack(app.sandbox_stage.persistent_stack)
 
-        # Ensure our Staff user pool is created
+        # Ensure our provider user pool is created
         persistent_stack_template.has_resource_properties(
             type=CfnUserPool.CFN_RESOURCE_TYPE_NAME,
             props={


### PR DESCRIPTION
We need to have a separate user pool to track licensee users (AKA providers) so they can authenticate with the app
separately from staff users.

### Requirements List
- No new requirements for this change.

### Description List
- Update UserPool common construct to allow child classes to define list of standard attributes.
- Added ProviderUsers construct with email configuration, standard attributes, and custom `providerId` and `compact` attributes.

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review

Closes #201 
