### PR TITLE
Bug/staff user query error

### DIFF
--- a/backend/compact-connect/lambdas/staff-users/data_model/client.py
+++ b/backend/compact-connect/lambdas/staff-users/data_model/client.py
@@ -108,6 +108,7 @@ class UserClient:
         """
         logger.info('Updating staff user permissions', user_id=user_id)
 
+        # Creating a mutable collection so the handlers can add their collected changes
         update_expression_parts = {'add': [], 'delete': []}
 
         # DynamoDB does not support both ADD and DELETE on the same String Set in a single UpdateItem call, so we will

--- a/backend/compact-connect/lambdas/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -1,5 +1,6 @@
 import json
 
+from boto3.dynamodb.types import TypeSerializer
 from moto import mock_aws
 
 from tests.function import TstFunction
@@ -36,6 +37,78 @@ class TestPatchUser(TstFunction):
                 },
                 'type': 'user',
                 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797',
+            },
+            user,
+        )
+
+    def test_patch_user_document_path_overlap(self):
+        user = {
+            'pk': 'USER#648864e8-10f1-702f-e666-2e0ff3482502',
+            'sk': 'COMPACT#octp',
+            'attributes': {
+                'email': 'test@example.com',
+                'familyName': 'User',
+                'givenName': 'Test',
+            },
+            'compact': 'octp',
+            'dateOfUpdate': '2024-10-21',
+            'famGiv': 'User#Test',
+            'permissions': {
+                'actions': {'read'}, 'jurisdictions': {'co': ['admin', 'write']}
+            },
+            'type': 'user',
+            'userId': '648864f8-10f1-702f-e666-2e0ff3482502',
+        }
+        self._table.put_item(Item=user)
+
+        from handlers.users import patch_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email octp/admin octp/octp.admin octp/co.admin'
+        event['pathParameters'] = {'compact': 'octp', 'userId': '648864e8-10f1-702f-e666-2e0ff3482502'}
+        event['body'] = json.dumps(
+            {
+                "permissions": {
+                    "octp": {
+                        "actions": {
+                            "read": True,
+                            "admin": False
+                        },
+                        "jurisdictions": {
+                            "co": {
+                                "actions": {
+                                    "write": True,
+                                    "admin": False
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        resp = patch_user(event, self.mock_context)
+
+        self.assertEqual(200, resp['statusCode'])
+        user = json.loads(resp['body'])
+        self.assertEqual(
+            {
+                'attributes': {
+                    'email': 'test@example.com',
+                    'familyName': 'User',
+                    'givenName': 'Test',
+                },
+                'dateOfUpdate': '2024-09-12',
+                'permissions': {
+                    'aslp': {
+                        'actions': {'read': True},
+                        'jurisdictions': {'oh': {'actions': {'admin': True, 'write': True}}},
+                    },
+                },
+                'type': 'user',
+                'userId': '648864e8-10f1-702f-e666-2e0ff3482502',
             },
             user,
         )


### PR DESCRIPTION
We identified a bug in the PATCH staff user method, where the updates fail if both `true` and `false` are provided in the same `actions` block in the request body. This update addresses that bug.

Closes #268 