### PR TITLE
Address voice a11y ux on user search input

### DIFF
--- a/webroot/src/components/Users/UserList/UserList.less
+++ b/webroot/src/components/Users/UserList/UserList.less
@@ -21,5 +21,9 @@
                 width: 50%;
             }
         }
+
+        .user-search-submit {
+            .visually-hidden();
+        }
     }
 }

--- a/webroot/src/components/Users/UserList/UserList.vue
+++ b/webroot/src/components/Users/UserList/UserList.vue
@@ -12,6 +12,12 @@
             <div class="search-container">
                 <form @submit.prevent="handleSearch">
                     <InputSearch :formInput="formData.userSearch" class="user-search" />
+                    <input
+                        type="submit"
+                        class="user-search-submit"
+                        tabindex="-1"
+                        :aria-label="$t('common.submit')"
+                    />
                 </form>
             </div>
         </div>

--- a/webroot/src/styles.common/_mixins.less
+++ b/webroot/src/styles.common/_mixins.less
@@ -11,3 +11,4 @@
 @import './mixins/list-wrap';
 @import './mixins/element-focus';
 @import './mixins/lazy-load';
+@import './mixins/visually-hidden';

--- a/webroot/src/styles.common/mixins/visually-hidden.less
+++ b/webroot/src/styles.common/mixins/visually-hidden.less
@@ -1,0 +1,17 @@
+//
+//  visually-hidden.less
+//  InspiringApps modules
+//
+//  Created by InspiringApps on 10/10/24.
+//
+
+.visually-hidden() {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+}


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Added a global visually-hidden CSS mixin class
- Created a hidden submit input on the user list search form, removed submit from tabindex

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Manually navigate (via URL bar) to `octp/Users`
    - _Replace `/octp` with `/aslp` or `/coun` if needed to accommodate personal permissions_
    - Ensure the user search still submits via keyboard as expected
        - _Depending on compact permissions, this user management feature may not be allowed, but for purposes of this PR, you can simply check that the network request was submitted_
    - Ensure the new submit button is not visible and is not in the tab order
    - Ensure the VoiceOver experience is more clear

Closes #223 
