### PR TITLE
Feat/privilege selection tweaks

### DIFF
--- a/webroot/src/models/PrivilegePurchaseOption/PrivilegePurchaseOption.model.spec.ts
+++ b/webroot/src/models/PrivilegePurchaseOption/PrivilegePurchaseOption.model.spec.ts
@@ -36,10 +36,10 @@ describe('PrivilegePurchaseOption model', () => {
         expect(privilegePurchaseOption.jurisdiction.id).to.equal(null);
         expect(privilegePurchaseOption.jurisdiction.abbrev).to.equal(null);
         expect(privilegePurchaseOption.compactType).to.equal(null);
-        expect(privilegePurchaseOption.fee).to.equal(null);
+        expect(privilegePurchaseOption.fee).to.equal(0);
         expect(privilegePurchaseOption.isMilitaryDiscountActive).to.equal(false);
         expect(privilegePurchaseOption.militaryDiscountType).to.equal(null);
-        expect(privilegePurchaseOption.militaryDiscountAmount).to.equal(null);
+        expect(privilegePurchaseOption.militaryDiscountAmount).to.equal(0);
         expect(privilegePurchaseOption.isJurisprudenceRequired).to.equal(false);
     });
     it('should create a PrivilegePurchaseOption with specific values', () => {

--- a/webroot/src/models/PrivilegePurchaseOption/PrivilegePurchaseOption.model.ts
+++ b/webroot/src/models/PrivilegePurchaseOption/PrivilegePurchaseOption.model.ts
@@ -14,10 +14,10 @@ import { State } from '@models/State/State.model';
 export interface InterfacePrivilegePurchaseOption {
     jurisdiction?: State;
     compactType?: string | null;
-    fee?: number | null;
+    fee?: number;
     isMilitaryDiscountActive?: boolean;
     militaryDiscountType?: FeeTypes | null;
-    militaryDiscountAmount?: number | null;
+    militaryDiscountAmount?: number;
     isJurisprudenceRequired?: boolean;
 }
 
@@ -28,10 +28,10 @@ export class PrivilegePurchaseOption implements InterfacePrivilegePurchaseOption
     public $tm?: any = () => [];
     public jurisdiction? = new State();
     public compactType? = null;
-    public fee? = null;
+    public fee? = 0;
     public isMilitaryDiscountActive? = false;
     public militaryDiscountType? = null;
-    public militaryDiscountAmount? = null;
+    public militaryDiscountAmount? = 0;
     public isJurisprudenceRequired? = false;
 
     constructor(data?: InterfacePrivilegePurchaseOption) {

--- a/webroot/src/network/mocks/mock.data.ts
+++ b/webroot/src/network/mocks/mock.data.ts
@@ -352,7 +352,8 @@ export const licensees = {
                     compact: 'aslp',
                     providerId: '1',
                     type: 'privilege',
-                    dateOfIssuance: '2024-08-29',
+                    dateOfIssuance: '2023-08-29',
+                    dateOfRenewal: '2024-08-29',
                     dateOfUpdate: '2024-08-29',
                     status: 'inactive'
                 },
@@ -362,27 +363,30 @@ export const licensees = {
                     compact: 'aslp',
                     providerId: '1',
                     type: 'privilege',
-                    dateOfIssuance: '2024-08-29',
+                    dateOfIssuance: '2023-08-29',
+                    dateOfRenewal: '2024-08-29',
                     dateOfUpdate: '2024-08-29',
                     status: 'active'
                 },
                 {
                     licenseJurisdiction: 'ar',
-                    dateOfExpiration: '2025-08-29',
+                    dateOfExpiration: '2026-08-29',
                     compact: 'aslp',
                     providerId: '1',
                     type: 'privilege',
-                    dateOfIssuance: '2024-08-29',
+                    dateOfIssuance: '2023-08-29',
+                    dateOfRenewal: '2024-08-29',
                     dateOfUpdate: '2024-08-29',
                     status: 'active'
                 },
                 {
                     licenseJurisdiction: 'ma',
-                    dateOfExpiration: '2025-08-29',
+                    dateOfExpiration: '2026-08-29',
                     compact: 'aslp',
                     providerId: '1',
                     type: 'privilege',
-                    dateOfIssuance: '2024-08-29',
+                    dateOfIssuance: '2023-08-29',
+                    dateOfRenewal: '2024-08-29',
                     dateOfUpdate: '2024-08-29',
                     status: 'active'
                 },
@@ -393,6 +397,7 @@ export const licensees = {
                     providerId: '1',
                     type: 'privilege',
                     dateOfIssuance: '2019-08-29',
+                    dateOfRenewal: '2024-08-29',
                     dateOfUpdate: '2024-08-29',
                     status: 'in'
                 }
@@ -428,7 +433,7 @@ export const licensees = {
                     dateOfIssuance: '2024-08-29',
                     ssn: '085-32-1496',
                     licenseType: 'audiologist',
-                    dateOfExpiration: '2024-08-29',
+                    dateOfExpiration: '2025-08-29',
                     homeAddressState: 'co',
                     providerId: '1',
                     dateOfRenewal: '2024-08-29',
@@ -505,7 +510,7 @@ export const licensees = {
                     compact: 'aslp',
                     providerId: '1',
                     type: 'privilege',
-                    dateOfIssuance: '2024-08-29',
+                    dateOfIssuance: '2023-08-29',
                     dateOfUpdate: '2024-08-29',
                     status: 'active'
                 },
@@ -515,17 +520,17 @@ export const licensees = {
                     compact: 'aslp',
                     providerId: '1',
                     type: 'privilege',
-                    dateOfIssuance: '2024-08-29',
+                    dateOfIssuance: '2023-08-29',
                     dateOfUpdate: '2024-08-29',
                     status: 'active'
                 },
                 {
                     licenseJurisdiction: 'ar',
-                    dateOfExpiration: '2024-08-29',
+                    dateOfExpiration: '2023-08-29',
                     compact: 'aslp',
                     providerId: '1',
                     type: 'privilege',
-                    dateOfIssuance: '2024-08-29',
+                    dateOfIssuance: '2023-08-29',
                     dateOfUpdate: '2024-08-29',
                     status: 'active'
                 }

--- a/webroot/src/pages/SelectPrivileges/SelectPrivileges.less
+++ b/webroot/src/pages/SelectPrivileges/SelectPrivileges.less
@@ -113,13 +113,23 @@
                         padding: 0 1rem;
                         border: 1px solid @lightGrey;
                         border-radius: 10px;
-                        cursor: pointer;
 
                         :deep(.checkbox-container) {
                             label {
                                 padding: 0 5rem 0 0.4rem;
                                 font-weight: @fontWeight;
                             }
+                        }
+
+                        .enabled-state-overlay {
+                            position: absolute;
+                            z-index: 2;
+                            width: 100%;
+                            height: 100%;
+                            margin: 0 -1rem;
+                            border-radius: 10px;
+                            cursor: pointer;
+                            opacity: 0.5;
                         }
 
                         .disabled-state-overlay {

--- a/webroot/src/pages/SelectPrivileges/SelectPrivileges.ts
+++ b/webroot/src/pages/SelectPrivileges/SelectPrivileges.ts
@@ -311,6 +311,7 @@ export default class SelectPrivileges extends mixins(MixinForm) {
         if (newValue === true) {
             if (stateAbbrev) {
                 this.jurisprudencePendingConfirmation = stateAbbrev;
+                this.formData.jurisprudenceConfirmations[stateAbbrev].value = false;
             }
         }
     }

--- a/webroot/src/pages/SelectPrivileges/SelectPrivileges.ts
+++ b/webroot/src/pages/SelectPrivileges/SelectPrivileges.ts
@@ -63,6 +63,10 @@ export default class SelectPrivileges extends mixins(MixinForm) {
         return this.currentCompact?.compactCommissionFee || null;
     }
 
+    get currentCompactCommissionFeeDisplay(): string {
+        return this.currentCompactCommissionFee?.toFixed(2) || '0.00';
+    }
+
     get userStore(): any {
         return this.$store.state.user;
     }
@@ -99,6 +103,24 @@ export default class SelectPrivileges extends mixins(MixinForm) {
 
         licenseList.forEach((license) => {
             if (license?.issueState?.abbrev) {
+                stateList.push(license?.issueState?.abbrev);
+            }
+        });
+
+        return stateList;
+    }
+
+    get disabledPrivilegeStateChoices(): Array<string> {
+        const licenseList = this.licenseList.concat(this.privilegeList);
+
+        const stateList: Array<string> = [];
+
+        licenseList.forEach((license) => {
+            if (
+                license?.issueState?.abbrev
+                && license?.expireDate === this.activeLicense?.expireDate
+                && license.statusState === LicenseStatus.ACTIVE
+            ) {
                 stateList.push(license?.issueState?.abbrev);
             }
         });
@@ -157,6 +179,27 @@ export default class SelectPrivileges extends mixins(MixinForm) {
             }
 
             return includes;
+        });
+    }
+
+    get selectedStatePurchaseDataDisplayList(): Array<object> {
+        return this.selectedStatePurchaseDataList.map((option) => {
+            let feeDisplay = '';
+            let militaryDiscountAmountDisplay = '';
+
+            if (option?.fee) {
+                feeDisplay = option?.fee?.toFixed(2);
+            }
+
+            if (option?.militaryDiscountAmount) {
+                militaryDiscountAmountDisplay = option?.militaryDiscountAmount?.toFixed(2);
+            }
+
+            return {
+                ...option,
+                feeDisplay,
+                militaryDiscountAmountDisplay
+            };
         });
     }
 
@@ -228,12 +271,14 @@ export default class SelectPrivileges extends mixins(MixinForm) {
         return date;
     }
 
-    get subTotalList(): Array<number> {
+    get subTotalListDisplay(): Array<string> {
         return this.selectedStatePurchaseDataList?.map((purchaseInfo) => {
             const militaryDiscount = purchaseInfo.isMilitaryDiscountActive && purchaseInfo.militaryDiscountAmount
                 ? purchaseInfo.militaryDiscountAmount : 0;
 
-            return ((purchaseInfo?.fee || 0) + (this.currentCompactCommissionFee || 0) - (militaryDiscount));
+            const total = ((purchaseInfo?.fee || 0) + (this.currentCompactCommissionFee || 0) - (militaryDiscount));
+
+            return total.toFixed(2);
         });
     }
 
@@ -382,7 +427,7 @@ export default class SelectPrivileges extends mixins(MixinForm) {
     }
 
     checkIfStateSelectIsDisabled(state): boolean {
-        return this.alreadyObtainedPrivilegeStates.includes(state.id);
+        return this.disabledPrivilegeStateChoices.includes(state.id);
     }
 
     @Watch('alreadyObtainedPrivilegeStates.length') reInitForm() {

--- a/webroot/src/pages/SelectPrivileges/SelectPrivileges.ts
+++ b/webroot/src/pages/SelectPrivileges/SelectPrivileges.ts
@@ -334,7 +334,10 @@ export default class SelectPrivileges extends mixins(MixinForm) {
     }
 
     deselectState(state) {
-        this.formData.stateCheckList.find((checkBox) => (checkBox.id === state?.jurisdiction?.abbrev)).value = false;
+        const stateAbbrev = state?.jurisdiction?.abbrev;
+
+        this.formData.stateCheckList.find((checkBox) => (checkBox.id === stateAbbrev)).value = false;
+        delete this.formData.jurisprudenceConfirmations[stateAbbrev];
     }
 
     submitUnderstanding() {
@@ -357,7 +360,7 @@ export default class SelectPrivileges extends mixins(MixinForm) {
         }
     }
 
-    checkState(stateFormInput) {
+    toggleStateSelected(stateFormInput) {
         const newStateFormInputValue = !stateFormInput.value;
         const stateAbbrev = stateFormInput.id;
 

--- a/webroot/src/pages/SelectPrivileges/SelectPrivileges.vue
+++ b/webroot/src/pages/SelectPrivileges/SelectPrivileges.vue
@@ -49,10 +49,13 @@
                             <div
                                 v-else
                                 class="state-select-unit"
-                                @click.stop="checkState(state)"
-                                @keyup.enter="checkState(state)"
-                                tabindex="0"
                             >
+                                <div
+                                    @click.prevent="checkState(state)"
+                                    @keyup.enter="checkState(state)"
+                                    tabindex="0"
+                                    class="enabled-state-overlay"
+                                />
                                 <InputCheckbox
                                     :formInput="state"
                                     @change="handleStateClicked(state)"

--- a/webroot/src/pages/SelectPrivileges/SelectPrivileges.vue
+++ b/webroot/src/pages/SelectPrivileges/SelectPrivileges.vue
@@ -51,14 +51,13 @@
                                 class="state-select-unit"
                             >
                                 <div
-                                    @click.prevent="checkState(state)"
-                                    @keyup.enter="checkState(state)"
+                                    @click.prevent="toggleStateSelected(state)"
+                                    @keyup.enter="toggleStateSelected(state)"
                                     tabindex="0"
                                     class="enabled-state-overlay"
                                 />
                                 <InputCheckbox
                                     :formInput="state"
-                                    @change="handleStateClicked(state)"
                                 />
                             </div>
                         </li>

--- a/webroot/src/pages/SelectPrivileges/SelectPrivileges.vue
+++ b/webroot/src/pages/SelectPrivileges/SelectPrivileges.vue
@@ -64,7 +64,7 @@
                     </ul>
                     <ul class="selected-state-list">
                         <li
-                            v-for="(state, i) in selectedStatePurchaseDataList"
+                            v-for="(state, i) in selectedStatePurchaseDataDisplayList"
                             :key="state.jurisdiction.abbrev"
                             class="selected-state-block"
                         >
@@ -83,19 +83,19 @@
                             </div>
                             <div class="info-row sub-row">
                                 <div class="info-row-label">{{jurisdictionFeeText}}</div>
-                                <div class="expire-date-value">${{state.fee.toFixed(2)}}</div>
+                                <div class="expire-date-value">${{state.feeDisplay}}</div>
                             </div>
                             <div class="info-row sub-row">
                                 <div class="info-row-label">{{commissionFeeText}}</div>
-                                <div class="expire-date-value">${{currentCompactCommissionFee.toFixed(2)}}</div>
+                                <div class="expire-date-value">${{currentCompactCommissionFeeDisplay}}</div>
                             </div>
                             <div v-if="state.isMilitaryDiscountActive" class="info-row sub-row">
                                 <div class="info-row-label">{{militaryDiscountText}}</div>
-                                <div class="expire-date-value">-${{state.militaryDiscountAmount.toFixed(2)}}</div>
+                                <div class="expire-date-value">-${{state.militaryDiscountAmountDisplay}}</div>
                             </div>
                             <div class="info-row">
                                 <div class="info-row-label">{{subtotalText}}</div>
-                                <div class="expire-date-value">${{subTotalList[i].toFixed(2)}}</div>
+                                <div class="expire-date-value">${{subTotalListDisplay[i]}}</div>
                             </div>
                             <div v-if="state.isJurisprudenceRequired" class="jurisprudence-check-box">
                                 <InputCheckbox


### PR DESCRIPTION
### Requirements List
- A user with one privilege that is not eligible for renewal

### Description List
- Upaded models and tests to set number params as number only rather than number or null as there seems to be a ts compiler bug involving values set as null initially (
- refactored privilege select screen to have more calculation inside the ts layer and outside the template layer
- Fixed all the bugs listed in the ticket
- Changed the grayed out behavior to match ticket description

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- Code review
- Check out the Privilege selection screen in both the real and mockAPI and confirm that it has been updated to match the changes and fixes described in the ticket

Closes #297 

Notes: The second active license is not reflected in what is grayed out in my display. However, this is an impossible edge case in the final version the user should not be able to get to this screen if they are in such an error state