### PR TITLE
fix conditional check for sandbox compact config upload

### DIFF
--- a/backend/compact-connect/stacks/persistent_stack/compact_configuration_upload.py
+++ b/backend/compact-connect/stacks/persistent_stack/compact_configuration_upload.py
@@ -124,7 +124,7 @@ class CompactConfigurationUpload(Construct):
 
     def _configuration_is_active_for_environment(self, environment_name: str, active_environments: list[str]) -> bool:
         """Check if the compact configuration is active in the given environment."""
-        return environment_name in active_environments or self.node.try_get_context('sandbox') == 'true'
+        return environment_name in active_environments or self.node.try_get_context('sandbox') is True
 
     def _generate_compact_configuration_json_string(self, environment_name: str) -> str:
         """Currently, all configuration for compacts and jurisdictions is hardcoded in the compact-config directory.


### PR DESCRIPTION
Sandbox deployments should upload the configuration for all jurisdictions/compacts. The conditional check used to determine if a developer is running a sandbox deployment was checking for a string value, when it should have been checking for a bool.

### Requirements List
- N/A

### Description List
- fix conditional check for sandbox compact config upload

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- Code review

Closes #
