### PR TITLE
Update check branch to accept development or any ancestor of developm…

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -8,8 +8,19 @@ jobs:
   check_branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Check branch
-        if: github.head_ref != 'development'
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check if branch is based on development
         run: |
-          echo "ERROR: You can only merge to main from development."
-          exit 1
+          # Fetch development branch
+          git fetch origin development
+
+          # Check if the current branch contains commits from the development branch
+          if git merge-base --is-ancestor origin/development HEAD; then
+            exit 0
+          else
+            echo "ERROR: The branch is not based on the 'development' branch."
+            exit 1
+          fi
+        shell: bash

--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -17,7 +17,7 @@ jobs:
           git fetch origin development
 
           # Check if the current branch contains commits from the development branch
-          if git merge-base --is-ancestor origin/development HEAD; then
+          if git merge-base --is-ancestor HEAD origin/development; then
             exit 0
           else
             echo "ERROR: The branch is not based on the 'development' branch."


### PR DESCRIPTION
…ent when merging into main.

This allows me to "freeze" the development branch for end-of-sprint code reviews, so that any PRs from future sprints that get merged into development are not included in this PR.

### Requirements List
-

### Description List
-

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- ???

Closes #
