### PR TITLE
Remove CODEOWNERS to support new PR workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @isabeleliassen @jlkravitz @carlsims


### PR DESCRIPTION
Remove CODEOWNERS file because, under the new PR workflow, I should not be assigned to review until the IA team is done with their internal review.