### PR TITLE
Frontend/state upload updates

### DIFF
--- a/webroot/src/components/Page/PageMainNav/PageMainNav.ts
+++ b/webroot/src/components/Page/PageMainNav/PageMainNav.ts
@@ -50,6 +50,23 @@ class PageMainNav extends Vue {
         return this.isLoggedIn && this.$store.getters['user/highestPermissionAuthType']() === AuthTypes.STAFF;
     }
 
+    get hasStatePermissions(): boolean {
+        const { model: user } = this.userStore;
+        let hasPermissions = false;
+
+        if (this.isLoggedInAsStaff) {
+            const compactType = this.currentCompact?.type;
+            const compactPermissions = user?.permissions?.find((permission) =>
+                permission.compact.type === compactType) || null;
+
+            if (compactPermissions?.states?.length) {
+                hasPermissions = true;
+            }
+        }
+
+        return hasPermissions;
+    }
+
     get mainLinks() {
         return reactive([
             {
@@ -64,7 +81,7 @@ class PageMainNav extends Vue {
                 to: 'StateUpload',
                 params: { compact: this.currentCompact?.type },
                 label: computed(() => this.$t('navigation.upload')),
-                isEnabled: Boolean(this.currentCompact) && this.isLoggedInAsStaff,
+                isEnabled: Boolean(this.currentCompact) && this.hasStatePermissions,
                 isExternal: false,
                 isExactActive: true,
             },

--- a/webroot/src/components/StateUpload/StateUpload.less
+++ b/webroot/src/components/StateUpload/StateUpload.less
@@ -75,9 +75,28 @@
             }
         }
 
-        .sub-title {
-            margin-top: 1.6rem;
-            padding: 0 8.2rem;
+        .success-actions {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            width: 100%;
+            margin-top: 2.4rem;
+
+            @media @desktopWidth {
+                flex-direction: row;
+            }
+
+            .success-btn {
+                margin-bottom: 1.6rem;
+                padding-top: 1rem;
+                padding-bottom: 1rem;
+
+                @media @desktopWidth {
+                    &:first-child {
+                        margin-right: 1.2rem;
+                    }
+                }
+            }
         }
     }
 }

--- a/webroot/src/components/StateUpload/StateUpload.spec.ts
+++ b/webroot/src/components/StateUpload/StateUpload.spec.ts
@@ -5,15 +5,53 @@
 //  Created by InspiringApps on 6/18/2024.
 //
 
+import { nextTick } from 'vue';
 import { expect } from 'chai';
 import { mountShallow } from '@tests/helpers/setup';
 import StateUpload from '@components/StateUpload/StateUpload.vue';
+import { Compact, CompactType } from '@models/Compact/Compact.model';
+import { StaffUser } from '@models/StaffUser/StaffUser.model';
 
 describe('StateUpload component', async () => {
+    before(() => {
+        global.requestAnimationFrame = (cb) => cb(); // JSDOM omits this global method, so we need to mock it ourselves
+    });
     it('should mount the component', async () => {
         const wrapper = await mountShallow(StateUpload);
 
         expect(wrapper.exists()).to.equal(true);
         expect(wrapper.findComponent(StateUpload).exists()).to.equal(true);
+    });
+    it('should successfully show form success', async () => {
+        const wrapper = await mountShallow(StateUpload);
+        const component = wrapper.vm;
+
+        component.$store.dispatch('user/setStoreUser', new StaffUser());
+        component.$store.dispatch('user/setCurrentCompact', new Compact({ type: CompactType.ASLP }));
+        component.isFormSuccessful = true;
+        await nextTick();
+
+        const success = wrapper.find('.state-upload-success');
+        const reset = wrapper.find('.success-btn');
+
+        expect(success.exists()).to.equal(true);
+        expect(reset.exists()).to.equal(true);
+    });
+    it('should successfully reset form when user is done', async () => {
+        const wrapper = await mountShallow(StateUpload);
+        const component = wrapper.vm;
+
+        component.isFormSuccessful = true;
+        await nextTick();
+
+        const reset = wrapper.find('.success-btn');
+
+        await reset.trigger('click');
+
+        const success = wrapper.find('.state-upload-success');
+        const form = wrapper.find('.state-upload-form');
+
+        expect(success.exists()).to.equal(false);
+        expect(form.exists()).to.equal(true);
     });
 });

--- a/webroot/src/components/StateUpload/StateUpload.ts
+++ b/webroot/src/components/StateUpload/StateUpload.ts
@@ -52,6 +52,12 @@ class StateUpload extends mixins(MixinForm) {
         this.initFormInputs();
     }
 
+    mounted() {
+        if (this.compactType && this.user) {
+            this.updateStateInput();
+        }
+    }
+
     //
     // Computed
     //
@@ -93,13 +99,9 @@ class StateUpload extends mixins(MixinForm) {
         let stateOptions: Array<StateOption> = [];
 
         if (compactPermissions) {
-            if (compactPermissions.isAdmin) {
-                stateOptions = this.compactStateOptions;
-            } else {
-                stateOptions = compactPermissions.states.map((statePermissions) => ({
-                    value: statePermissions?.state?.abbrev, name: statePermissions?.state?.name()
-                }));
-            }
+            stateOptions = compactPermissions.states.map((statePermissions) => ({
+                value: statePermissions?.state?.abbrev, name: statePermissions?.state?.name()
+            }));
         }
 
         if (!stateOptions.length) {
@@ -237,7 +239,11 @@ class StateUpload extends mixins(MixinForm) {
     }
 
     async mockPopulate(): Promise<void> {
-        this.populateFormInput(this.formData.state, this.stateOptions[1].value);
+        if (this.stateOptions.length === 1) {
+            this.populateFormInput(this.formData.state, this.stateOptions[0].value);
+        } else if (this.stateOptions.length > 1) {
+            this.populateFormInput(this.formData.state, this.stateOptions[1].value);
+        }
         this.populateFormInput(this.formData.files, new File([`a,b,c`], `test-file.csv`, { type: `text/csv` }));
     }
 

--- a/webroot/src/components/StateUpload/StateUpload.ts
+++ b/webroot/src/components/StateUpload/StateUpload.ts
@@ -134,6 +134,11 @@ class StateUpload extends mixins(MixinForm) {
         return Boolean(this.$envConfig.isDevelopment);
     }
 
+    get elementTransitionMode(): string {
+        // Test utils have a bug with transition modes; this only includes the mode in non-test contexts.
+        return (this.$envConfig.isTest) ? '' : 'out-in';
+    }
+
     //
     // Methods
     //
@@ -218,6 +223,17 @@ class StateUpload extends mixins(MixinForm) {
         });
 
         return upload;
+    }
+
+    resetForm(): void {
+        this.formData.state.value = '';
+        this.formData.files.value = [];
+        this.updateStateInput();
+        this.isFormLoading = false;
+        this.isFormSuccessful = false;
+        this.isFormError = false;
+        this.updateFormSubmitSuccess('');
+        this.updateFormSubmitError('');
     }
 
     async mockPopulate(): Promise<void> {

--- a/webroot/src/components/StateUpload/StateUpload.vue
+++ b/webroot/src/components/StateUpload/StateUpload.vue
@@ -7,33 +7,34 @@
 
 <template>
     <Card class="state-upload">
-        <Transition name="fade">
-        <LoadingSpinner v-if="isInitializing" />
-        </Transition>
-        <Transition name="fade" mode="out-in">
-        <div v-if="!isFormSuccessful" class="state-upload-form">
-            <h1>{{ $t('stateUpload.formTitle') }}</h1>
-            <div class="sub-title">{{ $t('stateUpload.formSubtext') }}</div>
-            <MockPopulate :isEnabled="isMockPopulateEnabled" @selected="mockPopulate" />
-            <div class="state-upload-form-container">
-                <form @submit.prevent="handleSubmit">
-                    <InputSelect :formInput="formData.state" class="state-select" />
-                    <InputFile :formInput="formData.files" class="file-select" />
-                    <InputSubmit
-                        :formInput="formData.submit"
-                        :label="submitLabel"
-                        :isEnabled="!isFormLoading"
-                    />
-                </form>
+        <Transition name="fade" :mode="elementTransitionMode">
+            <LoadingSpinner v-if="isInitializing" />
+            <div v-else-if="!isFormSuccessful" class="state-upload-form">
+                <h1>{{ $t('stateUpload.formTitle') }}</h1>
+                <div class="sub-title">{{ $t('stateUpload.formSubtext') }}</div>
+                <MockPopulate :isEnabled="isMockPopulateEnabled" @selected="mockPopulate" />
+                <div class="state-upload-form-container">
+                    <form @submit.prevent="handleSubmit">
+                        <InputSelect :formInput="formData.state" class="state-select" />
+                        <InputFile :formInput="formData.files" class="file-select" />
+                        <InputSubmit
+                            :formInput="formData.submit"
+                            :label="submitLabel"
+                            :isEnabled="!isFormLoading"
+                        />
+                    </form>
+                </div>
             </div>
-        </div>
-        <div v-else class="state-upload-success">
-            <div class="icon-container">
-                <CheckCircle />
+            <div v-else class="state-upload-success">
+                <div class="icon-container">
+                    <CheckCircle />
+                </div>
+                <h1>{{ $t('stateUpload.successTitle') }}</h1>
+                <div class="success-actions">
+                    <button class="success-btn transparent" @click="resetForm">Upload another</button>
+                    <button class="success-btn" @click="resetForm">Done</button>
+                </div>
             </div>
-            <h1>{{ $t('stateUpload.successTitle') }}</h1>
-            <div class="sub-title">{{ $t('stateUpload.successSubtext') }}</div>
-        </div>
         </Transition>
     </Card>
 </template>

--- a/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
+++ b/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
@@ -366,6 +366,10 @@ class UserRowEdit extends mixins(MixinForm) {
                 this.setError(err.message);
             });
 
+            if (this.user.id === this.currentUser.id) {
+                await this.$store.dispatch(`user/getStaffAccountRequest`);
+            }
+
             if (!this.isFormError) {
                 this.isFormSuccessful = true;
             }

--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -421,8 +421,7 @@
         "formTitle": "Compact data upload",
         "formSubtext": "Current uploads are for test purposes and the data will not be saved permanently",
         "uploadHint": "Only 1 CSV",
-        "successTitle": "Your document has been uploaded successfully",
-        "successSubtext": "Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet"
+        "successTitle": "Your document has been uploaded successfully"
     },
     "licensing": {
         "license": "License",

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -421,8 +421,7 @@
         "formTitle": "Carga de datos compacta",
         "formSubtext": "Las cargas actuales son para fines de prueba y los datos no se guardarán de forma permanente.",
         "uploadHint": "Sólo 1 archivo CSV",
-        "successTitle": "Su documento ha sido subido exitosamente",
-        "successSubtext": "Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet"
+        "successTitle": "Su documento ha sido subido exitosamente"
     },
     "licensing": {
         "licensingListTitle": "Datos de licencia",


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Remove Upload nav menu item for users without state permissions
- Add reset buttons to state upload success UI
- Remove lorem ipsum text from state upload success UI
- Add user account re-fetch when editing own permissions in user list
- Minor fix to the state upload dropdown populate
- Minor fix to the state upload local mock populate

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Staff users without specific state permissions should not see the Upload in the main nav
- If a staff user without specific state permissions somehow ends up on `/{{compact}}/StateUpload`, the drop down list should be empty
    - If in local environment, the mock populate should also not throw

Closes #279 
Closes #289 
