### PR TITLE
Update check-branch.yml to fetch full git history

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Check if branch is based on development
         run: |


### PR DESCRIPTION
Only the most recent development commit is fetched by default within Github Actions. This clones the entire git history.