### PR TITLE
Feat/ Add endpoint for compact admins to securely store payment processor credentials

### DIFF
--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "LicenseApi",
-    "version": "2024-10-02T23:57:27Z"
+    "version": "2024-11-01T16:20:45Z"
   },
   "servers": [
     {
@@ -38,6 +38,131 @@
       }
     },
     "/v1/compacts/{compact}": {
+      "options": {
+        "parameters": [
+          {
+            "name": "compact",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "204 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        }
+      }
+    },
+    "/v1/compacts/{compact}/credentials": {
+      "options": {
+        "parameters": [
+          {
+            "name": "compact",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "204 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        }
+      }
+    },
+    "/v1/compacts/{compact}/credentials/payment-processor": {
+      "post": {
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "compact",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestALicen2DxWvSHGB8ZT"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestALicen7iusNLvek0yj"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+              "aslp/write",
+              "octp/write",
+              "coun/write"
+            ]
+          }
+        ]
+      },
       "options": {
         "parameters": [
           {
@@ -111,51 +236,6 @@
         }
       }
     },
-    "/v1/compacts/{compact}/jurisdictions/{jurisdiction}": {
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "jurisdiction",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
     "/v1/compacts/{compact}/jurisdictions/{jurisdiction}/licenses": {
       "post": {
         "parameters": [
@@ -188,7 +268,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicensqVdeqIDiTUV"
+                "$ref": "#/components/schemas/TestALicenQnccteKO7FNN"
               }
             }
           },
@@ -200,7 +280,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenBHELNobWpOAZ"
+                  "$ref": "#/components/schemas/TestALicenS9gR8xZuJOb4"
                 }
               }
             }
@@ -208,7 +288,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "aslp/write",
               "octp/write",
               "coun/write"
@@ -294,7 +374,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenkelmvshNMdxq"
+                  "$ref": "#/components/schemas/TestALicenT3OCiUvjLlXl"
                 }
               }
             }
@@ -302,7 +382,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "aslp/write",
               "octp/write",
               "coun/write"
@@ -415,7 +495,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenkzXEuzbeBMcD"
+                "$ref": "#/components/schemas/TestALicengFI2IjAAwZc7"
               }
             }
           },
@@ -427,7 +507,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenk4wMidJp4tSI"
+                  "$ref": "#/components/schemas/TestALicennsvm2JbTZqEp"
                 }
               }
             }
@@ -435,7 +515,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "aslp/read",
               "octp/read",
               "coun/read"
@@ -513,7 +593,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenPWICF4WAig5B"
+                  "$ref": "#/components/schemas/TestALicen6fga18DSl6Sn"
                 }
               }
             }
@@ -521,7 +601,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "aslp/read",
               "octp/read",
               "coun/read"
@@ -598,7 +678,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennisEwvBxWQhC"
+                  "$ref": "#/components/schemas/TestALicenqqK4VgZ1dlWA"
                 }
               }
             }
@@ -606,7 +686,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "aslp/admin",
               "octp/admin",
               "coun/admin"
@@ -629,7 +709,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenDIQiicBLz4mm"
+                "$ref": "#/components/schemas/TestALicenj5DRkv2XbJUf"
               }
             }
           },
@@ -648,7 +728,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
                 }
               }
             }
@@ -656,7 +736,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "aslp/admin",
               "octp/admin",
               "coun/admin"
@@ -733,7 +813,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
                 }
               }
             }
@@ -741,7 +821,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "aslp/admin",
               "octp/admin",
               "coun/admin"
@@ -815,7 +895,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenNYOXdr8q1V6F"
+                "$ref": "#/components/schemas/TestALiceniunEmG0FUtea"
               }
             }
           },
@@ -834,7 +914,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
                 }
               }
             }
@@ -842,7 +922,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "aslp/admin",
               "octp/admin",
               "coun/admin"
@@ -896,7 +976,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenPWICF4WAig5B"
+                  "$ref": "#/components/schemas/TestALicen6fga18DSl6Sn"
                 }
               }
             }
@@ -904,7 +984,156 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
+            "PipelineStackTestAPIStackLicenseApiProviderUsersPoolAuthorizer835C0D15": []
+          }
+        ]
+      },
+      "options": {
+        "responses": {
+          "204": {
+            "description": "204 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        }
+      }
+    },
+    "/v1/purchases": {
+      "options": {
+        "responses": {
+          "204": {
+            "description": "204 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        }
+      }
+    },
+    "/v1/purchases/privileges": {
+      "post": {
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestALicenr0uVXCmc87u6"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestALicen65XdldxsvHUq"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "PipelineStackTestAPIStackLicenseApiProviderUsersPoolAuthorizer835C0D15": []
+          }
+        ]
+      },
+      "options": {
+        "responses": {
+          "204": {
+            "description": "204 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        }
+      }
+    },
+    "/v1/purchases/privileges/options": {
+      "get": {
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestALiceniV1nHletAsLX"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "PipelineStackTestAPIStackLicenseApiProviderUsersPoolAuthorizer835C0D15": []
           }
         ]
       },
@@ -976,7 +1205,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
                 }
               }
             }
@@ -984,7 +1213,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "profile"
             ]
           }
@@ -1020,7 +1249,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicencwCJNumn5Our"
+                "$ref": "#/components/schemas/TestALicensJLzcZ2dT5m4"
               }
             }
           },
@@ -1039,7 +1268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
                 }
               }
             }
@@ -1047,7 +1276,7 @@
         },
         "security": [
           {
-            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
               "profile"
             ]
           }
@@ -1057,7 +1286,24 @@
   },
   "components": {
     "schemas": {
-      "SandboLicenBHELNobWpOAZ": {
+      "TestALicenT3OCiUvjLlXl": {
+        "required": [
+          "fields"
+        ],
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "TestALicenS9gR8xZuJOb4": {
         "required": [
           "message"
         ],
@@ -1069,7 +1315,7 @@
         },
         "additionalProperties": false
       },
-      "SandboLicenkzXEuzbeBMcD": {
+      "TestALicengFI2IjAAwZc7": {
         "required": [
           "query"
         ],
@@ -1194,1124 +1440,7 @@
         },
         "additionalProperties": false
       },
-      "SandboLicenkelmvshNMdxq": {
-        "required": [
-          "fields"
-        ],
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "url": {
-            "type": "string"
-          }
-        }
-      },
-      "SandboLicenk4wMidJp4tSI": {
-        "required": [
-          "pagination"
-        ],
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "sorting": {
-            "required": [
-              "key"
-            ],
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "description": "The key to sort results by",
-                "enum": [
-                  "dateOfUpdate",
-                  "familyName"
-                ]
-              },
-              "direction": {
-                "type": "string",
-                "description": "Direction to sort results by",
-                "enum": [
-                  "ascending",
-                  "descending"
-                ]
-              }
-            },
-            "description": "How to sort results"
-          },
-          "providers": {
-            "maxLength": 100,
-            "type": "array",
-            "items": {
-              "required": [
-                "birthMonthDay",
-                "compact",
-                "dateOfBirth",
-                "dateOfExpiration",
-                "dateOfUpdate",
-                "familyName",
-                "givenName",
-                "homeAddressCity",
-                "homeAddressPostalCode",
-                "homeAddressState",
-                "homeAddressStreet1",
-                "licenseJurisdiction",
-                "licenseType",
-                "privilegeJurisdictions",
-                "providerId",
-                "ssn",
-                "status",
-                "type"
-              ],
-              "type": "object",
-              "properties": {
-                "licenseJurisdiction": {
-                  "type": "string",
-                  "enum": [
-                    "al",
-                    "ak",
-                    "az",
-                    "ar",
-                    "ca",
-                    "co",
-                    "ct",
-                    "de",
-                    "dc",
-                    "fl",
-                    "ga",
-                    "hi",
-                    "id",
-                    "il",
-                    "in",
-                    "ia",
-                    "ks",
-                    "ky",
-                    "la",
-                    "me",
-                    "md",
-                    "ma",
-                    "mi",
-                    "mn",
-                    "ms",
-                    "mo",
-                    "mt",
-                    "ne",
-                    "nv",
-                    "nh",
-                    "nj",
-                    "nm",
-                    "ny",
-                    "nc",
-                    "nd",
-                    "oh",
-                    "ok",
-                    "or",
-                    "pa",
-                    "pr",
-                    "ri",
-                    "sc",
-                    "sd",
-                    "tn",
-                    "tx",
-                    "ut",
-                    "vt",
-                    "va",
-                    "vi",
-                    "wa",
-                    "wv",
-                    "wi",
-                    "wy"
-                  ]
-                },
-                "compact": {
-                  "type": "string",
-                  "enum": [
-                    "aslp",
-                    "octp",
-                    "coun"
-                  ]
-                },
-                "homeAddressStreet2": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "npi": {
-                  "pattern": "^[0-9]{10}$",
-                  "type": "string"
-                },
-                "homeAddressPostalCode": {
-                  "maxLength": 7,
-                  "minLength": 5,
-                  "type": "string"
-                },
-                "givenName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "homeAddressStreet1": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "militaryWaiver": {
-                  "type": "boolean"
-                },
-                "dateOfBirth": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "privilegeJurisdictions": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "al",
-                      "ak",
-                      "az",
-                      "ar",
-                      "ca",
-                      "co",
-                      "ct",
-                      "de",
-                      "dc",
-                      "fl",
-                      "ga",
-                      "hi",
-                      "id",
-                      "il",
-                      "in",
-                      "ia",
-                      "ks",
-                      "ky",
-                      "la",
-                      "me",
-                      "md",
-                      "ma",
-                      "mi",
-                      "mn",
-                      "ms",
-                      "mo",
-                      "mt",
-                      "ne",
-                      "nv",
-                      "nh",
-                      "nj",
-                      "nm",
-                      "ny",
-                      "nc",
-                      "nd",
-                      "oh",
-                      "ok",
-                      "or",
-                      "pa",
-                      "pr",
-                      "ri",
-                      "sc",
-                      "sd",
-                      "tn",
-                      "tx",
-                      "ut",
-                      "vt",
-                      "va",
-                      "vi",
-                      "wa",
-                      "wv",
-                      "wi",
-                      "wy"
-                    ]
-                  }
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "provider"
-                  ]
-                },
-                "ssn": {
-                  "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-                  "type": "string"
-                },
-                "licenseType": {
-                  "type": "string",
-                  "enum": [
-                    "audiologist",
-                    "speech-language pathologist",
-                    "speech and language pathologist",
-                    "occupational therapist",
-                    "occupational therapy assistant",
-                    "licensed professional counselor",
-                    "licensed mental health counselor",
-                    "licensed clinical mental health counselor",
-                    "licensed professional clinical counselor"
-                  ]
-                },
-                "dateOfExpiration": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "homeAddressState": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "providerId": {
-                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
-                  "type": "string"
-                },
-                "familyName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "homeAddressCity": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "middleName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "birthMonthDay": {
-                  "pattern": "^[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "dateOfUpdate": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "active",
-                    "inactive"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "SandboLicennisEwvBxWQhC": {
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "users": {
-            "type": "array",
-            "items": {
-              "required": [
-                "attributes",
-                "permissions",
-                "userId"
-              ],
-              "type": "object",
-              "properties": {
-                "permissions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "read": {
-                            "type": "boolean"
-                          },
-                          "admin": {
-                            "type": "boolean"
-                          }
-                        }
-                      },
-                      "jurisdictions": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "object",
-                          "properties": {
-                            "actions": {
-                              "type": "object",
-                              "properties": {
-                                "admin": {
-                                  "type": "boolean"
-                                },
-                                "write": {
-                                  "type": "boolean"
-                                }
-                              },
-                              "additionalProperties": false
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                },
-                "attributes": {
-                  "type": "object",
-                  "properties": {
-                    "givenName": {
-                      "maxLength": 100,
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "maxLength": 100,
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "email": {
-                      "maxLength": 100,
-                      "minLength": 5,
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "userId": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenq0WHjwuOL0r5": {
-        "required": [
-          "attributes",
-          "permissions",
-          "userId"
-        ],
-        "type": "object",
-        "properties": {
-          "permissions": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "actions": {
-                  "type": "object",
-                  "properties": {
-                    "read": {
-                      "type": "boolean"
-                    },
-                    "admin": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "jurisdictions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "attributes": {
-            "type": "object",
-            "properties": {
-              "givenName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "familyName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "email": {
-                "maxLength": 100,
-                "minLength": 5,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          },
-          "userId": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicensqVdeqIDiTUV": {
-        "maxLength": 100,
-        "type": "array",
-        "items": {
-          "required": [
-            "dateOfBirth",
-            "dateOfExpiration",
-            "dateOfIssuance",
-            "dateOfRenewal",
-            "familyName",
-            "givenName",
-            "homeAddressCity",
-            "homeAddressPostalCode",
-            "homeAddressState",
-            "homeAddressStreet1",
-            "licenseType",
-            "ssn",
-            "status"
-          ],
-          "type": "object",
-          "properties": {
-            "homeAddressStreet2": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "npi": {
-              "pattern": "^[0-9]{10}$",
-              "type": "string"
-            },
-            "homeAddressPostalCode": {
-              "maxLength": 7,
-              "minLength": 5,
-              "type": "string"
-            },
-            "givenName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeAddressStreet1": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "militaryWaiver": {
-              "type": "boolean"
-            },
-            "dateOfBirth": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfIssuance": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "ssn": {
-              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-              "type": "string"
-            },
-            "licenseType": {
-              "type": "string",
-              "enum": [
-                "audiologist",
-                "speech-language pathologist",
-                "speech and language pathologist",
-                "occupational therapist",
-                "occupational therapy assistant",
-                "licensed professional counselor",
-                "licensed mental health counselor",
-                "licensed clinical mental health counselor",
-                "licensed professional clinical counselor"
-              ]
-            },
-            "dateOfExpiration": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "homeAddressState": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "dateOfRenewal": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "familyName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeAddressCity": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "middleName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "active",
-                "inactive"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "SandboLicencwCJNumn5Our": {
-        "type": "object",
-        "properties": {
-          "attributes": {
-            "type": "object",
-            "properties": {
-              "givenName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "familyName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenNYOXdr8q1V6F": {
-        "type": "object",
-        "properties": {
-          "permissions": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "actions": {
-                  "type": "object",
-                  "properties": {
-                    "read": {
-                      "type": "boolean"
-                    },
-                    "admin": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "jurisdictions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenDIQiicBLz4mm": {
-        "required": [
-          "attributes",
-          "permissions"
-        ],
-        "type": "object",
-        "properties": {
-          "permissions": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "actions": {
-                  "type": "object",
-                  "properties": {
-                    "read": {
-                      "type": "boolean"
-                    },
-                    "admin": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "jurisdictions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "attributes": {
-            "type": "object",
-            "properties": {
-              "givenName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "familyName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "email": {
-                "maxLength": 100,
-                "minLength": 5,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenowMgGlcoqmaG": {
-        "required": [
-          "items",
-          "pagination"
-        ],
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "sorting": {
-            "required": [
-              "key"
-            ],
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "enum": [
-                  "dateOfUpdate",
-                  "familyName"
-                ]
-              },
-              "direction": {
-                "type": "string",
-                "enum": [
-                  "ascending",
-                  "descending"
-                ]
-              }
-            },
-            "description": "Required if ssn is not provided"
-          },
-          "items": {
-            "maxLength": 100,
-            "type": "array",
-            "items": {
-              "required": [
-                "compact",
-                "dateOfBirth",
-                "dateOfExpiration",
-                "dateOfIssuance",
-                "dateOfRenewal",
-                "dateOfUpdate",
-                "familyName",
-                "givenName",
-                "homeStateCity",
-                "homeStatePostalCode",
-                "homeStateStreet1",
-                "jurisdiction",
-                "licenseType",
-                "providerId",
-                "ssn",
-                "status",
-                "type"
-              ],
-              "type": "object",
-              "properties": {
-                "compact": {
-                  "type": "string",
-                  "enum": [
-                    "aslp",
-                    "octp",
-                    "coun"
-                  ]
-                },
-                "homeStateStreet2": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "homeStateStreet1": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "npi": {
-                  "pattern": "^[0-9]{10}$",
-                  "type": "string"
-                },
-                "homeStatePostalCode": {
-                  "maxLength": 7,
-                  "minLength": 5,
-                  "type": "string"
-                },
-                "jurisdiction": {
-                  "type": "string",
-                  "enum": [
-                    "al",
-                    "ak",
-                    "az",
-                    "ar",
-                    "ca",
-                    "co",
-                    "ct",
-                    "de",
-                    "dc",
-                    "fl",
-                    "ga",
-                    "hi",
-                    "id",
-                    "il",
-                    "in",
-                    "ia",
-                    "ks",
-                    "ky",
-                    "la",
-                    "me",
-                    "md",
-                    "ma",
-                    "mi",
-                    "mn",
-                    "ms",
-                    "mo",
-                    "mt",
-                    "ne",
-                    "nv",
-                    "nh",
-                    "nj",
-                    "nm",
-                    "ny",
-                    "nc",
-                    "nd",
-                    "oh",
-                    "ok",
-                    "or",
-                    "pa",
-                    "pr",
-                    "ri",
-                    "sc",
-                    "sd",
-                    "tn",
-                    "tx",
-                    "ut",
-                    "vt",
-                    "va",
-                    "vi",
-                    "wa",
-                    "wv",
-                    "wi",
-                    "wy"
-                  ]
-                },
-                "givenName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "dateOfBirth": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "license-home"
-                  ]
-                },
-                "homeStateCity": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "dateOfIssuance": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "ssn": {
-                  "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-                  "type": "string"
-                },
-                "licenseType": {
-                  "type": "string",
-                  "enum": [
-                    "audiologist",
-                    "speech-language pathologist",
-                    "speech and language pathologist",
-                    "occupational therapist",
-                    "occupational therapy assistant",
-                    "licensed professional counselor",
-                    "licensed mental health counselor",
-                    "licensed clinical mental health counselor",
-                    "licensed professional clinical counselor"
-                  ]
-                },
-                "dateOfExpiration": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "providerId": {
-                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
-                  "type": "string"
-                },
-                "dateOfRenewal": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "familyName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "middleName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "dateOfUpdate": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "active",
-                    "inactive"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        }
-      },
-      "SandboLicenvvAhG5tzNXFz": {
-        "maxLength": 100,
-        "type": "array",
-        "items": {
-          "required": [
-            "dateOfBirth",
-            "dateOfExpiration",
-            "dateOfIssuance",
-            "dateOfRenewal",
-            "familyName",
-            "givenName",
-            "homeStateCity",
-            "homeStatePostalCode",
-            "homeStateStreet1",
-            "licenseType",
-            "ssn",
-            "status"
-          ],
-          "type": "object",
-          "properties": {
-            "homeStateStreet2": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeStateStreet1": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "npi": {
-              "pattern": "^[0-9]{10}$",
-              "type": "string"
-            },
-            "homeStatePostalCode": {
-              "maxLength": 7,
-              "minLength": 5,
-              "type": "string"
-            },
-            "givenName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "dateOfBirth": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "homeStateCity": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "dateOfIssuance": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "ssn": {
-              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-              "type": "string"
-            },
-            "licenseType": {
-              "type": "string",
-              "enum": [
-                "audiologist",
-                "speech-language pathologist",
-                "speech and language pathologist",
-                "occupational therapist",
-                "occupational therapy assistant",
-                "licensed professional counselor",
-                "licensed mental health counselor",
-                "licensed clinical mental health counselor",
-                "licensed professional clinical counselor"
-              ]
-            },
-            "dateOfExpiration": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfRenewal": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "familyName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "middleName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "active",
-                "inactive"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "SandboLicenuSflhMgaapO3": {
+      "TestALicenofZ5WRAY94p1": {
         "required": [
           "query"
         ],
@@ -2443,7 +1572,98 @@
         },
         "additionalProperties": false
       },
-      "SandboLicenPWICF4WAig5B": {
+      "TestALicen8yCTSsT1DDdY": {
+        "required": [
+          "attributes",
+          "permissions",
+          "userId"
+        ],
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "read": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jurisdictions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "write": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "email": {
+                "maxLength": 100,
+                "minLength": 5,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "userId": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TestALicen65XdldxsvHUq": {
+        "required": [
+          "transactionId"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the transaction"
+          },
+          "transactionId": {
+            "type": "string",
+            "description": "The transaction id for the purchase"
+          }
+        }
+      },
+      "TestALicen6fga18DSl6Sn": {
         "required": [
           "birthMonthDay",
           "compact",
@@ -2985,16 +2205,1383 @@
             ]
           }
         }
+      },
+      "TestALiceniunEmG0FUtea": {
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "read": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jurisdictions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "write": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "TestALicenWppIphQZnnDs": {
+        "maxLength": 100,
+        "type": "array",
+        "items": {
+          "required": [
+            "dateOfBirth",
+            "dateOfExpiration",
+            "dateOfIssuance",
+            "dateOfRenewal",
+            "familyName",
+            "givenName",
+            "homeStateCity",
+            "homeStatePostalCode",
+            "homeStateStreet1",
+            "licenseType",
+            "ssn",
+            "status"
+          ],
+          "type": "object",
+          "properties": {
+            "homeStateStreet2": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeStateStreet1": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "npi": {
+              "pattern": "^[0-9]{10}$",
+              "type": "string"
+            },
+            "homeStatePostalCode": {
+              "maxLength": 7,
+              "minLength": 5,
+              "type": "string"
+            },
+            "givenName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "dateOfBirth": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "homeStateCity": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "dateOfIssuance": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "ssn": {
+              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+              "type": "string"
+            },
+            "licenseType": {
+              "type": "string",
+              "enum": [
+                "audiologist",
+                "speech-language pathologist",
+                "speech and language pathologist",
+                "occupational therapist",
+                "occupational therapy assistant",
+                "licensed professional counselor",
+                "licensed mental health counselor",
+                "licensed clinical mental health counselor",
+                "licensed professional clinical counselor"
+              ]
+            },
+            "dateOfExpiration": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfRenewal": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "familyName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "middleName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "active",
+                "inactive"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "TestALiceniV1nHletAsLX": {
+        "required": [
+          "items",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "lastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
+              }
+            }
+          },
+          "items": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "required": [
+                    "compactCommissionFee",
+                    "compactName",
+                    "type"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "compactCommissionFee": {
+                      "required": [
+                        "feeAmount",
+                        "feeType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "feeAmount": {
+                          "type": "number"
+                        },
+                        "feeType": {
+                          "type": "string",
+                          "enum": [
+                            "FLAT_RATE"
+                          ]
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "compact"
+                      ]
+                    },
+                    "compactName": {
+                      "type": "string",
+                      "description": "The name of the compact"
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "jurisdictionFee",
+                    "jurisdictionName",
+                    "jurisprudenceRequirements",
+                    "postalAbbreviation",
+                    "type"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "militaryDiscount": {
+                      "required": [
+                        "active",
+                        "discountAmount",
+                        "discountType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the military discount is active"
+                        },
+                        "discountAmount": {
+                          "type": "number",
+                          "description": "The amount of the discount"
+                        },
+                        "discountType": {
+                          "type": "string",
+                          "description": "The type of discount",
+                          "enum": [
+                            "FLAT_RATE"
+                          ]
+                        }
+                      }
+                    },
+                    "postalAbbreviation": {
+                      "type": "string",
+                      "description": "The postal abbreviation of the jurisdiction"
+                    },
+                    "jurisprudenceRequirements": {
+                      "required": [
+                        "required"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether jurisprudence requirements exist"
+                        }
+                      }
+                    },
+                    "jurisdictionName": {
+                      "type": "string",
+                      "description": "The name of the jurisdiction"
+                    },
+                    "jurisdictionFee": {
+                      "type": "number",
+                      "description": "The fee for the jurisdiction"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "jurisdiction"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "TestALicen2DxWvSHGB8ZT": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "object",
+            "properties": {
+              "apiLoginId": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string",
+                "description": "The api login id for the payment processor"
+              },
+              "transactionKey": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string",
+                "description": "The transaction key for the payment processor"
+              },
+              "processor": {
+                "type": "string",
+                "description": "The type of payment processor",
+                "enum": [
+                  "authorize.net"
+                ]
+              }
+            },
+            "description": "payment processor credentials"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TestALicenr0uVXCmc87u6": {
+        "required": [
+          "orderInformation",
+          "selectedJurisdictions"
+        ],
+        "type": "object",
+        "properties": {
+          "orderInformation": {
+            "required": [
+              "billing",
+              "card"
+            ],
+            "type": "object",
+            "properties": {
+              "card": {
+                "required": [
+                  "cvv",
+                  "expiration",
+                  "number"
+                ],
+                "type": "object",
+                "properties": {
+                  "number": {
+                    "maxLength": 19,
+                    "minLength": 15,
+                    "type": "string",
+                    "description": "The card number"
+                  },
+                  "cvv": {
+                    "maxLength": 4,
+                    "minLength": 3,
+                    "type": "string",
+                    "description": "The card cvv"
+                  },
+                  "expiration": {
+                    "maxLength": 7,
+                    "minLength": 7,
+                    "type": "string",
+                    "description": "The card expiration date"
+                  }
+                }
+              },
+              "billing": {
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "state",
+                  "streetAddress",
+                  "zip"
+                ],
+                "type": "object",
+                "properties": {
+                  "zip": {
+                    "maxLength": 10,
+                    "minLength": 5,
+                    "type": "string",
+                    "description": "The zip code for the card"
+                  },
+                  "firstName": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "The first name on the card"
+                  },
+                  "lastName": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "The last name on the card"
+                  },
+                  "streetAddress": {
+                    "maxLength": 150,
+                    "minLength": 2,
+                    "type": "string",
+                    "description": "The street address for the card"
+                  },
+                  "streetAddress2": {
+                    "maxLength": 150,
+                    "type": "string",
+                    "description": "The second street address for the card"
+                  },
+                  "state": {
+                    "maxLength": 2,
+                    "minLength": 2,
+                    "type": "string",
+                    "description": "The state postal abbreviation for the card"
+                  }
+                }
+              }
+            }
+          },
+          "selectedJurisdictions": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Jurisdictions a provider has selected to purchase privileges in.",
+              "enum": [
+                "al",
+                "ak",
+                "az",
+                "ar",
+                "ca",
+                "co",
+                "ct",
+                "de",
+                "dc",
+                "fl",
+                "ga",
+                "hi",
+                "id",
+                "il",
+                "in",
+                "ia",
+                "ks",
+                "ky",
+                "la",
+                "me",
+                "md",
+                "ma",
+                "mi",
+                "mn",
+                "ms",
+                "mo",
+                "mt",
+                "ne",
+                "nv",
+                "nh",
+                "nj",
+                "nm",
+                "ny",
+                "nc",
+                "nd",
+                "oh",
+                "ok",
+                "or",
+                "pa",
+                "pr",
+                "ri",
+                "sc",
+                "sd",
+                "tn",
+                "tx",
+                "ut",
+                "vt",
+                "va",
+                "vi",
+                "wa",
+                "wv",
+                "wi",
+                "wy"
+              ]
+            }
+          }
+        }
+      },
+      "TestALicenQnccteKO7FNN": {
+        "maxLength": 100,
+        "type": "array",
+        "items": {
+          "required": [
+            "dateOfBirth",
+            "dateOfExpiration",
+            "dateOfIssuance",
+            "dateOfRenewal",
+            "familyName",
+            "givenName",
+            "homeAddressCity",
+            "homeAddressPostalCode",
+            "homeAddressState",
+            "homeAddressStreet1",
+            "licenseType",
+            "ssn",
+            "status"
+          ],
+          "type": "object",
+          "properties": {
+            "homeAddressStreet2": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "npi": {
+              "pattern": "^[0-9]{10}$",
+              "type": "string"
+            },
+            "homeAddressPostalCode": {
+              "maxLength": 7,
+              "minLength": 5,
+              "type": "string"
+            },
+            "givenName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeAddressStreet1": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "militaryWaiver": {
+              "type": "boolean"
+            },
+            "dateOfBirth": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfIssuance": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "ssn": {
+              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+              "type": "string"
+            },
+            "licenseType": {
+              "type": "string",
+              "enum": [
+                "audiologist",
+                "speech-language pathologist",
+                "speech and language pathologist",
+                "occupational therapist",
+                "occupational therapy assistant",
+                "licensed professional counselor",
+                "licensed mental health counselor",
+                "licensed clinical mental health counselor",
+                "licensed professional clinical counselor"
+              ]
+            },
+            "dateOfExpiration": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "homeAddressState": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "dateOfRenewal": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "familyName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeAddressCity": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "middleName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "active",
+                "inactive"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "TestALicennsvm2JbTZqEp": {
+        "required": [
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "lastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
+              }
+            }
+          },
+          "sorting": {
+            "required": [
+              "key"
+            ],
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key to sort results by",
+                "enum": [
+                  "dateOfUpdate",
+                  "familyName"
+                ]
+              },
+              "direction": {
+                "type": "string",
+                "description": "Direction to sort results by",
+                "enum": [
+                  "ascending",
+                  "descending"
+                ]
+              }
+            },
+            "description": "How to sort results"
+          },
+          "providers": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "required": [
+                "birthMonthDay",
+                "compact",
+                "dateOfBirth",
+                "dateOfExpiration",
+                "dateOfUpdate",
+                "familyName",
+                "givenName",
+                "homeAddressCity",
+                "homeAddressPostalCode",
+                "homeAddressState",
+                "homeAddressStreet1",
+                "licenseJurisdiction",
+                "licenseType",
+                "privilegeJurisdictions",
+                "providerId",
+                "ssn",
+                "status",
+                "type"
+              ],
+              "type": "object",
+              "properties": {
+                "licenseJurisdiction": {
+                  "type": "string",
+                  "enum": [
+                    "al",
+                    "ak",
+                    "az",
+                    "ar",
+                    "ca",
+                    "co",
+                    "ct",
+                    "de",
+                    "dc",
+                    "fl",
+                    "ga",
+                    "hi",
+                    "id",
+                    "il",
+                    "in",
+                    "ia",
+                    "ks",
+                    "ky",
+                    "la",
+                    "me",
+                    "md",
+                    "ma",
+                    "mi",
+                    "mn",
+                    "ms",
+                    "mo",
+                    "mt",
+                    "ne",
+                    "nv",
+                    "nh",
+                    "nj",
+                    "nm",
+                    "ny",
+                    "nc",
+                    "nd",
+                    "oh",
+                    "ok",
+                    "or",
+                    "pa",
+                    "pr",
+                    "ri",
+                    "sc",
+                    "sd",
+                    "tn",
+                    "tx",
+                    "ut",
+                    "vt",
+                    "va",
+                    "vi",
+                    "wa",
+                    "wv",
+                    "wi",
+                    "wy"
+                  ]
+                },
+                "compact": {
+                  "type": "string",
+                  "enum": [
+                    "aslp",
+                    "octp",
+                    "coun"
+                  ]
+                },
+                "homeAddressStreet2": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "npi": {
+                  "pattern": "^[0-9]{10}$",
+                  "type": "string"
+                },
+                "homeAddressPostalCode": {
+                  "maxLength": 7,
+                  "minLength": 5,
+                  "type": "string"
+                },
+                "givenName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "homeAddressStreet1": {
+                  "maxLength": 100,
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "militaryWaiver": {
+                  "type": "boolean"
+                },
+                "dateOfBirth": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "privilegeJurisdictions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "al",
+                      "ak",
+                      "az",
+                      "ar",
+                      "ca",
+                      "co",
+                      "ct",
+                      "de",
+                      "dc",
+                      "fl",
+                      "ga",
+                      "hi",
+                      "id",
+                      "il",
+                      "in",
+                      "ia",
+                      "ks",
+                      "ky",
+                      "la",
+                      "me",
+                      "md",
+                      "ma",
+                      "mi",
+                      "mn",
+                      "ms",
+                      "mo",
+                      "mt",
+                      "ne",
+                      "nv",
+                      "nh",
+                      "nj",
+                      "nm",
+                      "ny",
+                      "nc",
+                      "nd",
+                      "oh",
+                      "ok",
+                      "or",
+                      "pa",
+                      "pr",
+                      "ri",
+                      "sc",
+                      "sd",
+                      "tn",
+                      "tx",
+                      "ut",
+                      "vt",
+                      "va",
+                      "vi",
+                      "wa",
+                      "wv",
+                      "wi",
+                      "wy"
+                    ]
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "provider"
+                  ]
+                },
+                "ssn": {
+                  "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+                  "type": "string"
+                },
+                "licenseType": {
+                  "type": "string",
+                  "enum": [
+                    "audiologist",
+                    "speech-language pathologist",
+                    "speech and language pathologist",
+                    "occupational therapist",
+                    "occupational therapy assistant",
+                    "licensed professional counselor",
+                    "licensed mental health counselor",
+                    "licensed clinical mental health counselor",
+                    "licensed professional clinical counselor"
+                  ]
+                },
+                "dateOfExpiration": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "homeAddressState": {
+                  "maxLength": 100,
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "providerId": {
+                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
+                  "type": "string"
+                },
+                "familyName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "homeAddressCity": {
+                  "maxLength": 100,
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "middleName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "birthMonthDay": {
+                  "pattern": "^[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "dateOfUpdate": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "inactive"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "TestALicenqqK4VgZ1dlWA": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "lastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
+              }
+            }
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "required": [
+                "attributes",
+                "permissions",
+                "userId"
+              ],
+              "type": "object",
+              "properties": {
+                "permissions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "read": {
+                            "type": "boolean"
+                          },
+                          "admin": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "jurisdictions": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "actions": {
+                              "type": "object",
+                              "properties": {
+                                "admin": {
+                                  "type": "boolean"
+                                },
+                                "write": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "givenName": {
+                      "maxLength": 100,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "familyName": {
+                      "maxLength": 100,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "email": {
+                      "maxLength": 100,
+                      "minLength": 5,
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "userId": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "TestALicensOPeW9O2tyBj": {
+        "required": [
+          "items",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "lastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
+              }
+            }
+          },
+          "sorting": {
+            "required": [
+              "key"
+            ],
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "enum": [
+                  "dateOfUpdate",
+                  "familyName"
+                ]
+              },
+              "direction": {
+                "type": "string",
+                "enum": [
+                  "ascending",
+                  "descending"
+                ]
+              }
+            },
+            "description": "Required if ssn is not provided"
+          },
+          "items": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "required": [
+                "compact",
+                "dateOfBirth",
+                "dateOfExpiration",
+                "dateOfIssuance",
+                "dateOfRenewal",
+                "dateOfUpdate",
+                "familyName",
+                "givenName",
+                "homeStateCity",
+                "homeStatePostalCode",
+                "homeStateStreet1",
+                "jurisdiction",
+                "licenseType",
+                "providerId",
+                "ssn",
+                "status",
+                "type"
+              ],
+              "type": "object",
+              "properties": {
+                "compact": {
+                  "type": "string",
+                  "enum": [
+                    "aslp",
+                    "octp",
+                    "coun"
+                  ]
+                },
+                "homeStateStreet2": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "homeStateStreet1": {
+                  "maxLength": 100,
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "npi": {
+                  "pattern": "^[0-9]{10}$",
+                  "type": "string"
+                },
+                "homeStatePostalCode": {
+                  "maxLength": 7,
+                  "minLength": 5,
+                  "type": "string"
+                },
+                "jurisdiction": {
+                  "type": "string",
+                  "enum": [
+                    "al",
+                    "ak",
+                    "az",
+                    "ar",
+                    "ca",
+                    "co",
+                    "ct",
+                    "de",
+                    "dc",
+                    "fl",
+                    "ga",
+                    "hi",
+                    "id",
+                    "il",
+                    "in",
+                    "ia",
+                    "ks",
+                    "ky",
+                    "la",
+                    "me",
+                    "md",
+                    "ma",
+                    "mi",
+                    "mn",
+                    "ms",
+                    "mo",
+                    "mt",
+                    "ne",
+                    "nv",
+                    "nh",
+                    "nj",
+                    "nm",
+                    "ny",
+                    "nc",
+                    "nd",
+                    "oh",
+                    "ok",
+                    "or",
+                    "pa",
+                    "pr",
+                    "ri",
+                    "sc",
+                    "sd",
+                    "tn",
+                    "tx",
+                    "ut",
+                    "vt",
+                    "va",
+                    "vi",
+                    "wa",
+                    "wv",
+                    "wi",
+                    "wy"
+                  ]
+                },
+                "givenName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "dateOfBirth": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "license-home"
+                  ]
+                },
+                "homeStateCity": {
+                  "maxLength": 100,
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "dateOfIssuance": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "ssn": {
+                  "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+                  "type": "string"
+                },
+                "licenseType": {
+                  "type": "string",
+                  "enum": [
+                    "audiologist",
+                    "speech-language pathologist",
+                    "speech and language pathologist",
+                    "occupational therapist",
+                    "occupational therapy assistant",
+                    "licensed professional counselor",
+                    "licensed mental health counselor",
+                    "licensed clinical mental health counselor",
+                    "licensed professional clinical counselor"
+                  ]
+                },
+                "dateOfExpiration": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "providerId": {
+                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
+                  "type": "string"
+                },
+                "dateOfRenewal": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "familyName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "middleName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "dateOfUpdate": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "inactive"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "TestALicenj5DRkv2XbJUf": {
+        "required": [
+          "attributes",
+          "permissions"
+        ],
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "read": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jurisdictions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "write": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "email": {
+                "maxLength": 100,
+                "minLength": 5,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "TestALicen7iusNLvek0yj": {
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the request"
+          }
+        }
+      },
+      "TestALicensJLzcZ2dT5m4": {
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     },
     "securitySchemes": {
-      "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": {
+      "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": {
         "type": "apiKey",
         "name": "Authorization",
         "in": "header",
         "x-amazon-apigateway-authtype": "cognito_user_pools"
       },
-      "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": {
+      "PipelineStackTestAPIStackLicenseApiProviderUsersPoolAuthorizer835C0D15": {
         "type": "apiKey",
         "name": "Authorization",
         "in": "header",

--- a/backend/compact-connect/lambdas/custom-resources/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/custom-resources/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/custom-resources/requirements-dev.in
 #
-boto3==1.35.49
+boto3==1.35.52
     # via moto
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   moto

--- a/backend/compact-connect/lambdas/custom-resources/requirements.txt
+++ b/backend/compact-connect/lambdas/custom-resources/requirements.txt
@@ -6,9 +6,9 @@
 #
 aws-lambda-powertools==2.43.1
     # via -r compact-connect/lambdas/custom-resources/requirements.in
-boto3==1.35.49
+boto3==1.35.52
     # via -r compact-connect/lambdas/custom-resources/requirements.in
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   s3transfer

--- a/backend/compact-connect/lambdas/delete-objects/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/delete-objects/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/delete-objects/requirements-dev.in
 #
-boto3==1.35.49
+boto3==1.35.52
     # via moto
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   moto

--- a/backend/compact-connect/lambdas/delete-objects/requirements.txt
+++ b/backend/compact-connect/lambdas/delete-objects/requirements.txt
@@ -6,9 +6,9 @@
 #
 aws-lambda-powertools==2.43.1
     # via -r compact-connect/lambdas/delete-objects/requirements.in
-boto3==1.35.49
+boto3==1.35.52
     # via -r compact-connect/lambdas/delete-objects/requirements.in
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   s3transfer

--- a/backend/compact-connect/lambdas/license-data/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/license-data/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/license-data/requirements-dev.in
 #
-boto3==1.35.49
+boto3==1.35.52
     # via moto
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   moto

--- a/backend/compact-connect/lambdas/license-data/requirements.txt
+++ b/backend/compact-connect/lambdas/license-data/requirements.txt
@@ -6,9 +6,9 @@
 #
 aws-lambda-powertools==2.43.1
     # via -r compact-connect/lambdas/license-data/requirements.in
-boto3==1.35.49
+boto3==1.35.52
     # via -r compact-connect/lambdas/license-data/requirements.in
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   s3transfer

--- a/backend/compact-connect/lambdas/provider-data-v1/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/provider-data-v1/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/provider-data-v1/requirements-dev.in
 #
-boto3==1.35.49
+boto3==1.35.52
     # via moto
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   moto

--- a/backend/compact-connect/lambdas/provider-data-v1/requirements.txt
+++ b/backend/compact-connect/lambdas/provider-data-v1/requirements.txt
@@ -6,9 +6,9 @@
 #
 aws-lambda-powertools==2.43.1
     # via -r compact-connect/lambdas/provider-data-v1/requirements.in
-boto3==1.35.49
+boto3==1.35.52
     # via -r compact-connect/lambdas/provider-data-v1/requirements.in
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   s3transfer

--- a/backend/compact-connect/lambdas/purchases/handlers/credentials.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/credentials.py
@@ -1,7 +1,10 @@
 import json
+
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from handlers.utils import api_handler, authorize_compact
 from purchase_client import PurchaseClient
+
+from handlers.utils import api_handler, authorize_compact
+
 
 @api_handler
 @authorize_compact(action='write')
@@ -14,6 +17,4 @@ def post_payment_processor_credentials(event: dict, context: LambdaContext):  # 
     body = json.loads(event['body'])
 
     # this will raise an exception if the credentials are invalid
-    response = PurchaseClient().validate_and_store_credentials(compact_name=compact, credentials=body)
-
-    return response
+    return PurchaseClient().validate_and_store_credentials(compact_name=compact, credentials=body)

--- a/backend/compact-connect/lambdas/purchases/handlers/credentials.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/credentials.py
@@ -1,0 +1,19 @@
+import json
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from handlers.utils import api_handler, authorize_compact
+from purchase_client import PurchaseClient
+
+@api_handler
+@authorize_compact(action='write')
+def post_payment_processor_credentials(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
+    """Stores payment processor credentials for a compact in secrets manager.
+    :param event: Standard API Gateway event, API schema documented in the CDK ApiStack
+    :param LambdaContext context:
+    """
+    compact = event['pathParameters']['compact']
+    body = json.loads(event['body'])
+
+    # this will raise an exception if the credentials are invalid
+    response = PurchaseClient().validate_and_store_credentials(compact_name=compact, credentials=body)
+
+    return response

--- a/backend/compact-connect/lambdas/purchases/handlers/credentials.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/credentials.py
@@ -3,11 +3,11 @@ import json
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from purchase_client import PurchaseClient
 
-from handlers.utils import api_handler, authorize_compact
+from handlers.utils import api_handler, authorize_compact_scoped_action
 
 
 @api_handler
-@authorize_compact(action='write')
+@authorize_compact_scoped_action(action='admin')
 def post_payment_processor_credentials(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
     """Stores payment processor credentials for a compact in secrets manager.
     :param event: Standard API Gateway event, API schema documented in the CDK ApiStack

--- a/backend/compact-connect/lambdas/purchases/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/privileges.py
@@ -151,11 +151,24 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
     license_record = _find_best_license(
         [record for record in user_provider_data['items'] if record['type'] == 'license']
     )
+    existing_privilege_jurisdictions = [
+        record["jurisdiction"] for record in user_provider_data['items'] if record['type'] == 'privilege'
+    ]
     # this should never happen, but we check just in case
     if provider_record is None:
         raise CCNotFoundException('Provider not found')
     if license_record is None:
         raise CCNotFoundException('License record not found for this user')
+
+    license_jurisdiction = license_record['jurisdiction']
+    if license_jurisdiction.lower() in selected_jurisdictions_postal_abbreviations:
+        raise CCInvalidRequestException(f'Selected privilege jurisdiction \'{license_jurisdiction}\''
+                                        f' matches license jurisdiction')
+    
+    for privilege_jurisdiction in existing_privilege_jurisdictions:
+        if privilege_jurisdiction.lower() in selected_jurisdictions_postal_abbreviations:
+            raise CCInvalidRequestException(f'Selected privilege jurisdiction \'{privilege_jurisdiction}\''
+                                            f' matches existing privilege jurisdiction')
 
     license_expiration_date: date = license_record['dateOfExpiration']
     user_active_military = bool(provider_record.get('militaryWaiver', False))

--- a/backend/compact-connect/lambdas/purchases/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/privileges.py
@@ -152,7 +152,7 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
         [record for record in user_provider_data['items'] if record['type'] == 'license']
     )
     existing_privilege_jurisdictions = [
-        record["jurisdiction"] for record in user_provider_data['items'] if record['type'] == 'privilege'
+        record['jurisdiction'] for record in user_provider_data['items'] if record['type'] == 'privilege'
     ]
     # this should never happen, but we check just in case
     if provider_record is None:
@@ -162,13 +162,16 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
 
     license_jurisdiction = license_record['jurisdiction']
     if license_jurisdiction.lower() in selected_jurisdictions_postal_abbreviations:
-        raise CCInvalidRequestException(f'Selected privilege jurisdiction \'{license_jurisdiction}\''
-                                        f' matches license jurisdiction')
-    
+        raise CCInvalidRequestException(
+            f"Selected privilege jurisdiction '{license_jurisdiction}'" f' matches license jurisdiction'
+        )
+
     for privilege_jurisdiction in existing_privilege_jurisdictions:
         if privilege_jurisdiction.lower() in selected_jurisdictions_postal_abbreviations:
-            raise CCInvalidRequestException(f'Selected privilege jurisdiction \'{privilege_jurisdiction}\''
-                                            f' matches existing privilege jurisdiction')
+            raise CCInvalidRequestException(
+                f"Selected privilege jurisdiction '{privilege_jurisdiction}'"
+                f' matches existing privilege jurisdiction'
+            )
 
     license_expiration_date: date = license_record['dateOfExpiration']
     user_active_military = bool(provider_record.get('militaryWaiver', False))

--- a/backend/compact-connect/lambdas/purchases/handlers/utils.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/utils.py
@@ -109,3 +109,35 @@ def api_handler(fn: Callable):
             raise
 
     return caught_handler
+
+class authorize_compact:  # noqa: N801 invalid-name
+    """Authorize endpoint by matching path parameter compact to the expected scope, (i.e. aslp/read)"""
+
+    def __init__(self, action: str):
+        super().__init__()
+        self.action = action
+
+    def __call__(self, fn: Callable):
+        @wraps(fn)
+        @logger.inject_lambda_context
+        def authorized(event: dict, context: LambdaContext):
+            try:
+                resource_value = event['pathParameters']['compact']
+            except KeyError as e:
+                logger.error('Access attempt with missing path parameter!')
+                raise CCInvalidRequestException('Missing path parameter!') from e
+
+            logger.debug('Checking authorizer context', request_context=event['requestContext'])
+            try:
+                scopes = event['requestContext']['authorizer']['claims']['scope'].split(' ')
+            except KeyError as e:
+                logger.error('Unauthorized access attempt!', exc_info=e)
+                raise CCUnauthorizedException('Unauthorized access attempt!') from e
+
+            required_scope = f'{resource_value}/{self.action}'
+            if required_scope not in scopes:
+                logger.warning('Forbidden access attempt!')
+                raise CCAccessDeniedException('Forbidden access attempt!')
+            return fn(event, context)
+
+        return authorized

--- a/backend/compact-connect/lambdas/purchases/handlers/utils.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/utils.py
@@ -110,7 +110,7 @@ def api_handler(fn: Callable):
 
     return caught_handler
 
-def _authorize_compact_with_scope(event: dict, resource_parameter: str, scope_parameter: str, action: str):
+def _authorize_compact_with_scope(event: dict, resource_parameter: str, scope_parameter: str, action: str) -> None:
     """
     Check the authorization of the user attempting to access the endpoint.
 
@@ -161,8 +161,6 @@ def _authorize_compact_with_scope(event: dict, resource_parameter: str, scope_pa
     if required_scope not in scopes:
         logger.warning('Forbidden access attempt!')
         raise CCAccessDeniedException('Forbidden access attempt!')
-
-    return None
 
 
 class authorize_compact_jurisdiction:  # noqa: N801 invalid-name

--- a/backend/compact-connect/lambdas/purchases/handlers/utils.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/utils.py
@@ -110,6 +110,7 @@ def api_handler(fn: Callable):
 
     return caught_handler
 
+
 class authorize_compact:  # noqa: N801 invalid-name
     """Authorize endpoint by matching path parameter compact to the expected scope, (i.e. aslp/read)"""
 

--- a/backend/compact-connect/lambdas/purchases/handlers/utils.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/utils.py
@@ -146,6 +146,8 @@ def _authorize_compact_with_scope(event: dict, resource_parameter: str, scope_pa
         if scope_parameter != resource_parameter:
             scope_value = event['pathParameters'][scope_parameter]
         else:
+            # if the scope parameter is the same as the resource parameter,
+            # we use the resource value as the scope value
             scope_value = resource_value
     except KeyError as e:
         logger.error('Access attempt with missing path parameters!')

--- a/backend/compact-connect/lambdas/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/purchase_client.py
@@ -362,13 +362,12 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
             )
             return {'message': 'Successfully verified credentials'}
 
-        else:
-            logger_message = 'Failed to verify credentials.'
-            error_code = response.messages.message[0]['code'].text
-            error_message = response.messages.message[0]['text'].text
-            # logging this as a warning, as the credentials were likely invalid, but if it occurs
-            # frequently, we may want to investigate further.
-            logger.warning(logger_message, error_code=error_code, error_message=error_message)
+        logger_message = 'Failed to verify credentials.'
+        error_code = response.messages.message[0]['code'].text
+        error_message = response.messages.message[0]['text'].text
+        # logging this as a warning, as the credentials were likely invalid, but if it occurs
+        # frequently, we may want to investigate further.
+        logger.warning(logger_message, error_code=error_code, error_message=error_message)
 
         raise CCInvalidRequestException(f'{logger_message} Error code: {error_code}, Error message: {error_message}')
 
@@ -415,9 +414,7 @@ class PurchaseClient:
         self.payment_processor_client = None
 
     def _get_payment_processor_secret_name_for_compact(self, compact_name: str) -> str:
-        return (
-            f'compact-connect/env/{config.environment_name}' f'/compact/{compact_name}/credentials/payment-processor'
-        )
+        return f'compact-connect/env/{config.environment_name}' f'/compact/{compact_name}/credentials/payment-processor'
 
     def _get_compact_payment_processor_client(self, compact_name: str) -> PaymentProcessorClient:
         """

--- a/backend/compact-connect/lambdas/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/purchase_client.py
@@ -414,7 +414,7 @@ class PurchaseClient:
         self.payment_processor_client = None
 
     def _get_payment_processor_secret_name_for_compact(self, compact_name: str) -> str:
-        return f'compact-connect/env/{config.environment_name}' f'/compact/{compact_name}/credentials/payment-processor'
+        return f'compact-connect/env/{config.environment_name}/compact/{compact_name}/credentials/payment-processor'
 
     def _get_compact_payment_processor_client(self, compact_name: str) -> PaymentProcessorClient:
         """

--- a/backend/compact-connect/lambdas/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/purchase_client.py
@@ -507,12 +507,3 @@ class PurchaseClient:
             )
 
         return response
-
-
-if __name__ == '__main__':
-    purchase_client = PurchaseClient()
-    purchase_client.validate_and_store_credentials("count", {
-        "processor": "authorize.net",
-        "apiLoginId": "24xMHMr4L5TX",
-        "transactionKey": "2e732TCu3hm8Q2FF"
-    })

--- a/backend/compact-connect/lambdas/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/purchase_client.py
@@ -2,7 +2,7 @@ import json
 from abc import ABC, abstractmethod
 
 from authorizenet import apicontractsv1
-from authorizenet.apicontrollers import createTransactionController
+from authorizenet.apicontrollers import createTransactionController, getMerchantDetailsController
 from authorizenet.constants import constants
 from config import config, logger
 from data_model.schema.compact import Compact, CompactFeeType
@@ -331,25 +331,21 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
         merchant_auth.name = self.api_login_id
         merchant_auth.transactionKey = self.transaction_key
 
-        transaction_request = apicontractsv1.transactionRequestType()
-        transaction_request.transactionType = 'authenticateTestRequest'
-
-        # Assemble the complete transaction request
-        create_transaction_request = apicontractsv1.createTransactionRequest()
-        create_transaction_request.merchantAuthentication = merchant_auth
-        create_transaction_request.transactionRequest = transaction_request
+        # Assemble the get merchant details request
+        get_merchant_detail_request = apicontractsv1.getMerchantDetailsRequest()
+        get_merchant_detail_request.merchantAuthentication = merchant_auth
 
         # Create the controller
-        transaction_controller = createTransactionController(create_transaction_request)
+        get_merchant_details_controller = getMerchantDetailsController(get_merchant_detail_request)
 
         # set the environment based on the environment we are running in
         if config.environment_name != 'prod':
-            transaction_controller.setenvironment(constants.SANDBOX)
+            get_merchant_details_controller.setenvironment(constants.SANDBOX)
         else:
-            transaction_controller.setenvironment(constants.PRODUCTION)
+            get_merchant_details_controller.setenvironment(constants.PRODUCTION)
 
-        transaction_controller.execute()
-        response = transaction_controller.getresponse()
+        get_merchant_details_controller.execute()
+        response = get_merchant_details_controller.getresponse()
 
         if response is None:
             raise CCInvalidRequestException('Failed to verify credentials')
@@ -498,3 +494,8 @@ class PurchaseClient:
         )
 
         return response
+
+
+if __name__ == '__main__':
+    authorize_net = AuthorizeNetPaymentProcessorClient('24xMHMr4L5TX', '2e732TCu3hm8Q2FF')
+    authorize_net.validate_credentials()

--- a/backend/compact-connect/lambdas/purchases/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/purchases/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/purchases/requirements-dev.in
 #
-boto3==1.35.49
+boto3==1.35.52
     # via moto
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   moto

--- a/backend/compact-connect/lambdas/purchases/requirements.txt
+++ b/backend/compact-connect/lambdas/purchases/requirements.txt
@@ -8,9 +8,9 @@ authorizenet==1.1.5
     # via -r compact-connect/lambdas/purchases/requirements.in
 aws-lambda-powertools==2.43.1
     # via -r compact-connect/lambdas/purchases/requirements.in
-boto3==1.35.49
+boto3==1.35.52
     # via -r compact-connect/lambdas/purchases/requirements.in
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   s3transfer

--- a/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_credentials.py
+++ b/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_credentials.py
@@ -1,0 +1,94 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from exceptions import CCInvalidRequestException
+from moto import mock_aws
+
+from tests.function import TstFunction
+
+TEST_COMPACT = 'aslp'
+# this value is defined in the provider.json file
+TEST_PROVIDER_ID = '89a6377e-c3a5-40e5-bca5-317ec854c570'
+
+MOCK_LOGIN_ID = '1234'
+MOCK_TRANSACTION_KEY = '5678'
+
+
+def _generate_test_request_body():
+    return json.dumps(
+        {
+            'processor': 'authorize.net',
+            'apiLoginId': MOCK_LOGIN_ID,
+            'transactionKey': MOCK_TRANSACTION_KEY,
+        }
+    )
+
+@mock_aws
+class TestPostPaymentProcessorCredentials(TstFunction):
+    def _when_testing_compact_admin_uploads_creds(self):
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+            event['pathParameters'] = {
+                'compact': TEST_COMPACT
+            }
+            # user is a compact admin with write permissions
+            event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/write'
+            event['body'] = _generate_test_request_body()
+
+        return event
+
+
+    def _when_purchase_client_successfully_verifies_credentials(self, mock_purchase_client_constructor):
+        mock_purchase_client = MagicMock()
+        mock_purchase_client_constructor.return_value = mock_purchase_client
+        mock_purchase_client.validate_and_store_credentials.return_value = {
+                'message': 'Successfully verified credentials'
+            }
+
+        return mock_purchase_client
+
+    def _when_purchase_client_raises_exception(self, mock_purchase_client_constructor):
+        mock_purchase_client = MagicMock()
+        mock_purchase_client_constructor.return_value = mock_purchase_client
+        mock_purchase_client.validate_and_store_credentials.side_effect = CCInvalidRequestException(
+            # actual error code and error message from the authorize.net client
+            'Failed to verify credentials. Error code: E00124, Error message: '
+            'The provided access token is invalid'
+        )
+
+        return mock_purchase_client
+
+    @patch('handlers.credentials.PurchaseClient')
+    def test_post_payment_processor_credentials_calls_purchase_client_with_expected_parameters(
+        self, mock_purchase_client_constructor
+    ):
+        mock_purchase_client = self._when_purchase_client_successfully_verifies_credentials(
+            mock_purchase_client_constructor
+        )
+        from handlers.credentials import post_payment_processor_credentials
+
+        event = self._when_testing_compact_admin_uploads_creds()
+
+        resp = post_payment_processor_credentials(event, self.mock_context)
+        self.assertEqual(200, resp['statusCode'])
+
+        purchase_client_call_kwargs = mock_purchase_client.validate_and_store_credentials.call_args.kwargs
+
+        self.assertEqual(TEST_COMPACT, purchase_client_call_kwargs['compact_name'])
+        self.assertEqual(json.loads(event['body']), purchase_client_call_kwargs['credentials'])
+
+    @patch('handlers.credentials.PurchaseClient')
+    def test_post_payment_processor_credentials_returns_exception_message_if_credentials_invalid(self,
+                                                                                    mock_purchase_client_constructor):
+        from handlers.credentials import post_payment_processor_credentials
+
+        self._when_purchase_client_raises_exception(mock_purchase_client_constructor)
+
+        event = self._when_testing_compact_admin_uploads_creds()
+
+        resp = post_payment_processor_credentials(event, self.mock_context)
+        self.assertEqual(400, resp['statusCode'])
+        response_body = json.loads(resp['body'])
+
+        self.assertEqual({'message': 'Failed to verify credentials. Error code: E00124, Error message: '
+            'The provided access token is invalid'}, response_body)

--- a/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_credentials.py
+++ b/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_credentials.py
@@ -113,7 +113,10 @@ class TestPostPaymentProcessorCredentials(TstFunction):
     ):
         from handlers.credentials import post_payment_processor_credentials
 
-        self._when_purchase_client_raises_exception(mock_purchase_client_constructor)
+        # if authorization fails, the PurchaseClient will not be called
+        mock_purchase_client = self._when_purchase_client_successfully_verifies_credentials(
+            mock_purchase_client_constructor
+        )
 
         event = self._when_testing_jurisdiction_admin_user()
 
@@ -123,3 +126,5 @@ class TestPostPaymentProcessorCredentials(TstFunction):
 
         self.assertEqual({'message': 'Access denied'}, response_body,
         )
+
+        mock_purchase_client.validate_and_store_credentials.assert_not_called()

--- a/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_credentials.py
+++ b/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_credentials.py
@@ -23,27 +23,25 @@ def _generate_test_request_body():
         }
     )
 
+
 @mock_aws
 class TestPostPaymentProcessorCredentials(TstFunction):
     def _when_testing_compact_admin_uploads_creds(self):
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
-            event['pathParameters'] = {
-                'compact': TEST_COMPACT
-            }
+            event['pathParameters'] = {'compact': TEST_COMPACT}
             # user is a compact admin with write permissions
             event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/write'
             event['body'] = _generate_test_request_body()
 
         return event
 
-
     def _when_purchase_client_successfully_verifies_credentials(self, mock_purchase_client_constructor):
         mock_purchase_client = MagicMock()
         mock_purchase_client_constructor.return_value = mock_purchase_client
         mock_purchase_client.validate_and_store_credentials.return_value = {
-                'message': 'Successfully verified credentials'
-            }
+            'message': 'Successfully verified credentials'
+        }
 
         return mock_purchase_client
 
@@ -52,8 +50,7 @@ class TestPostPaymentProcessorCredentials(TstFunction):
         mock_purchase_client_constructor.return_value = mock_purchase_client
         mock_purchase_client.validate_and_store_credentials.side_effect = CCInvalidRequestException(
             # actual error code and error message from the authorize.net client
-            'Failed to verify credentials. Error code: E00124, Error message: '
-            'The provided access token is invalid'
+            'Failed to verify credentials. Error code: E00124, Error message: ' 'The provided access token is invalid'
         )
 
         return mock_purchase_client
@@ -78,8 +75,9 @@ class TestPostPaymentProcessorCredentials(TstFunction):
         self.assertEqual(json.loads(event['body']), purchase_client_call_kwargs['credentials'])
 
     @patch('handlers.credentials.PurchaseClient')
-    def test_post_payment_processor_credentials_returns_exception_message_if_credentials_invalid(self,
-                                                                                    mock_purchase_client_constructor):
+    def test_post_payment_processor_credentials_returns_exception_message_if_credentials_invalid(
+        self, mock_purchase_client_constructor
+    ):
         from handlers.credentials import post_payment_processor_credentials
 
         self._when_purchase_client_raises_exception(mock_purchase_client_constructor)
@@ -90,5 +88,10 @@ class TestPostPaymentProcessorCredentials(TstFunction):
         self.assertEqual(400, resp['statusCode'])
         response_body = json.loads(resp['body'])
 
-        self.assertEqual({'message': 'Failed to verify credentials. Error code: E00124, Error message: '
-            'The provided access token is invalid'}, response_body)
+        self.assertEqual(
+            {
+                'message': 'Failed to verify credentials. Error code: E00124, Error message: '
+                'The provided access token is invalid'
+            },
+            response_body,
+        )

--- a/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -167,6 +167,10 @@ class TestPostPurchasePrivileges(TstFunction):
     def test_post_purchase_privileges_returns_400_if_selected_jurisdiction_matches_existing_license(
         self, mock_purchase_client_constructor
     ):
+        """
+        In this case, the user is attempting to purchase a privilege in ohio, but they already have a license in ohio.
+        So the request should be rejected.
+        """
         from handlers.privileges import post_purchase_privileges
 
         self._when_purchase_client_successfully_processes_request(mock_purchase_client_constructor)
@@ -186,6 +190,9 @@ class TestPostPurchasePrivileges(TstFunction):
     def test_post_purchase_privileges_returns_400_if_selected_jurisdiction_matches_existing_privilege(
         self, mock_purchase_client_constructor
     ):
+        """
+        In this case, the user is attempting to purchase a privilege in kentucky twice.
+        """
         from handlers.privileges import post_purchase_privileges
 
         self._when_purchase_client_successfully_processes_request(mock_purchase_client_constructor)

--- a/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -39,6 +39,10 @@ def _generate_test_request_body(selected_jurisdictions: list[str] = None):
 
 @mock_aws
 class TestPostPurchasePrivileges(TstFunction):
+    """
+    In this test setup, we simulate having a licensee that has a license in ohio and is
+    purchasing a privilege in kentucky.
+    """
     def _load_test_jurisdiction(self):
         with open('tests/resources/dynamo/jurisdiction.json') as f:
             jurisdiction = json.load(f)

--- a/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -42,11 +42,11 @@ class TestPostPurchasePrivileges(TstFunction):
     def _load_test_jurisdiction(self):
         with open('tests/resources/dynamo/jurisdiction.json') as f:
             jurisdiction = json.load(f)
-            #swap out the jurisdiction postal abbreviation for ky
+            # swap out the jurisdiction postal abbreviation for ky
             jurisdiction['postalAbbreviation'] = 'ky'
             jurisdiction['jurisdictionName'] = 'Kentucky'
-            jurisdiction['pk'] = "aslp#CONFIGURATION"
-            jurisdiction['sk'] = "aslp#JURISDICTION#ky"
+            jurisdiction['pk'] = 'aslp#CONFIGURATION'
+            jurisdiction['sk'] = 'aslp#JURISDICTION#ky'
             self.config.compact_configuration_table.put_item(Item=jurisdiction)
 
     def _when_testing_provider_user_event_with_custom_claims(self, test_compact=TEST_COMPACT, load_license=True):
@@ -161,7 +161,7 @@ class TestPostPurchasePrivileges(TstFunction):
 
     @patch('handlers.privileges.PurchaseClient')
     def test_post_purchase_privileges_returns_400_if_selected_jurisdiction_matches_existing_license(
-            self, mock_purchase_client_constructor
+        self, mock_purchase_client_constructor
     ):
         from handlers.privileges import post_purchase_privileges
 
@@ -174,12 +174,13 @@ class TestPostPurchasePrivileges(TstFunction):
         self.assertEqual(400, resp['statusCode'])
         response_body = json.loads(resp['body'])
 
-        self.assertEqual({'message': 'Selected privilege jurisdiction \'oh\' matches license jurisdiction'},
-                         response_body)
+        self.assertEqual(
+            {'message': "Selected privilege jurisdiction 'oh' matches license jurisdiction"}, response_body
+        )
 
     @patch('handlers.privileges.PurchaseClient')
     def test_post_purchase_privileges_returns_400_if_selected_jurisdiction_matches_existing_privilege(
-            self, mock_purchase_client_constructor
+        self, mock_purchase_client_constructor
     ):
         from handlers.privileges import post_purchase_privileges
 
@@ -196,8 +197,9 @@ class TestPostPurchasePrivileges(TstFunction):
         self.assertEqual(400, resp['statusCode'])
         response_body = json.loads(resp['body'])
 
-        self.assertEqual({'message': 'Selected privilege jurisdiction \'ky\' matches existing privilege jurisdiction'},
-                            response_body)
+        self.assertEqual(
+            {'message': "Selected privilege jurisdiction 'ky' matches existing privilege jurisdiction"}, response_body
+        )
 
     @patch('handlers.privileges.PurchaseClient')
     def test_post_purchase_privileges_returns_404_if_provider_not_found(self, mock_purchase_client_constructor):

--- a/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
@@ -420,15 +420,15 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
 
         return self._setup_mock_transaction_controller(mock_create_transaction_controller, mock_success_response)
 
-    @patch('purchase_client.createTransactionController')
+    @patch('purchase_client.getMerchantDetailsController')
     def test_purchase_client_validates_credentials_using_authorize_net_processor(
-        self, mock_create_transaction_controller
+        self, mock_get_merchant_details_controller
     ):
         from purchase_client import PurchaseClient
 
         mock_secrets_manager_client = self._generate_mock_secrets_manager_client()
         self._when_authorize_dot_net_credentials_are_valid(
-            mock_create_transaction_controller=mock_create_transaction_controller
+            mock_create_transaction_controller=mock_get_merchant_details_controller
         )
 
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
@@ -439,21 +439,19 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
 
         self.assertEqual({'message': 'Successfully verified credentials'}, result)
 
-        call_args = mock_create_transaction_controller.call_args.args
+        call_args = mock_get_merchant_details_controller.call_args.args
         api_contract_v1_obj = call_args[0]
-        # we check every line of the object to ensure that the correct values are being passed to the authorize.net SDK
-        self.assertEqual('authenticateTestRequest', api_contract_v1_obj.transactionRequest.transactionType)
         # authentication fields
         self.assertEqual(MOCK_LOGIN_ID, api_contract_v1_obj.merchantAuthentication.name)
         self.assertEqual(MOCK_TRANSACTION_KEY, api_contract_v1_obj.merchantAuthentication.transactionKey)
 
-    @patch('purchase_client.createTransactionController')
-    def test_purchase_client_store_valid_credentials(self, mock_create_transaction_controller):
+    @patch('purchase_client.getMerchantDetailsController')
+    def test_purchase_client_store_valid_credentials(self, mock_get_merchant_details_controller):
         from purchase_client import PurchaseClient
 
         mock_secrets_manager_client = self._generate_mock_secrets_manager_client()
         self._when_authorize_dot_net_credentials_are_valid(
-            mock_create_transaction_controller=mock_create_transaction_controller
+            mock_create_transaction_controller=mock_get_merchant_details_controller
         )
 
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
@@ -475,13 +473,13 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             ),
         )
 
-    @patch('purchase_client.createTransactionController')
-    def test_purchase_client_raises_exception_if_invalid_processor(self, mock_create_transaction_controller):
+    @patch('purchase_client.getMerchantDetailsController')
+    def test_purchase_client_raises_exception_if_invalid_processor(self, mock_get_merchant_details_controller):
         from purchase_client import PurchaseClient
 
         mock_secrets_manager_client = self._generate_mock_secrets_manager_client()
         self._when_authorize_dot_net_credentials_are_valid(
-            mock_create_transaction_controller=mock_create_transaction_controller
+            mock_create_transaction_controller=mock_get_merchant_details_controller
         )
 
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
@@ -496,13 +494,13 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
                 },
             )
 
-    @patch('purchase_client.createTransactionController')
-    def test_purchase_client_raises_exception_if_invalid_credentials(self, mock_create_transaction_controller):
+    @patch('purchase_client.getMerchantDetailsController')
+    def test_purchase_client_raises_exception_if_invalid_credentials(self, mock_get_merchant_details_controller):
         from purchase_client import PurchaseClient
 
         mock_secrets_manager_client = self._generate_mock_secrets_manager_client()
         self._when_authorize_dot_net_credentials_are_not_valid(
-            mock_create_transaction_controller=mock_create_transaction_controller
+            mock_create_transaction_controller=mock_get_merchant_details_controller
         )
 
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)

--- a/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
@@ -499,6 +499,8 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
 
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
+        # In this case, the 'aslp' compact has an existing secret in place
+        # so if a compact admin uploads new credentials, the existing secret should be updated
         result = test_purchase_client.validate_and_store_credentials(
             compact_name='aslp', credentials=self._generate_test_credentials_object()
         )

--- a/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
@@ -398,43 +398,32 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
     @staticmethod
     def _generate_test_credentials_object():
         return {
-                'processor': 'authorize.net',
-                'apiLoginId': MOCK_LOGIN_ID,
-                'transactionKey': MOCK_TRANSACTION_KEY,
-            }
+            'processor': 'authorize.net',
+            'apiLoginId': MOCK_LOGIN_ID,
+            'transactionKey': MOCK_TRANSACTION_KEY,
+        }
 
     def _when_authorize_dot_net_credentials_are_valid(self, mock_create_transaction_controller):
         mock_success_response = {
-            "messages": {
-                "resultCode": "Ok",
-                "message": [
-                    {
-                        "code": "I00001",
-                        "text": "Successful."
-                    }
-                ]
-            }
+            'messages': {'resultCode': 'Ok', 'message': [{'code': 'I00001', 'text': 'Successful.'}]}
         }
 
         return self._setup_mock_transaction_controller(mock_create_transaction_controller, mock_success_response)
 
     def _when_authorize_dot_net_credentials_are_not_valid(self, mock_create_transaction_controller):
         mock_success_response = {
-            "messages": {
-                "resultCode": "Error",
-                "message": [
-                    {
-                        "code": "E00124",
-                        "text": "The provided access token is invalid"
-                    }
-                ]
+            'messages': {
+                'resultCode': 'Error',
+                'message': [{'code': 'E00124', 'text': 'The provided access token is invalid'}],
             }
         }
 
         return self._setup_mock_transaction_controller(mock_create_transaction_controller, mock_success_response)
 
     @patch('purchase_client.createTransactionController')
-    def test_purchase_client_validates_credentials_using_authorize_net_processor(self, mock_create_transaction_controller):
+    def test_purchase_client_validates_credentials_using_authorize_net_processor(
+        self, mock_create_transaction_controller
+    ):
         from purchase_client import PurchaseClient
 
         mock_secrets_manager_client = self._generate_mock_secrets_manager_client()
@@ -445,8 +434,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
         result = test_purchase_client.validate_and_store_credentials(
-            compact_name='aslp',
-            credentials=self._generate_test_credentials_object()
+            compact_name='aslp', credentials=self._generate_test_credentials_object()
         )
 
         self.assertEqual({'message': 'Successfully verified credentials'}, result)
@@ -471,19 +459,20 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
         result = test_purchase_client.validate_and_store_credentials(
-            compact_name='aslp',
-            credentials=self._generate_test_credentials_object()
+            compact_name='aslp', credentials=self._generate_test_credentials_object()
         )
 
         self.assertEqual({'message': 'Successfully verified credentials'}, result)
 
         mock_secrets_manager_client.put_secret_value.assert_called_once_with(
             SecretId='compact-connect/env/test/compact/aslp/credentials/payment-processor',
-            SecretString=json.dumps({
-                'processor': 'authorize.net',
-                'api_login_id': MOCK_LOGIN_ID,
-                'transaction_key': MOCK_TRANSACTION_KEY,
-            })
+            SecretString=json.dumps(
+                {
+                    'processor': 'authorize.net',
+                    'api_login_id': MOCK_LOGIN_ID,
+                    'transaction_key': MOCK_TRANSACTION_KEY,
+                }
+            ),
         )
 
     @patch('purchase_client.createTransactionController')
@@ -503,8 +492,8 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
                 credentials={
                     'processor': 'stripe',
                     'apiLoginId': 'mock_login_id',
-                    'transactionKey': MOCK_TRANSACTION_KEY
-                             }
+                    'transactionKey': MOCK_TRANSACTION_KEY,
+                },
             )
 
     @patch('purchase_client.createTransactionController')
@@ -520,8 +509,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
 
         with self.assertRaises(CCInvalidRequestException) as context:
             test_purchase_client.validate_and_store_credentials(
-                compact_name='aslp',
-                credentials=self._generate_test_credentials_object()
+                compact_name='aslp', credentials=self._generate_test_credentials_object()
             )
 
         self.assertIn('Failed to verify credentials', str(context.exception.message))

--- a/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
@@ -82,8 +82,9 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
     """Testing that the purchase client works with authorize.net SDK as expected."""
     def _generate_mock_secrets_manager_client(self):
         mock_secrets_manager_client = MagicMock()
-        mock_secrets_manager_client.exceptions.ResourceNotFoundException = config.secrets_manager_client.exceptions.ResourceNotFoundException
-        def get_secret_value_side_effect(SecretId):  # noqa: N803 invalid-name
+        mock_secrets_manager_client.exceptions.ResourceNotFoundException = (config.secrets_manager_client
+                                                                            .exceptions.ResourceNotFoundException)
+        def get_secret_value_side_effect(SecretId):  # noqa: N803 invalid-name required for mock
             if SecretId == 'compact-connect/env/test/compact/aslp/credentials/payment-processor':
                 return {'SecretString': json.dumps(MOCK_ASLP_SECRET)}
             raise config.secrets_manager_client.exceptions.ResourceNotFoundException(
@@ -91,7 +92,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
                 operation_name='get_secret_value',
             )
 
-        def describe_secret_side_effect(SecretId):
+        def describe_secret_side_effect(SecretId): # noqa: N803 invalid-name required for mock
             if SecretId == 'compact-connect/env/test/compact/aslp/credentials/payment-processor':
                 # add other fields here if needed
                 return {'Name': 'compact-connect/env/test/compact/aslp/credentials/payment-processor'}

--- a/backend/compact-connect/lambdas/staff-user-pre-token/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/staff-user-pre-token/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/staff-user-pre-token/requirements-dev.in
 #
-boto3==1.35.49
+boto3==1.35.52
     # via moto
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   moto

--- a/backend/compact-connect/lambdas/staff-user-pre-token/requirements.txt
+++ b/backend/compact-connect/lambdas/staff-user-pre-token/requirements.txt
@@ -6,9 +6,9 @@
 #
 aws-lambda-powertools==2.43.1
     # via -r compact-connect/lambdas/staff-user-pre-token/requirements.in
-boto3==1.35.49
+boto3==1.35.52
     # via -r compact-connect/lambdas/staff-user-pre-token/requirements.in
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   s3transfer

--- a/backend/compact-connect/lambdas/staff-users/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/staff-users/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/staff-users/requirements-dev.in
 #
-boto3==1.35.49
+boto3==1.35.52
     # via moto
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   moto

--- a/backend/compact-connect/lambdas/staff-users/requirements.txt
+++ b/backend/compact-connect/lambdas/staff-users/requirements.txt
@@ -6,9 +6,9 @@
 #
 aws-lambda-powertools==2.43.1
     # via -r compact-connect/lambdas/staff-users/requirements.in
-boto3==1.35.49
+boto3==1.35.52
     # via -r compact-connect/lambdas/staff-users/requirements.in
-botocore==1.35.49
+botocore==1.35.52
     # via
     #   boto3
     #   s3transfer

--- a/backend/compact-connect/requirements-dev.txt
+++ b/backend/compact-connect/requirements-dev.txt
@@ -76,7 +76,7 @@ pytest==8.3.3
     # via
     #   -r compact-connect/requirements-dev.in
     #   pytest-cov
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r compact-connect/requirements-dev.in
 python-dateutil==2.9.0.post0
     # via faker

--- a/backend/compact-connect/requirements.txt
+++ b/backend/compact-connect/requirements.txt
@@ -8,7 +8,7 @@ attrs==24.2.0
     # via
     #   cattrs
     #   jsii
-aws-cdk-asset-awscli-v1==2.2.208
+aws-cdk-asset-awscli-v1==2.2.209
     # via aws-cdk-lib
 aws-cdk-asset-kubectl-v20==2.1.3
     # via aws-cdk-lib
@@ -25,7 +25,7 @@ aws-cdk-lib==2.164.1
     #   cdk-nag
 cattrs==24.1.2
     # via jsii
-cdk-nag==2.29.20
+cdk-nag==2.30.2
     # via -r compact-connect/requirements.in
 constructs==10.4.2
     # via

--- a/backend/compact-connect/stacks/api_stack/cc_api.py
+++ b/backend/compact-connect/stacks/api_stack/cc_api.py
@@ -4,7 +4,7 @@ import json
 from functools import cached_property
 
 import jsii
-from aws_cdk import Aspects, CfnOutput, Duration, IAspect
+from aws_cdk import ArnFormat, Aspects, CfnOutput, Duration, IAspect
 from aws_cdk.aws_apigateway import (
     AccessLogFormat,
     CognitoUserPoolsAuthorizer,
@@ -28,7 +28,7 @@ from aws_cdk.aws_route53 import ARecord, IHostedZone, RecordTarget
 from aws_cdk.aws_route53_targets import ApiGateway
 from cdk_nag import NagSuppressions
 from common_constructs.security_profile import SecurityProfile
-from common_constructs.stack import AppStack
+from common_constructs.stack import AppStack, Stack
 from common_constructs.webacl import WebACL, WebACLScope
 from constructs import Construct
 
@@ -333,6 +333,31 @@ class CCApi(RestApi):
                 **self.v0_common_license_properties,
             },
         )
+
+    def get_secrets_manager_compact_payment_processor_arns(self):
+        """
+        For each supported compact in the system, return the secret arn for the payment processor credentials.
+        The secret arn follows this pattern:
+        compact-connect/env/{environment_name}/compact/{compact_name}/credentials/payment-processor
+
+
+        This is used to scope the permissions granted to the lambda to only the secrets it needs to access.
+        """
+        stack = Stack.of(self)
+        environment_name = stack.common_env_vars['ENVIRONMENT_NAME']
+        compacts = json.loads(stack.common_env_vars['COMPACTS'])
+        return [
+            stack.format_arn(
+                service='secretsmanager',
+                arn_format=ArnFormat.COLON_RESOURCE_NAME,
+                resource='secret',
+                resource_name=(
+                    # add wildcard to account for random version uuid suffix appended to secret name by secrets manager
+                    f'compact-connect/env/{environment_name}/compact/{compact}/credentials/payment-processor*'
+                ),
+            )
+            for compact in compacts
+        ]
 
     def _configure_alarms(self):
         # Any time the API returns a 5XX

--- a/backend/compact-connect/stacks/api_stack/cc_api.py
+++ b/backend/compact-connect/stacks/api_stack/cc_api.py
@@ -352,8 +352,9 @@ class CCApi(RestApi):
                 arn_format=ArnFormat.COLON_RESOURCE_NAME,
                 resource='secret',
                 resource_name=(
-                    # add wildcard to account for random version uuid suffix appended to secret name by secrets manager
-                    f'compact-connect/env/{environment_name}/compact/{compact}/credentials/payment-processor*'
+                    # add wildcard characters to account for 6-character
+                    # random version suffix appended to secret name by secrets manager
+                    f'compact-connect/env/{environment_name}/compact/{compact}/credentials/payment-processor-??????'
                 ),
             )
             for compact in compacts

--- a/backend/compact-connect/stacks/api_stack/v1_api/api.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api.py
@@ -10,6 +10,7 @@ from stacks.api_stack.v1_api.purchases import Purchases
 from stacks.api_stack.v1_api.query_providers import QueryProviders
 
 from .api_model import ApiModel
+from .credentials import Credentials
 from .post_licenses import PostLicenses
 from .staff_users import StaffUsers
 
@@ -62,12 +63,22 @@ class V1Api:
             api_model=self.api_model,
         )
 
+        # /v1/compacts
+        self.compacts_resource = self.resource.add_resource('compacts')
         # /v1/compacts/{compact}
-        compact_resource = self.resource.add_resource('compacts').add_resource('{compact}')
+        self.compact_resource = self.compacts_resource.add_resource('{compact}')
+
+        # /v1/compacts/{compact}/credentials
+        credentials_resource = self.compact_resource.add_resource('credentials')
+        self.credentials = Credentials(
+            resource=credentials_resource,
+            method_options=write_auth_method_options,
+            api_model=self.api_model,
+        )
 
         # POST /v1/compacts/{compact}/providers/query
         # GET  /v1/compacts/{compact}/providers/{providerId}
-        providers_resource = compact_resource.add_resource('providers')
+        providers_resource = self.compact_resource.add_resource('providers')
         QueryProviders(
             resource=providers_resource,
             method_options=read_auth_method_options,
@@ -79,7 +90,7 @@ class V1Api:
         # POST /v1/compacts/{compact}/jurisdictions/{jurisdiction}/licenses
         # GET  /v1/compacts/{compact}/jurisdictions/{jurisdiction}/licenses/bulk-upload
         licenses_resource = (
-            compact_resource.add_resource('jurisdictions').add_resource('{jurisdiction}').add_resource('licenses')
+            self.compact_resource.add_resource('jurisdictions').add_resource('{jurisdiction}').add_resource('licenses')
         )
         PostLicenses(
             resource=licenses_resource,
@@ -95,7 +106,7 @@ class V1Api:
         )
 
         # /v1/staff-users
-        staff_users_admin_resource = compact_resource.add_resource('staff-users')
+        staff_users_admin_resource = self.compact_resource.add_resource('staff-users')
         staff_users_self_resource = self.resource.add_resource('staff-users')
         # GET    /v1/staff-users/me
         # PATCH  /v1/staff-users/me

--- a/backend/compact-connect/stacks/api_stack/v1_api/api.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api.py
@@ -44,6 +44,12 @@ class V1Api:
             authorization_scopes=write_scopes,
         )
 
+        admin_auth_method_options = MethodOptions(
+            authorization_type=AuthorizationType.COGNITO,
+            authorizer=self.api.staff_users_authorizer,
+            authorization_scopes=admin_scopes,
+        )
+
         # /v1/provider-users
         self.provider_users_resource = self.resource.add_resource('provider-users')
         self.provider_users = ProviderUsers(
@@ -72,7 +78,7 @@ class V1Api:
         credentials_resource = self.compact_resource.add_resource('credentials')
         self.credentials = Credentials(
             resource=credentials_resource,
-            method_options=write_auth_method_options,
+            method_options=admin_auth_method_options,
             api_model=self.api_model,
         )
 

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -271,6 +271,48 @@ class ApiModel:
         return self.api._v1_post_purchase_privileges_request_model
 
     @property
+    def post_credentials_payment_processor_request_model(self) -> Model:
+        """Return the post payment processor credentials request model, which should only be created once per API"""
+        if hasattr(self.api, '_v1_post_credentials_payment_processor_request_model'):
+            return self.api._v1_post_credentials_payment_processor_request_model
+        self.api._v1_post_credentials_payment_processor_request_model = self.api.add_model(
+            'V1PostCredentialsPaymentProcessorRequestModel',
+            description='Post payment processor credentials request model',
+            schema=JsonSchema(
+                type=JsonSchemaType.OBJECT,
+                additional_properties=False,
+                required=['processor', 'apiLoginId', 'transactionKey'],
+                properties={
+                    'query': JsonSchema(
+                        type=JsonSchemaType.OBJECT,
+                        description='payment processor credentials',
+                        properties={
+                            'processor': JsonSchema(
+                                type=JsonSchemaType.STRING,
+                                description='The type of payment processor',
+                                # for now, we only allow 'authorize.net'
+                                enum=['authorize.net'],
+                            ),
+                            'apiLoginId': JsonSchema(
+                                type=JsonSchemaType.STRING,
+                                description='The api login id for the payment processor',
+                                min_length=1,
+                                max_length=100,
+                            ),
+                            'transactionKey': JsonSchema(
+                                type=JsonSchemaType.STRING,
+                                description='The transaction key for the payment processor',
+                                min_length=1,
+                                max_length=100,
+                            ),
+                        },
+                    ),
+                },
+            ),
+        )
+        return self.api._v1_post_credentials_payment_processor_request_model
+
+    @property
     def post_purchase_privileges_response_model(self) -> Model:
         """Return the purchase privilege response model, which should only be created once per API"""
         if hasattr(self.api, '_v1_post_purchase_privileges_response_model'):
@@ -294,6 +336,28 @@ class ApiModel:
             ),
         )
         return self.api._v1_post_purchase_privileges_response_model
+
+
+    @property
+    def post_credentials_payment_processor_response_model(self) -> Model:
+        """Return the purchase privilege response model, which should only be created once per API"""
+        if hasattr(self.api, '_v1_post_credentials_payment_processor_response_model'):
+            return self.api._v1_post_credentials_payment_processor_response_model
+        self.api._v1_post_credentials_payment_processor_response_model = self.api.add_model(
+            'V1PostCredentialsPaymentProcessorResponseModel',
+            description='Post payment processor credentials response model',
+            schema=JsonSchema(
+                type=JsonSchemaType.OBJECT,
+                required=['message'],
+                properties={
+                    'message': JsonSchema(
+                        type=JsonSchemaType.STRING,
+                        description='A message about the request',
+                    ),
+                },
+            ),
+        )
+        return self.api._v1_post_credentials_payment_processor_response_model
 
     @property
     def purchase_privilege_options_response_model(self) -> Model:

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -283,10 +283,6 @@ class ApiModel:
                 additional_properties=False,
                 required=['processor', 'apiLoginId', 'transactionKey'],
                 properties={
-                    'query': JsonSchema(
-                        type=JsonSchemaType.OBJECT,
-                        description='payment processor credentials',
-                        properties={
                             'processor': JsonSchema(
                                 type=JsonSchemaType.STRING,
                                 description='The type of payment processor',
@@ -306,8 +302,6 @@ class ApiModel:
                                 max_length=100,
                             ),
                         },
-                    ),
-                },
             ),
         )
         return self.api._v1_post_credentials_payment_processor_request_model

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -337,7 +337,6 @@ class ApiModel:
         )
         return self.api._v1_post_purchase_privileges_response_model
 
-
     @property
     def post_credentials_payment_processor_response_model(self) -> Model:
         """Return the purchase privilege response model, which should only be created once per API"""

--- a/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
@@ -59,12 +59,14 @@ class Credentials:
             method_responses=[
                 MethodResponse(
                     status_code='200',
-                    response_models={'application/json':
-                                         self.api_model.post_credentials_payment_processor_response_model},
+                    response_models={
+                        'application/json': self.api_model.post_credentials_payment_processor_response_model
+                    },
                 ),
             ],
-            integration=LambdaIntegration(self.post_credentials_payment_processor_handler,
-                                          timeout=Duration.seconds(29)),
+            integration=LambdaIntegration(
+                self.post_credentials_payment_processor_handler, timeout=Duration.seconds(29)
+            ),
             request_parameters={'method.request.header.Authorization': True},
             authorization_type=method_options.authorization_type,
             authorizer=method_options.authorizer,

--- a/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import os
+
+from aws_cdk import Duration
+from aws_cdk.aws_apigateway import LambdaIntegration, MethodOptions, MethodResponse, Resource
+from aws_cdk.aws_iam import Effect, PolicyStatement
+from cdk_nag import NagSuppressions
+from common_constructs.python_function import PythonFunction
+from common_constructs.stack import Stack
+
+# Importing module level to allow lazy loading for typing
+from stacks.api_stack import cc_api
+
+from .api_model import ApiModel
+
+
+class Credentials:
+    def __init__(
+        self,
+        *,
+        resource: Resource,
+        method_options: MethodOptions,
+        api_model: ApiModel,
+    ):
+        super().__init__()
+
+        self.resource = resource
+        self.api: cc_api.CCApi = resource.api
+        self.api_model = api_model
+
+        stack: Stack = Stack.of(resource)
+        lambda_environment = {
+            **stack.common_env_vars,
+        }
+
+        # /v1/compacts/{compact}/credentials/payment-processor
+        self._add_post_credentials_payment_processor(
+            method_options=method_options,
+            lambda_environment=lambda_environment,
+        )
+
+    def _add_post_credentials_payment_processor(
+        self,
+        method_options: MethodOptions,
+        lambda_environment: dict,
+    ):
+        self.payment_processor_resource = self.resource.add_resource('payment-processor')
+
+        self.post_credentials_payment_processor_handler = self._post_credentials_payment_processor_handler(
+            lambda_environment=lambda_environment,
+        )
+        self.api.log_groups.append(self.post_credentials_payment_processor_handler.log_group)
+
+        self.payment_processor_resource.add_method(
+            'POST',
+            request_validator=self.api.parameter_body_validator,
+            request_models={'application/json': self.api_model.post_credentials_payment_processor_request_model},
+            method_responses=[
+                MethodResponse(
+                    status_code='200',
+                    response_models={'application/json':
+                                         self.api_model.post_credentials_payment_processor_response_model},
+                ),
+            ],
+            integration=LambdaIntegration(self.post_credentials_payment_processor_handler,
+                                          timeout=Duration.seconds(29)),
+            request_parameters={'method.request.header.Authorization': True},
+            authorization_type=method_options.authorization_type,
+            authorizer=method_options.authorizer,
+            authorization_scopes=method_options.authorization_scopes,
+        )
+
+    def _post_credentials_payment_processor_handler(
+        self,
+        lambda_environment: dict,
+    ) -> PythonFunction:
+        stack = Stack.of(self.api)
+        handler = PythonFunction(
+            self.resource,
+            'PostCredentialsPaymentProcessorHandler',
+            description='Post credentials payment processor handler',
+            entry=os.path.join('lambdas', 'purchases'),
+            index=os.path.join('handlers', 'credentials.py'),
+            handler='post_payment_processor_credentials',
+            environment=lambda_environment,
+            alarm_topic=self.api.alarm_topic,
+        )
+
+        # grant handler access to post secrets for supported compacts
+        # compact-connect/env/{environment_name}/compact/{compact_name}/credentials/payment-processor
+        handler.add_to_role_policy(
+            PolicyStatement(
+                effect=Effect.ALLOW,
+                actions=[
+                    'secretsmanager:PutSecretValue',
+                ],
+                resources=self.api.get_secrets_manager_compact_payment_processor_arns(),
+            )
+        )
+
+        NagSuppressions.add_resource_suppressions_by_path(
+            stack,
+            path=f'{handler.node.path}/ServiceRole/DefaultPolicy/Resource',
+            suppressions=[
+                {
+                    'id': 'AwsSolutions-IAM5',
+                    'reason': 'The actions in this policy are specifically what this lambda needs to read '
+                    'and is scoped to one table and encryption key.',
+                },
+            ],
+        )
+        return handler

--- a/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
@@ -87,6 +87,8 @@ class Credentials:
             handler='post_payment_processor_credentials',
             environment=lambda_environment,
             alarm_topic=self.api.alarm_topic,
+            # required as this lambda is bundled with the authorize.net SDK which is large
+            memory_size=256,
         )
 
         # grant handler access to post secrets for supported compacts

--- a/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
@@ -97,7 +97,11 @@ class Credentials:
             PolicyStatement(
                 effect=Effect.ALLOW,
                 actions=[
+                    # this lambda needs to be able to Describe the secret to check if it exists, create it if it doesn't
+                    # and update it if it does
                     'secretsmanager:PutSecretValue',
+                    'secretsmanager:CreateSecret',
+                    'secretsmanager:DescribeSecret',
                 ],
                 resources=self.api.get_secrets_manager_compact_payment_processor_arns(),
             )

--- a/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/credentials.py
@@ -65,6 +65,8 @@ class Credentials:
                 ),
             ],
             integration=LambdaIntegration(
+                # setting the timeout to 29 seconds to allow for
+                # the lambda to complete before the API Gateway times out at 30 seconds
                 self.post_credentials_payment_processor_handler, timeout=Duration.seconds(29)
             ),
             request_parameters={'method.request.header.Authorization': True},

--- a/backend/compact-connect/stacks/api_stack/v1_api/purchases.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/purchases.py
@@ -103,6 +103,8 @@ class Purchases:
             handler='post_purchase_privileges',
             environment=lambda_environment,
             alarm_topic=self.api.alarm_topic,
+            # required as this lambda is bundled with the authorize.net SDK which is large
+            memory_size=256,
         )
         data_encryption_key.grant_decrypt(handler)
         compact_configuration_table.grant_read_data(handler)
@@ -177,6 +179,8 @@ class Purchases:
             handler='get_purchase_privilege_options',
             environment=lambda_environment,
             alarm_topic=self.api.alarm_topic,
+            # required as this lambda is bundled with the authorize.net SDK which is large
+            memory_size=256,
         )
         data_encryption_key.grant_decrypt(handler)
         compact_configuration_table.grant_read_data(handler)

--- a/backend/compact-connect/tests/resources/snapshots/CREDENTIALS_PAYMENT_PROCESSOR_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/CREDENTIALS_PAYMENT_PROCESSOR_REQUEST_SCHEMA.json
@@ -1,9 +1,6 @@
 {
   "additionalProperties": false,
   "properties": {
-    "query": {
-      "description": "payment processor credentials",
-      "properties": {
         "processor": {
           "description": "The type of payment processor",
           "enum": [
@@ -23,9 +20,6 @@
           "minLength": 1,
           "type": "string"
         }
-      },
-      "type": "object"
-    }
   },
   "required": [
     "processor",

--- a/backend/compact-connect/tests/resources/snapshots/CREDENTIALS_PAYMENT_PROCESSOR_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/CREDENTIALS_PAYMENT_PROCESSOR_REQUEST_SCHEMA.json
@@ -1,0 +1,37 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "query": {
+      "description": "payment processor credentials",
+      "properties": {
+        "processor": {
+          "description": "The type of payment processor",
+          "enum": [
+            "authorize.net"
+          ],
+          "type": "string"
+        },
+        "apiLoginId": {
+          "description": "The api login id for the payment processor",
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "transactionKey": {
+          "description": "The transaction key for the payment processor",
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "processor",
+    "apiLoginId",
+    "transactionKey"
+  ],
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/backend/compact-connect/tests/unit/test_compact_api.py
+++ b/backend/compact-connect/tests/unit/test_compact_api.py
@@ -8,7 +8,7 @@ from tests.unit.test_api import TestApi
 def _generate_expected_secret_arn(compact: str) -> str:
     return (
         f'arn:aws:secretsmanager:us-east-1:111122223333:secret:compact-connect/env'
-        f'/justin/compact/{compact}/credentials/payment-processor*'
+        f'/justin/compact/{compact}/credentials/payment-processor-??????'
     )
 
 

--- a/backend/compact-connect/tests/unit/test_compact_api.py
+++ b/backend/compact-connect/tests/unit/test_compact_api.py
@@ -29,7 +29,7 @@ class TestCompactsApi(TestApi):
         api_stack = self.app.sandbox_stage.api_stack
         api_stack_template = Template.from_stack(api_stack)
 
-        #/v1/compacts
+        # /v1/compacts
         api_stack_template.has_resource_properties(
             type=CfnResource.CFN_RESOURCE_TYPE_NAME,
             props={
@@ -74,13 +74,16 @@ class TestCompactsApi(TestApi):
 
         # Ensure the resource is created with expected path
         post_credentials_payment_processor_handler = TestApi.get_resource_properties_by_logical_id(
-            api_stack.get_logical_id(api_stack.api.v1_api.credentials
-                                     .post_credentials_payment_processor_handler.node.default_child),
+            api_stack.get_logical_id(
+                api_stack.api.v1_api.credentials.post_credentials_payment_processor_handler.node.default_child
+            ),
             api_stack_template.find_resources(CfnFunction.CFN_RESOURCE_TYPE_NAME),
         )
 
-        self.assertEqual(post_credentials_payment_processor_handler['Handler'],
-                         'handlers.credentials.post_payment_processor_credentials')
+        self.assertEqual(
+            post_credentials_payment_processor_handler['Handler'],
+            'handlers.credentials.post_payment_processor_credentials',
+        )
 
         handler_role_logical_id = api_stack.get_logical_id(
             api_stack.api.v1_api.credentials.post_credentials_payment_processor_handler.role.node.default_child

--- a/backend/compact-connect/tests/unit/test_compact_api.py
+++ b/backend/compact-connect/tests/unit/test_compact_api.py
@@ -104,7 +104,8 @@ class TestCompactsApi(TestApi):
         # We need to ensure the lambda can read these secrets, else all transactions will fail
         self.assertIn(
             {
-                'Action': 'secretsmanager:PutSecretValue',
+                'Action': ['secretsmanager:CreateSecret', 'secretsmanager:DescribeSecret',
+                           'secretsmanager:PutSecretValue'],
                 'Effect': 'Allow',
                 'Resource': [
                     _generate_expected_secret_arn('aslp'),

--- a/backend/compact-connect/tests/unit/test_compact_api.py
+++ b/backend/compact-connect/tests/unit/test_compact_api.py
@@ -1,0 +1,176 @@
+from aws_cdk.assertions import Capture, Template
+from aws_cdk.aws_apigateway import CfnMethod, CfnModel, CfnResource
+from aws_cdk.aws_lambda import CfnFunction
+
+from tests.unit.test_api import TestApi
+
+
+def _generate_expected_secret_arn(compact: str) -> str:
+    return (
+        f'arn:aws:secretsmanager:us-east-1:111122223333:secret:compact-connect/env'
+        f'/justin/compact/{compact}/credentials/payment-processor*'
+    )
+
+
+class TestCompactsApi(TestApi):
+    """
+    These tests are focused on checking that the API endpoints for the `/compacts/ root path are configured correctly.
+
+    When adding or modifying API resources under /compacts/, a test should be added to ensure that the
+    resource is created as expected. The pattern for these tests includes the following checks:
+    1. The path and parent id of the API Gateway resource matches expected values.
+    2. If the resource has a lambda function associated with it, the function is present with the expected
+    module and function.
+    3. Check the methods associated with the resource, ensuring they are all present and have the correct handlers.
+    4. Ensure the request and response models for the endpoint are present and match the expected schemas.
+    """
+
+    def test_synth_generates_compacts_resources(self):
+        api_stack = self.app.sandbox_stage.api_stack
+        api_stack_template = Template.from_stack(api_stack)
+
+        #/v1/compacts
+        api_stack_template.has_resource_properties(
+            type=CfnResource.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'ParentId': {
+                    # Verify the parent id matches the expected 'v1' resource
+                    'Ref': api_stack.get_logical_id(api_stack.api.v1_api.resource.node.default_child),
+                },
+                'PathPart': 'compacts',
+            },
+        )
+        # /v1/compacts/{compact}
+        api_stack_template.has_resource_properties(
+            type=CfnResource.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'ParentId': {
+                    # Verify the parent id matches the expected 'v1' resource
+                    'Ref': api_stack.get_logical_id(api_stack.api.v1_api.compacts_resource.node.default_child),
+                },
+                'PathPart': '{compact}',
+            },
+        )
+
+    def test_synth_generates_credentials_resource(self):
+        api_stack = self.app.sandbox_stage.api_stack
+        api_stack_template = Template.from_stack(api_stack)
+
+        # /v1/compacts/{compact}/credentials
+        api_stack_template.has_resource_properties(
+            type=CfnResource.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'ParentId': {
+                    # Verify the parent id matches the expected 'v1' resource
+                    'Ref': api_stack.get_logical_id(api_stack.api.v1_api.compact_resource.node.default_child),
+                },
+                'PathPart': 'credentials',
+            },
+        )
+
+    def test_synth_generates_post_credentials_payment_processor_handler_with_required_secret_permissions(self):
+        api_stack = self.app.sandbox_stage.api_stack
+        api_stack_template = Template.from_stack(api_stack)
+
+        # Ensure the resource is created with expected path
+        post_credentials_payment_processor_handler = TestApi.get_resource_properties_by_logical_id(
+            api_stack.get_logical_id(api_stack.api.v1_api.credentials
+                                     .post_credentials_payment_processor_handler.node.default_child),
+            api_stack_template.find_resources(CfnFunction.CFN_RESOURCE_TYPE_NAME),
+        )
+
+        self.assertEqual(post_credentials_payment_processor_handler['Handler'],
+                         'handlers.credentials.post_payment_processor_credentials')
+
+        handler_role_logical_id = api_stack.get_logical_id(
+            api_stack.api.v1_api.credentials.post_credentials_payment_processor_handler.role.node.default_child
+        )
+
+        # get the policy attached to the role using this match
+        # "Roles": [
+        #     {
+        #         "Ref": "<role logical id>"
+        #     }
+        # ]
+        policy = next(
+            policy
+            for policy_logical_id, policy in api_stack_template.find_resources('AWS::IAM::Policy').items()
+            if handler_role_logical_id in policy['Properties']['Roles'][0]['Ref']
+        )
+
+        # We need to ensure the lambda can read these secrets, else all transactions will fail
+        self.assertIn(
+            {
+                'Action': 'secretsmanager:PutSecretValue',
+                'Effect': 'Allow',
+                'Resource': [
+                    _generate_expected_secret_arn('aslp'),
+                    _generate_expected_secret_arn('coun'),
+                    _generate_expected_secret_arn('octp'),
+                ],
+            },
+            policy['Properties']['PolicyDocument']['Statement'],
+        )
+
+    def test_synth_generates_post_credentials_payment_processor_endpoint_resources(self):
+        api_stack = self.app.sandbox_stage.api_stack
+        api_stack_template = Template.from_stack(api_stack)
+
+        # Ensure the resource is created with expected path
+        method_request_model_logical_id_capture = Capture()
+        method_response_model_logical_id_capture = Capture()
+
+        # ensure the POST method is configured with the lambda integration and authorizer
+        api_stack_template.has_resource_properties(
+            type=CfnMethod.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'HttpMethod': 'POST',
+                # verify endpoint using staff users authorizer
+                'AuthorizerId': {
+                    'Ref': api_stack.get_logical_id(api_stack.api.staff_users_authorizer.node.default_child),
+                },
+                # ensure the lambda integration is configured with the expected handler
+                'Integration': TestApi.generate_expected_integration_object(
+                    api_stack.get_logical_id(
+                        api_stack.api.v1_api.credentials.post_credentials_payment_processor_handler.node.default_child,
+                    ),
+                ),
+                'RequestModels': {'application/json': {'Ref': method_request_model_logical_id_capture}},
+                'MethodResponses': [
+                    {
+                        'ResponseModels': {'application/json': {'Ref': method_response_model_logical_id_capture}},
+                        'StatusCode': '200',
+                    },
+                ],
+            },
+        )
+
+        # check that request model matches expected contract
+        post_credentials_payment_processor_request_model = TestApi.get_resource_properties_by_logical_id(
+            method_request_model_logical_id_capture.as_string(),
+            api_stack_template.find_resources(CfnModel.CFN_RESOURCE_TYPE_NAME),
+        )
+
+        self.compare_snapshot(
+            actual=post_credentials_payment_processor_request_model['Schema'],
+            snapshot_name='CREDENTIALS_PAYMENT_PROCESSOR_REQUEST_SCHEMA',
+            overwrite_snapshot=False,
+        )
+
+        # now check the response matches expected contract
+        post_credentials_payment_processor_response_model = self.get_resource_properties_by_logical_id(
+            method_response_model_logical_id_capture.as_string(),
+            api_stack_template.find_resources(CfnModel.CFN_RESOURCE_TYPE_NAME),
+        )
+
+        self.assertEqual(
+            {
+                '$schema': 'http://json-schema.org/draft-04/schema#',
+                'properties': {
+                    'message': {'description': 'A message about the request', 'type': 'string'},
+                },
+                'required': ['message'],
+                'type': 'object',
+            },
+            post_credentials_payment_processor_response_model['Schema'],
+        )

--- a/backend/compact-connect/tests/unit/test_purchases_api.py
+++ b/backend/compact-connect/tests/unit/test_purchases_api.py
@@ -8,7 +8,7 @@ from tests.unit.test_api import TestApi
 def _generate_expected_secret_arn(compact: str) -> str:
     return (
         f'arn:aws:secretsmanager:us-east-1:111122223333:secret:compact-connect/env'
-        f'/justin/compact/{compact}/credentials/payment-processor*'
+        f'/justin/compact/{compact}/credentials/payment-processor-??????'
     )
 
 

--- a/backend/compact-connect/tests/unit/test_purchases_api.py
+++ b/backend/compact-connect/tests/unit/test_purchases_api.py
@@ -107,7 +107,7 @@ class TestPurchasesApi(TestApi):
         method_request_model_logical_id_capture = Capture()
         method_response_model_logical_id_capture = Capture()
 
-        # ensure the GET method is configured with the lambda integration and authorizer
+        # ensure the POST method is configured with the lambda integration and authorizer
         api_stack_template.has_resource_properties(
             type=CfnMethod.CFN_RESOURCE_TYPE_NAME,
             props={
@@ -133,19 +133,19 @@ class TestPurchasesApi(TestApi):
         )
 
         # check that request model matches expected contract
-        post_purchase_privilege_options_request_model = TestApi.get_resource_properties_by_logical_id(
+        post_purchase_privilege_request_model = TestApi.get_resource_properties_by_logical_id(
             method_request_model_logical_id_capture.as_string(),
             api_stack_template.find_resources(CfnModel.CFN_RESOURCE_TYPE_NAME),
         )
 
         self.compare_snapshot(
-            actual=post_purchase_privilege_options_request_model['Schema'],
+            actual=post_purchase_privilege_request_model['Schema'],
             snapshot_name='PURCHASE_PRIVILEGE_REQUEST_SCHEMA',
             overwrite_snapshot=False,
         )
 
         # now check the response matches expected contract
-        post_purchase_privilege_options_response_model = self.get_resource_properties_by_logical_id(
+        post_purchase_privilege_response_model = self.get_resource_properties_by_logical_id(
             method_response_model_logical_id_capture.as_string(),
             api_stack_template.find_resources(CfnModel.CFN_RESOURCE_TYPE_NAME),
         )
@@ -160,7 +160,7 @@ class TestPurchasesApi(TestApi):
                 'required': ['transactionId'],
                 'type': 'object',
             },
-            post_purchase_privilege_options_response_model['Schema'],
+            post_purchase_privilege_response_model['Schema'],
         )
 
     def test_synth_generates_get_purchases_privileges_options_endpoint_resource(self):

--- a/backend/multi-account/requirements.txt
+++ b/backend/multi-account/requirements.txt
@@ -8,7 +8,7 @@ attrs==24.2.0
     # via
     #   cattrs
     #   jsii
-aws-cdk-asset-awscli-v1==2.2.208
+aws-cdk-asset-awscli-v1==2.2.209
     # via aws-cdk-lib
 aws-cdk-asset-kubectl-v20==2.1.3
     # via aws-cdk-lib


### PR DESCRIPTION
In order to support using different authorize.net credentials for different compacts, we need an API endpoint that takes in an apiLoginId and transactionKey which will be used to process transactions for that compact within the application.

This POST endpoint takes in the following request body:
```
{
        "processor": "authorize.net", # The payment processor to use, only authorize.net is supported
        "apiLoginId": "<api_login_id>", # required for authorize.net transactions
        "transactionKey": "<transaction_key>", # required for authorize.net transactions
}
```
It validates the provided login id and key by calling a test endpoint. If the credentials are valid, it stores them in AWS
secrets manager under a defined namespace. If the credentials are invalid, the endpoint returns a 400.

### Requirements List
- No new requirements needed for this change to deploy

### Description List
- Add api endpoint POST /v1/compacts/{compact}/credentials/payment-processor which only compact admins can call
- Added check to purchase endpoint to make sure an licensee cannot purchase a privilege for same jurisdiction as license or existing privilege

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- Code review

Closes #267 
