### PR TITLE
Bugfix: validate licenseType on POST licenses schema

### DIFF
--- a/backend/compact-connect/lambdas/provider-data-v1/data_model/schema/license.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/data_model/schema/license.py
@@ -47,6 +47,13 @@ class LicensePostSchema(LicensePublicSchema):
     phoneNumber = ITUTE164PhoneNumber(required=False, allow_none=False)
 
 
+    @validates_schema
+    def validate_license_type(self, data, **kwargs):  # pylint: disable=unused-argument
+        license_types = config.license_types_for_compact(data['compact'])
+        if data['licenseType'] not in license_types:
+            raise ValidationError({'licenseType': f"'licenseType' must be one of {license_types}"})
+
+
 @BaseRecordSchema.register_schema('license')
 class LicenseRecordSchema(BaseRecordSchema, LicensePostSchema):
     """
@@ -56,12 +63,6 @@ class LicenseRecordSchema(BaseRecordSchema, LicensePostSchema):
 
     # Provided fields
     providerId = UUID(required=True, allow_none=False)
-
-    @validates_schema
-    def validate_license_type(self, data, **kwargs):  # pylint: disable=unused-argument
-        license_types = config.license_types_for_compact(data['compact'])
-        if data['licenseType'] not in license_types:
-            raise ValidationError({'licenseType': f"'licenseType' must be one of {license_types}"})
 
     @pre_dump
     def generate_pk_sk(self, in_data, **kwargs):  # pylint: disable=unused-argument

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_licenses.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_licenses.py
@@ -1,0 +1,47 @@
+import json
+
+from moto import mock_aws
+from tests.function import TstFunction
+
+
+@mock_aws
+class TestLicenses(TstFunction):
+    def test_post_licenses(self):
+        from handlers.licenses import post_licenses
+
+        with open('tests/resources/api-event.json', 'r') as f:
+            event = json.load(f)
+
+        # The user has read permission for aslp
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read aslp/write aslp/oh.write'
+        event['pathParameters'] = {
+            'compact': 'aslp',
+            'jurisdiction': 'oh'
+        }
+        with open('tests/resources/api/license-post.json', 'r') as f:
+            event['body'] = json.dumps([json.load(f)])
+
+        resp = post_licenses(event, self.mock_context)
+
+        self.assertEqual(200, resp['statusCode'])
+
+    def test_post_licenses_invalid_license_type(self):
+        from handlers.licenses import post_licenses
+
+        with open('tests/resources/api-event.json', 'r') as f:
+            event = json.load(f)
+
+        # The user has read permission for aslp
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read aslp/write aslp/oh.write'
+        event['pathParameters'] = {
+            'compact': 'aslp',
+            'jurisdiction': 'oh'
+        }
+        with open('tests/resources/api/license-post.json', 'r') as f:
+            license_data = json.load(f)
+        license_data['licenseType'] = 'occupational therapist'
+        event['body'] = json.dumps([license_data])
+
+        resp = post_licenses(event, self.mock_context)
+
+        self.assertEqual(400, resp['statusCode'])


### PR DESCRIPTION
 I discovered a bug in the API validation while I was doing unrelated things. This closes a testing gap and fixes the bug.

### Description List
- Add function tests of the post_licenses handler
- Move license type validation to parent schema class (`LicensePostSchema`)