### PR TITLE
Frontend/staff user invites

### DIFF
--- a/backend/compact-connect/stacks/api_stack/v1_api/staff_users.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/staff_users.py
@@ -509,6 +509,7 @@ class StaffUsers:
     def _attributes_schema(self):
         return JsonSchema(
             type=JsonSchemaType.OBJECT,
+            required=['email', 'givenName', 'familyName'],
             additional_properties=False,
             properties={
                 'email': JsonSchema(type=JsonSchemaType.STRING, min_length=5, max_length=100),

--- a/webroot/src/components/Forms/_mixins/form.mixin.ts
+++ b/webroot/src/components/Forms/_mixins/form.mixin.ts
@@ -16,6 +16,7 @@ class MixinForm extends Vue {
     // Data
     //
     formData: any = {};
+    shouldValuesIncludeDisabled = false;
     isFormValid = false;
     isFormLoading = false;
     isFormSuccessful = false;
@@ -33,7 +34,7 @@ class MixinForm extends Vue {
         const values: any = {};
 
         this.formKeys.forEach((key) => {
-            if (!formData[key].isSubmitInput && !formData[key].isDisabled) {
+            if (!formData[key].isSubmitInput && (!formData[key].isDisabled || this.shouldValuesIncludeDisabled)) {
                 values[key] = formData[key].value;
             }
         });

--- a/webroot/src/components/Forms/_mixins/mixins.spec.ts
+++ b/webroot/src/components/Forms/_mixins/mixins.spec.ts
@@ -28,13 +28,36 @@ describe('Form mixin', async () => {
 
         expect(component.formValues).to.matchPattern({});
     });
-    it('should get custom form values', async () => {
+    it('should get custom form values (standard)', async () => {
         const wrapper = await mountShallow(FormMixin);
         const component = wrapper.vm;
 
         component.formData = { id: { value: 1 }};
 
         expect(component.formValues).to.matchPattern({ id: 1 });
+    });
+    it('should get custom form values (exclude disabled by default)', async () => {
+        const wrapper = await mountShallow(FormMixin);
+        const component = wrapper.vm;
+
+        component.formData = {
+            prop1: { value: 1 },
+            prop2: { value: 2, isDisabled: true },
+        };
+
+        expect(component.formValues).to.matchPattern({ prop1: 1 });
+    });
+    it('should get custom form values (override to include disabled)', async () => {
+        const wrapper = await mountShallow(FormMixin);
+        const component = wrapper.vm;
+
+        component.shouldValuesIncludeDisabled = true;
+        component.formData = {
+            prop1: { value: 1 },
+            prop2: { value: 2, isDisabled: true },
+        };
+
+        expect(component.formValues).to.matchPattern({ prop1: 1, prop2: 2 });
     });
     it('should have super-scope input and blur methods', async () => {
         const wrapper = await mountShallow(FormMixin);

--- a/webroot/src/components/Page/PageMainNav/PageMainNav.ts
+++ b/webroot/src/components/Page/PageMainNav/PageMainNav.ts
@@ -9,6 +9,7 @@ import { reactive, computed } from 'vue';
 import { Component, Vue, toNative } from 'vue-facing-decorator';
 import { AuthTypes } from '@/app.config';
 import { Compact } from '@models/Compact/Compact.model';
+import { CompactPermission } from '@models/StaffUser/StaffUser.model';
 
 @Component({
     name: 'PageMainNav',
@@ -50,21 +51,44 @@ class PageMainNav extends Vue {
         return this.isLoggedIn && this.$store.getters['user/highestPermissionAuthType']() === AuthTypes.STAFF;
     }
 
-    get hasStatePermissions(): boolean {
+    get staffPermission(): CompactPermission | null {
         const { model: user } = this.userStore;
-        let hasPermissions = false;
+        const currentPermissions = user?.permissions;
+        const compactPermission = currentPermissions?.find((currentPermission) =>
+            currentPermission.compact.type === this.currentCompact?.type) || null;
+
+        return compactPermission;
+    }
+
+    get isAnyTypeOfAdmin(): boolean {
+        let isAdmin = false;
 
         if (this.isLoggedInAsStaff) {
-            const compactType = this.currentCompact?.type;
-            const compactPermissions = user?.permissions?.find((permission) =>
-                permission.compact.type === compactType) || null;
+            const { staffPermission } = this;
 
-            if (compactPermissions?.states?.length) {
-                hasPermissions = true;
+            if (staffPermission?.isAdmin) {
+                isAdmin = true;
+            } else if (staffPermission?.states?.some((statePermission) => statePermission.isAdmin)) {
+                isAdmin = true;
             }
         }
 
-        return hasPermissions;
+        return isAdmin;
+    }
+
+    get hasStateWritePermissions(): boolean {
+        let hasWritePermissions = false;
+
+        if (this.isLoggedInAsStaff) {
+            const { staffPermission } = this;
+
+            if (staffPermission?.states?.some((statePermission) =>
+                statePermission.isAdmin || statePermission.isWrite)) {
+                hasWritePermissions = true;
+            }
+        }
+
+        return hasWritePermissions;
     }
 
     get mainLinks() {
@@ -81,7 +105,7 @@ class PageMainNav extends Vue {
                 to: 'StateUpload',
                 params: { compact: this.currentCompact?.type },
                 label: computed(() => this.$t('navigation.upload')),
-                isEnabled: Boolean(this.currentCompact) && this.hasStatePermissions,
+                isEnabled: Boolean(this.currentCompact) && this.hasStateWritePermissions,
                 isExternal: false,
                 isExactActive: true,
             },
@@ -96,7 +120,7 @@ class PageMainNav extends Vue {
                 to: 'Users',
                 params: { compact: this.currentCompact?.type },
                 label: computed(() => this.$t('navigation.users')),
-                isEnabled: Boolean(this.currentCompact) && this.isLoggedInAsStaff,
+                isEnabled: this.isAnyTypeOfAdmin,
                 isExternal: false,
                 isExactActive: false,
             },

--- a/webroot/src/components/Page/PageMainNav/PageMainNav.ts
+++ b/webroot/src/components/Page/PageMainNav/PageMainNav.ts
@@ -92,14 +92,14 @@ class PageMainNav extends Vue {
                 isExternal: false,
                 isExactActive: false,
             },
-            // { // @NOTE: Disable user-list nav while the user management feature is WIP
-            //     to: 'Users',
-            //     params: { compact: this.currentCompact?.type },
-            //     label: computed(() => this.$t('navigation.users')),
-            //     isEnabled: this.isLoggedIn && Boolean(this.currentCompact),
-            //     isExternal: false,
-            //     isExactActive: false,
-            // },
+            {
+                to: 'Users',
+                params: { compact: this.currentCompact?.type },
+                label: computed(() => this.$t('navigation.users')),
+                isEnabled: Boolean(this.currentCompact) && this.isLoggedInAsStaff,
+                isExternal: false,
+                isExactActive: false,
+            },
             {
                 to: 'Logout',
                 label: computed(() => this.$t('navigation.logout')),

--- a/webroot/src/components/Users/UserInvite/UserInvite.less
+++ b/webroot/src/components/Users/UserInvite/UserInvite.less
@@ -28,6 +28,10 @@
         justify-content: space-between;
     }
 
+    .invite-email {
+        width: 100%;
+    }
+
     .permission-type-select {
         width: 50%;
     }

--- a/webroot/src/components/Users/UserInvite/UserInvite.less
+++ b/webroot/src/components/Users/UserInvite/UserInvite.less
@@ -24,8 +24,21 @@
     .invite-user-form-row {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
+
+        &:deep(.input-container label) {
+            display: block;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+
+            @media @tabletWidth {
+                display: flex;
+                overflow: unset;
+                white-space: unset;
+            }
+        }
     }
 
     .invite-user-meta {
@@ -43,7 +56,7 @@
     .input-connector {
         width: 5%;
         height: 2px;
-        margin-bottom: 12px;
+        margin-top: 46px;
         background-color: @black;
     }
 

--- a/webroot/src/components/Users/UserInvite/UserInvite.less
+++ b/webroot/src/components/Users/UserInvite/UserInvite.less
@@ -1,0 +1,78 @@
+//
+//  UserInvite.less
+//  CompactConnect
+//
+//  Created by InspiringApps on 11/11/2024.
+//
+
+.invite-user-container {
+    display: flex;
+    flex-direction: column;
+    max-height: 100vh;
+    overflow-y: auto;
+
+    .invite-user-title {
+        margin-bottom: 2rem;
+        font-size: @fontSizeExtraLarge;
+    }
+
+    .invite-user-name {
+        margin-bottom: 1.2rem;
+        font-size: @fontSizeLarge;
+    }
+
+    .invite-user-form-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .permission-type-select {
+        width: 50%;
+    }
+
+    .permission-select {
+        width: 40%;
+    }
+
+    .input-connector {
+        width: 5%;
+        height: 2px;
+        margin-bottom: 12px;
+        background-color: @black;
+    }
+
+    .row-separator {
+        width: 100%;
+        height: 2px;
+        margin-top: -32px;
+        background-color: @lightGrey;
+    }
+
+    .add-state {
+        margin-top: -2rem;
+        margin-bottom: 2rem;
+        margin-left: auto;
+    }
+
+    .invite-user-button {
+        width: 100%;
+
+        &:not(:first-child) {
+            margin-top: 1.6rem;
+        }
+
+        @media @desktopWidth {
+            width: 48%;
+
+            &:not(:first-child) {
+                margin-top: 0;
+            }
+        }
+
+        &:deep(input) {
+            width: 100%;
+        }
+    }
+}

--- a/webroot/src/components/Users/UserInvite/UserInvite.less
+++ b/webroot/src/components/Users/UserInvite/UserInvite.less
@@ -28,7 +28,7 @@
         justify-content: space-between;
     }
 
-    .invite-email {
+    .invite-user-meta {
         width: 100%;
     }
 

--- a/webroot/src/components/Users/UserInvite/UserInvite.spec.ts
+++ b/webroot/src/components/Users/UserInvite/UserInvite.spec.ts
@@ -1,0 +1,19 @@
+//
+//  UserInvite.spec.ts
+//  CompactConnect
+//
+//  Created by InspiringApps on 11/11/2024.
+//
+
+import { expect } from 'chai';
+import { mountShallow } from '@tests/helpers/setup';
+import UserInvite from '@components/Users/UserInvite/UserInvite.vue';
+
+describe('UserInvite component', async () => {
+    it('should mount the component', async () => {
+        const wrapper = await mountShallow(UserInvite);
+
+        expect(wrapper.exists()).to.equal(true);
+        expect(wrapper.findComponent(UserInvite).exists()).to.equal(true);
+    });
+});

--- a/webroot/src/components/Users/UserInvite/UserInvite.ts
+++ b/webroot/src/components/Users/UserInvite/UserInvite.ts
@@ -179,6 +179,7 @@ class UserInvite extends mixins(MixinForm) {
             const assignedStatesNum = Object.keys(this.formData)
                 .filter((formKey) => formKey.startsWith('state-option')).length;
 
+            // If there are available states that haven't been assigned, the button should be shown
             if (availableStatesNum > assignedStatesNum) {
                 shouldShow = true;
             }
@@ -288,6 +289,7 @@ class UserInvite extends mixins(MixinForm) {
                 const stateInputId = permissionInput.id.split('-').pop();
                 const stateInput = this.formData[`state-option-${stateInputId}`];
 
+                // If state has already been selected then show it in the options list as disabled
                 if (stateInput.value && stateInput.value === optionState.value) {
                     option.isDisabled = true;
                 }

--- a/webroot/src/components/Users/UserInvite/UserInvite.ts
+++ b/webroot/src/components/Users/UserInvite/UserInvite.ts
@@ -221,6 +221,20 @@ class UserInvite extends mixins(MixinForm) {
                 placeholder: computed(() => this.$t('common.emailAddress')),
                 validation: Joi.string().required().email({ tlds: false }).messages(this.joiMessages.string),
             }),
+            firstName: new FormInput({
+                id: 'first-name',
+                name: 'first-name',
+                label: computed(() => this.$t('common.firstName')),
+                placeholder: computed(() => this.$t('common.firstName')),
+                validation: Joi.string().required().messages(this.joiMessages.string),
+            }),
+            lastName: new FormInput({
+                id: 'last-name',
+                name: 'last-name',
+                label: computed(() => this.$t('common.lastName')),
+                placeholder: computed(() => this.$t('common.lastName')),
+                validation: Joi.string().required().messages(this.joiMessages.string),
+            }),
             submit: new FormInput({
                 isSubmitInput: true,
                 id: 'submit',
@@ -412,6 +426,8 @@ class UserInvite extends mixins(MixinForm) {
         const { formValues } = this;
         const userData = {
             email: formValues.email,
+            firstName: formValues.firstName,
+            lastName: formValues.lastName,
         };
         const compactData = {
             compact: formValues.compact,
@@ -436,6 +452,8 @@ class UserInvite extends mixins(MixinForm) {
 
     mockPopulate(): void {
         this.formData.email.value = `test@example.com`;
+        this.formData.firstName.value = `Test`;
+        this.formData.lastName.value = `User`;
     }
 }
 

--- a/webroot/src/components/Users/UserInvite/UserInvite.ts
+++ b/webroot/src/components/Users/UserInvite/UserInvite.ts
@@ -1,0 +1,382 @@
+//
+//  UserInvite.ts
+//  CompactConnect
+//
+//  Created by InspiringApps on 11/11/2024.
+//
+
+import { Component, mixins, toNative } from 'vue-facing-decorator';
+import { reactive, computed, ComputedRef } from 'vue';
+import MixinForm from '@components/Forms/_mixins/form.mixin';
+import Card from '@components/Card/Card.vue';
+import InputText from '@components/Forms/InputText/InputText.vue';
+import InputSelect from '@components/Forms/InputSelect/InputSelect.vue';
+import InputButton from '@components/Forms/InputButton/InputButton.vue';
+import InputSubmit from '@components/Forms/InputSubmit/InputSubmit.vue';
+import LoadingSpinner from '@components/LoadingSpinner/LoadingSpinner.vue';
+import { Compact } from '@models/Compact/Compact.model';
+import { State } from '@models/State/State.model';
+import {
+    StaffUser,
+    StaffUserSerializer,
+    CompactPermission,
+    StatePermission
+} from '@models/StaffUser/StaffUser.model';
+import { FormInput } from '@models/FormInput/FormInput.model';
+import Joi from 'joi';
+
+interface PermissionOption {
+    value: string | number;
+    name: string | ComputedRef<string>;
+    isDisabled?: boolean;
+}
+
+enum Permission {
+    NONE = 'none',
+    READ = 'read',
+    WRITE = 'write',
+    ADMIN = 'admin',
+}
+
+interface PermissionObject {
+    isRead?: boolean;
+    isWrite?: boolean;
+    isAdmin?: boolean;
+}
+
+@Component({
+    name: 'UserInvite',
+    components: {
+        Card,
+        InputText,
+        InputSelect,
+        InputButton,
+        InputSubmit,
+        LoadingSpinner,
+    },
+    emits: [ 'cancel', 'saved' ],
+})
+class UserInvite extends mixins(MixinForm) {
+    //
+    // Data
+    //
+    permissionStateInputs: Array<FormInput> = [];
+
+    //
+    // Lifecycle
+    //
+    created() {
+        this.initFormInputs();
+    }
+
+    //
+    // Computed
+    //
+    get userStore() {
+        return this.$store.state.user;
+    }
+
+    get currentUser(): StaffUser {
+        return this.userStore.model;
+    }
+
+    get currentCompact(): Compact | null {
+        return this.userStore.currentCompact;
+    }
+
+    get currentUserCompactPermission(): CompactPermission | null {
+        const currentPermissions = this.currentUser?.permissions;
+        const compactPermission = currentPermissions?.find((currentPermission: CompactPermission) =>
+            currentPermission.compact.type === this.currentCompact?.type) || null;
+
+        return compactPermission;
+    }
+
+    get isCurrentUserCompactAdmin(): boolean {
+        return this.getCompactPermission(this.currentUserCompactPermission) === Permission.ADMIN;
+    }
+
+    get userCompactOptions(): Array<PermissionOption> {
+        const { currentCompact } = this;
+        const compactOptions: Array<PermissionOption> = [
+            { value: Permission.NONE, name: this.$t('account.accessLevel.none') },
+        ];
+
+        if (currentCompact && currentCompact.type) {
+            compactOptions.push({
+                value: currentCompact.type,
+                name: currentCompact.abbrev(),
+            });
+        }
+
+        return compactOptions;
+    }
+
+    get userPermissionOptionsCompact(): Array<PermissionOption> {
+        return [
+            { value: Permission.NONE, name: this.$t('account.accessLevel.none') },
+            { value: Permission.READ, name: this.$t('account.accessLevel.read') },
+            { value: Permission.ADMIN, name: this.$t('account.accessLevel.admin') },
+        ];
+    }
+
+    get userPermissionOptionsState(): Array<PermissionOption> {
+        return [
+            { value: Permission.NONE, name: this.$t('account.accessLevel.none') },
+            { value: Permission.WRITE, name: this.$t('account.accessLevel.write') },
+            { value: Permission.ADMIN, name: this.$t('account.accessLevel.admin') },
+        ];
+    }
+
+    get userOptionsState(): Array<PermissionOption> {
+        const { currentCompact } = this;
+        const options = currentCompact?.memberStates?.map((memberState: State) => ({
+            value: (memberState.abbrev as unknown as string)?.toLowerCase() || '',
+            name: memberState.name(),
+        })) || [];
+
+        options.unshift({ value: '', name: this.$t('common.select') });
+
+        return options;
+    }
+
+    //
+    // Methods
+    //
+    initFormInputs(): void {
+        this.formData = reactive({
+            compact: new FormInput({
+                id: 'compact',
+                name: 'compact',
+                label: computed(() => this.$t('account.affiliation')),
+                placeholder: computed(() => this.$t('account.affiliation')),
+                valueOptions: this.userCompactOptions,
+                value: this.currentCompact?.type,
+                isDisabled: true,
+            }),
+            compactPermission: new FormInput({
+                id: 'compact-permission',
+                name: 'compact-permission',
+                label: computed(() => this.$t('account.permission')),
+                placeholder: computed(() => this.$t('account.permission')),
+                valueOptions: this.userPermissionOptionsCompact,
+                value: Permission.NONE,
+            }),
+            email: new FormInput({
+                id: 'email',
+                name: 'email',
+                label: computed(() => this.$t('common.emailAddress')),
+                placeholder: computed(() => this.$t('common.emailAddress')),
+                validation: Joi.string().required().email({ tlds: false }).messages(this.joiMessages.string),
+            }),
+            submit: new FormInput({
+                isSubmitInput: true,
+                id: 'submit',
+                shouldHideMargin: true,
+            }),
+        });
+
+        this.watchFormInputs(); // Important if you want automated form validation
+    }
+
+    addStateFormInput(statePermission?: StatePermission): void {
+        const { state } = statePermission || {};
+        const stateAbbrev = state?.abbrev || '';
+        const stateOptions = this.filterStateOptions();
+        const isStateInOptions = stateOptions.some((stateOption) => stateOption.value === stateAbbrev);
+        const index = this.permissionStateInputs.length;
+
+        if (isStateInOptions) {
+            const stateInput = new FormInput({
+                id: `state-option-${index}`,
+                name: `state-option-${index}`,
+                label: computed(() => this.$t('account.state')),
+                placeholder: computed(() => this.$t('account.state')),
+                validation: (!statePermission) ? Joi.string().required().messages(this.joiMessages.string) : null,
+                valueOptions: stateOptions,
+                value: state?.abbrev || '',
+                isDisabled: Boolean(statePermission),
+            });
+            const permissionInput = new FormInput({
+                id: `state-permission-${index}`,
+                name: `state-permission-${index}`,
+                label: computed(() => this.$t('account.permission')),
+                placeholder: computed(() => this.$t('account.permission')),
+                validation: (!statePermission) ? Joi.string().required().messages(this.joiMessages.string) : null,
+                valueOptions: this.userPermissionOptionsState,
+                value: (statePermission) ? this.getStatePermission(statePermission) : Permission.NONE,
+            });
+
+            this.formData[`state-option-${index}`] = stateInput;
+            this.formData[`state-permission-${index}`] = permissionInput;
+
+            this.permissionStateInputs.push(permissionInput);
+        }
+    }
+
+    filterStateOptions(): Array<PermissionOption> {
+        return this.userOptionsState.map((optionState) => {
+            const option = { ...optionState };
+
+            this.permissionStateInputs.forEach((permissionInput) => {
+                const stateInputId = permissionInput.id.split('-').pop();
+                const stateInput = this.formData[`state-option-${stateInputId}`];
+
+                if (stateInput.value && stateInput.value === optionState.value) {
+                    option.isDisabled = true;
+                }
+            });
+
+            return option;
+        });
+    }
+
+    lockInStateOptions(): void {
+        const { formData } = this;
+
+        Object.keys(this.formData).forEach((key) => {
+            if (key.startsWith('state-option')) {
+                formData[key].isDisabled = true;
+            }
+        });
+    }
+
+    createNewStatePermission(): void {
+        this.validateAll({ asTouched: true });
+
+        if (this.isFormValid) {
+            this.lockInStateOptions();
+            this.addStateFormInput();
+        }
+    }
+
+    getCompactPermission(compactPermission: CompactPermission | null): Permission {
+        let permission = Permission.NONE;
+
+        if (compactPermission) {
+            if (compactPermission.isAdmin) {
+                permission = Permission.ADMIN;
+            } else if (compactPermission.isRead) {
+                permission = Permission.READ;
+            }
+        }
+
+        return permission;
+    }
+
+    setCompactPermission(permission: Permission): PermissionObject {
+        const response: PermissionObject = {};
+
+        switch (permission) {
+        case Permission.NONE:
+            response.isRead = false;
+            response.isAdmin = false;
+            break;
+        case Permission.READ:
+            response.isRead = true;
+            response.isAdmin = false;
+            break;
+        case Permission.ADMIN:
+            response.isRead = true;
+            response.isAdmin = true;
+            break;
+        default:
+            break;
+        }
+
+        return response;
+    }
+
+    getStatePermission(statePermission: StatePermission | null): Permission {
+        let permission = Permission.NONE;
+
+        if (statePermission) {
+            if (statePermission.isAdmin) {
+                permission = Permission.ADMIN;
+            } else if (statePermission.isWrite) {
+                permission = Permission.WRITE;
+            }
+        }
+
+        return permission;
+    }
+
+    setStatePermission(permission: Permission): PermissionObject {
+        const response: PermissionObject = {};
+
+        switch (permission) {
+        case Permission.NONE:
+            response.isWrite = false;
+            response.isAdmin = false;
+            break;
+        case Permission.WRITE:
+            response.isWrite = true;
+            response.isAdmin = false;
+            break;
+        case Permission.ADMIN:
+            response.isWrite = true;
+            response.isAdmin = true;
+            break;
+        default:
+            break;
+        }
+
+        return response;
+    }
+
+    handleCancel(): void {
+        this.$emit('cancel');
+    }
+
+    async handleSubmit(): Promise<void> {
+        this.validateAll({ asTouched: true });
+
+        if (this.isFormValid) {
+            this.startFormLoading();
+
+            const formData = this.prepFormData();
+            const serverData = StaffUserSerializer.toServer({ permissions: [formData] });
+
+            await this.$store.dispatch(`users/createUserRequest`, {
+                compact: this.currentCompact?.type,
+                data: serverData,
+            }).catch((err) => {
+                this.setError(err.message);
+            });
+
+            if (!this.isFormError) {
+                this.isFormSuccessful = true;
+            }
+
+            this.$emit('saved');
+            this.endFormLoading();
+        }
+    }
+
+    prepFormData(): object {
+        const { formValues } = this;
+        const compactData = {
+            compact: formValues.compact,
+            ...this.setCompactPermission(formValues.compactPermission),
+            states: [] as Array<object>,
+        };
+        const stateKeys = Object.keys(formValues).filter((key) => key.startsWith('state-option'));
+
+        stateKeys.forEach((stateKey) => {
+            const keyNum = stateKey.split('-').pop();
+            const stateAbbrev = formValues[`state-option-${keyNum}`];
+            const statePermission = formValues[`state-permission-${keyNum}`];
+
+            compactData.states.push({
+                abbrev: stateAbbrev,
+                ...this.setStatePermission(statePermission),
+            });
+        });
+
+        return compactData;
+    }
+}
+
+export default toNative(UserInvite);
+
+// export default UserInvite;

--- a/webroot/src/components/Users/UserInvite/UserInvite.ts
+++ b/webroot/src/components/Users/UserInvite/UserInvite.ts
@@ -174,7 +174,7 @@ class UserInvite extends mixins(MixinForm) {
     get shouldShowAddStateButton(): boolean {
         let shouldShow = false;
 
-        if (this.isCurrentUserStateAdminAny) {
+        if (this.isCurrentUserCompactAdmin || this.isCurrentUserStateAdminAny) {
             const availableStatesNum = this.userOptionsState.length - 1;
             const assignedStatesNum = Object.keys(this.formData)
                 .filter((formKey) => formKey.startsWith('state-option')).length;

--- a/webroot/src/components/Users/UserInvite/UserInvite.vue
+++ b/webroot/src/components/Users/UserInvite/UserInvite.vue
@@ -1,0 +1,59 @@
+<!--
+    UserInvite.vue
+    CompactConnect
+
+    Created by InspiringApps on 11/11/2024.
+-->
+
+<template>
+    <Card class="invite-user-container">
+        <div class="invite-user-title">{{ $t('account.inviteNewUser') }}</div>
+        <form @submit.prevent="handleSubmit">
+            <div class="invite-user-form-row">
+                <InputText :formInput="formData.email" class="invite-email" />
+            </div>
+            <div class="invite-user-form-row">
+                <InputSelect :formInput="formData.compact" class="permission-type-select" />
+                <div class="input-connector"></div>
+                <InputSelect :formInput="formData.compactPermission" class="permission-select" />
+            </div>
+            <TransitionGroup name="fade">
+                <div
+                    v-for="(formInput, index) in permissionStateInputs"
+                    :key="formInput.id"
+                    class="invite-user-form-row"
+                >
+                    <div v-if="index === 0" class="row-separator"></div>
+                    <InputSelect :formInput="formData[`state-option-${index}`]" class="permission-type-select" />
+                    <div class="input-connector"></div>
+                    <InputSelect :formInput="formInput" class="permission-select" />
+                </div>
+            </TransitionGroup>
+            <div v-if="isCurrentUserCompactAdmin" class="invite-user-form-row">
+                <button
+                    class="add-state text-like"
+                    @click.prevent="createNewStatePermission"
+                    @keyup.enter.prevent="createNewStatePermission"
+                >+ {{ $t('account.addState') }}</button>
+            </div>
+            <div class="invite-user-form-row">
+                <InputButton
+                    class="invite-user-button"
+                    :label="$t('common.cancel')"
+                    :shouldHideMargin="true"
+                    :isTransparent="true"
+                    :onClick="handleCancel"
+                />
+                <InputSubmit
+                    class="invite-user-button"
+                    :formInput="formData.submit"
+                    :label="$t('common.sendInvite')"
+                    :isEnabled="!isFormLoading"
+                />
+            </div>
+        </form>
+    </Card>
+</template>
+
+<script lang="ts" src="./UserInvite.ts"></script>
+<style scoped lang="less" src="./UserInvite.less"></style>

--- a/webroot/src/components/Users/UserInvite/UserInvite.vue
+++ b/webroot/src/components/Users/UserInvite/UserInvite.vue
@@ -11,7 +11,13 @@
         <MockPopulate :isEnabled="isMockPopulateEnabled" @selected="mockPopulate" />
         <form @submit.prevent="handleSubmit">
             <div class="invite-user-form-row">
-                <InputText :formInput="formData.email" class="invite-email" />
+                <InputText :formInput="formData.email" class="invite-user-meta invite-email" />
+            </div>
+            <div class="invite-user-form-row">
+                <InputText :formInput="formData.firstName" class="invite-user-meta invite-first-name" />
+            </div>
+            <div class="invite-user-form-row">
+                <InputText :formInput="formData.lastName" class="invite-user-meta invite-last-name" />
             </div>
             <div class="invite-user-form-row">
                 <InputSelect :formInput="formData.compact" class="permission-type-select" />

--- a/webroot/src/components/Users/UserInvite/UserInvite.vue
+++ b/webroot/src/components/Users/UserInvite/UserInvite.vue
@@ -8,6 +8,7 @@
 <template>
     <Card class="invite-user-container">
         <div class="invite-user-title">{{ $t('account.inviteNewUser') }}</div>
+        <MockPopulate :isEnabled="isMockPopulateEnabled" @selected="mockPopulate" />
         <form @submit.prevent="handleSubmit">
             <div class="invite-user-form-row">
                 <InputText :formInput="formData.email" class="invite-email" />
@@ -29,7 +30,7 @@
                     <InputSelect :formInput="formInput" class="permission-select" />
                 </div>
             </TransitionGroup>
-            <div v-if="isCurrentUserCompactAdmin" class="invite-user-form-row">
+            <div v-if="shouldShowAddStateButton" class="invite-user-form-row">
                 <button
                     class="add-state text-like"
                     @click.prevent="createNewStatePermission"
@@ -48,7 +49,7 @@
                     class="invite-user-button"
                     :formInput="formData.submit"
                     :label="$t('common.sendInvite')"
-                    :isEnabled="!isFormLoading"
+                    :isEnabled="!isFormLoading && isAnyTypeOfAdmin"
                 />
             </div>
         </form>

--- a/webroot/src/components/Users/UserList/UserList.less
+++ b/webroot/src/components/Users/UserList/UserList.less
@@ -12,6 +12,11 @@
         display: flex;
         flex-direction: column;
         width: 100%;
+        padding-bottom: 1.2rem;
+
+        @media @desktopWidth {
+            flex-direction: row;
+        }
 
         .search-container {
             width: 100%;
@@ -20,10 +25,47 @@
             @media @desktopWidth {
                 width: 50%;
             }
+
+            .user-search-submit {
+                .visually-hidden();
+            }
         }
 
-        .user-search-submit {
-            .visually-hidden();
+        .invite-button-container {
+            display: flex;
+
+            @media @desktopWidth {
+                margin-left: auto;
+            }
+
+            .invite-user {
+                height: 4.0rem;
+            }
+        }
+    }
+
+    .modal-mask {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 2;
+        width: 100%;
+        min-width: 100vw;
+        height: 100%;
+        min-height: 100vh;
+        background-color: #00000040;
+    }
+
+    .invite-user-modal {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        z-index: 4;
+        width: 90%;
+        transform: translate(-50%, -50%);
+
+        @media @desktopWidth {
+            width: 50rem;
         }
     }
 }

--- a/webroot/src/components/Users/UserList/UserList.ts
+++ b/webroot/src/components/Users/UserList/UserList.ts
@@ -15,6 +15,7 @@ import { reactive, computed } from 'vue';
 import MixinForm from '@components/Forms/_mixins/form.mixin';
 import ListContainer from '@components/Lists/ListContainer/ListContainer.vue';
 import InputSearch from '@components/Forms/InputSearch/InputSearch.vue';
+import UserInvite from '@components/Users/UserInvite/UserInvite.vue';
 import UserRow from '@components/Users/UserRow/UserRow.vue';
 import { FormInput } from '@models/FormInput/FormInput.model';
 import { SortDirection } from '@store/sorting/sorting.state';
@@ -26,6 +27,7 @@ import { PageExhaustError } from '@store/pagination';
     components: {
         ListContainer,
         InputSearch,
+        UserInvite,
         UserRow,
     }
 })
@@ -38,6 +40,7 @@ class UserList extends mixins(MixinForm) {
     isInitialFetchCompleted = false;
     prevKey = '';
     nextKey = '';
+    isInviteActive = false;
 
     //
     // Lifecycle
@@ -111,6 +114,7 @@ class UserList extends mixins(MixinForm) {
             userSearch: new FormInput({
                 id: 'user-search',
                 name: 'user-search',
+                shouldHideLabel: true,
                 placeholder: computed(() => this.$t('account.userSearchLabel')),
             }),
         });
@@ -274,6 +278,14 @@ class UserList extends mixins(MixinForm) {
         if (this.isInitialFetchCompleted) {
             await this.fetchListData();
         }
+    }
+
+    toggleUserInvite(): void {
+        this.isInviteActive = !this.isInviteActive;
+    }
+
+    closeUserInvite(): void {
+        this.isInviteActive = false;
     }
 }
 

--- a/webroot/src/components/Users/UserList/UserList.vue
+++ b/webroot/src/components/Users/UserList/UserList.vue
@@ -20,6 +20,9 @@
                     />
                 </form>
             </div>
+            <div class="invite-button-container">
+                <button class="invite-user" @click="toggleUserInvite">+ {{ $t('common.invite') }}</button>
+            </div>
         </div>
         <ListContainer
             :listId="listId"
@@ -56,6 +59,14 @@
                 />
             </template>
         </ListContainer>
+        <transition mode="out-in">
+            <div v-if="isInviteActive">
+                <div class="modal-mask"></div>
+                <div class="invite-user-modal">
+                    <UserInvite @saved="closeUserInvite" @cancel="closeUserInvite" />
+                </div>
+            </div>
+        </transition>
     </div>
 </template>
 

--- a/webroot/src/components/Users/UserList/UserList.vue
+++ b/webroot/src/components/Users/UserList/UserList.vue
@@ -21,7 +21,12 @@
                 </form>
             </div>
             <div class="invite-button-container">
-                <button class="invite-user" @click="toggleUserInvite">+ {{ $t('common.invite') }}</button>
+                <button
+                    class="invite-user"
+                    @click="toggleUserInvite"
+                >
+                    + {{ $t('common.invite') }}
+                </button>
             </div>
         </div>
         <ListContainer

--- a/webroot/src/components/Users/UserRowEdit/UserRowEdit.less
+++ b/webroot/src/components/Users/UserRowEdit/UserRowEdit.less
@@ -24,8 +24,21 @@
     .edit-user-form-row {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
+
+        &:deep(.input-container label) {
+            display: block;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+
+            @media @tabletWidth {
+                display: flex;
+                overflow: unset;
+                white-space: unset;
+            }
+        }
     }
 
     .permission-type-select {
@@ -39,7 +52,7 @@
     .input-connector {
         width: 5%;
         height: 2px;
-        margin-bottom: 12px;
+        margin-top: 46px;
         background-color: @black;
     }
 

--- a/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
+++ b/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
@@ -193,7 +193,7 @@ class UserRowEdit extends mixins(MixinForm) {
     get shouldShowAddStateButton(): boolean {
         let shouldShow = false;
 
-        if (this.isCurrentUserStateAdminAny) {
+        if (this.isCurrentUserCompactAdmin || this.isCurrentUserStateAdminAny) {
             const availableStatesNum = this.userOptionsState.length - 1;
             const assignedStatesNum = Object.keys(this.formData)
                 .filter((formKey) => formKey.startsWith('state-option')).length;

--- a/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
+++ b/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
@@ -71,6 +71,7 @@ class UserRowEdit extends mixins(MixinForm) {
     // Lifecycle
     //
     created() {
+        this.shouldValuesIncludeDisabled = true;
         this.initFormInputs();
     }
 
@@ -109,6 +110,18 @@ class UserRowEdit extends mixins(MixinForm) {
         return this.getCompactPermission(this.currentUserCompactPermission) === Permission.ADMIN;
     }
 
+    get isCurrentUserStateAdminAny(): boolean {
+        const { currentUserCompactPermission } = this;
+        const statePermissions = currentUserCompactPermission?.states || [];
+        const isStateAdminAny = statePermissions.some((statePermission) => statePermission.isAdmin);
+
+        return isStateAdminAny;
+    }
+
+    get isAnyTypeOfAdmin(): boolean {
+        return this.isCurrentUserCompactAdmin || this.isCurrentUserStateAdminAny;
+    }
+
     get userCompact(): Compact | null {
         return this.rowUserCompactPermission?.compact || null;
     }
@@ -137,6 +150,12 @@ class UserRowEdit extends mixins(MixinForm) {
         ];
     }
 
+    get currentUserStatePermissions(): Array<StatePermission> {
+        const statePermissions = this.currentUserCompactPermission?.states || [];
+
+        return statePermissions;
+    }
+
     get userStatePermissions(): Array<StatePermission> {
         return this.rowUserCompactPermission?.states || [];
     }
@@ -151,14 +170,40 @@ class UserRowEdit extends mixins(MixinForm) {
 
     get userOptionsState(): Array<PermissionOption> {
         const { userCompact } = this;
-        const options = userCompact?.memberStates?.map((memberState: State) => ({
+        let options = userCompact?.memberStates?.map((memberState: State) => ({
             value: (memberState.abbrev as unknown as string)?.toLowerCase() || '',
             name: memberState.name(),
         })) || [];
 
+        if (!this.isCurrentUserCompactAdmin) {
+            options = options.filter((option) =>
+                this.currentUserStatePermissions.some((statePermission) => {
+                    const stateAbbrev = statePermission.state?.abbrev || '';
+                    const isStateAdmin = statePermission.isAdmin;
+
+                    return stateAbbrev === option.value && isStateAdmin;
+                }));
+        }
+
         options.unshift({ value: '', name: this.$t('common.select') });
 
         return options;
+    }
+
+    get shouldShowAddStateButton(): boolean {
+        let shouldShow = false;
+
+        if (this.isCurrentUserStateAdminAny) {
+            const availableStatesNum = this.userOptionsState.length - 1;
+            const assignedStatesNum = Object.keys(this.formData)
+                .filter((formKey) => formKey.startsWith('state-option')).length;
+
+            if (availableStatesNum > assignedStatesNum) {
+                shouldShow = true;
+            }
+        }
+
+        return shouldShow;
     }
 
     //
@@ -182,6 +227,7 @@ class UserRowEdit extends mixins(MixinForm) {
                 placeholder: computed(() => this.$t('account.permission')),
                 valueOptions: this.userPermissionOptionsCompact,
                 value: this.getCompactPermission(this.rowUserCompactPermission),
+                isDisabled: !this.isCurrentUserCompactAdmin,
             }),
             submit: new FormInput({
                 isSubmitInput: true,

--- a/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
+++ b/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
@@ -198,6 +198,7 @@ class UserRowEdit extends mixins(MixinForm) {
             const assignedStatesNum = Object.keys(this.formData)
                 .filter((formKey) => formKey.startsWith('state-option')).length;
 
+            // If there are available states that haven't been assigned, the button should be shown
             if (availableStatesNum > assignedStatesNum) {
                 shouldShow = true;
             }
@@ -289,6 +290,7 @@ class UserRowEdit extends mixins(MixinForm) {
                 const stateInputId = permissionInput.id.split('-').pop();
                 const stateInput = this.formData[`state-option-${stateInputId}`];
 
+                // If there are available states that haven't been assigned, the button should be shown
                 if (stateInput.value && stateInput.value === optionState.value) {
                     option.isDisabled = true;
                 }

--- a/webroot/src/components/Users/UserRowEdit/UserRowEdit.vue
+++ b/webroot/src/components/Users/UserRowEdit/UserRowEdit.vue
@@ -29,7 +29,7 @@
                     <InputSelect :formInput="formInput" class="permission-select" />
                 </div>
             </TransitionGroup>
-            <div v-if="isCurrentUserCompactAdmin" class="edit-user-form-row">
+            <div v-if="shouldShowAddStateButton" class="edit-user-form-row">
                 <button
                     class="add-state text-like"
                     @click.prevent="createNewStatePermission"
@@ -48,7 +48,7 @@
                     class="edit-user-button"
                     :formInput="formData.submit"
                     :label="$t('common.saveChanges')"
-                    :isEnabled="!isFormLoading && rowUserCompactPermission"
+                    :isEnabled="!isFormLoading && isAnyTypeOfAdmin"
                 />
             </div>
         </form>

--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -20,8 +20,10 @@
         "add": "Add",
         "remove": "Remove",
         "reset": "Reset",
+        "invite": "Invite",
         "save": "Save",
         "saveChanges": "Save changes",
+        "sendInvite": "Send invite",
         "submit": "Submit",
         "clear": "Clear",
         "success": "Success",
@@ -528,7 +530,8 @@
         "edit": "Edit",
         "editPermissions": "Edit permissions",
         "editUserPermissions": "Edit user permissions",
-        "addState": "Add state / jurisdiction"
+        "addState": "Add state / jurisdiction",
+        "inviteNewUser": "Invite new user"
     },
     "styleGuide": {
         "headerPlaceholder": "Header Content",

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -20,7 +20,9 @@
         "add": "Agregar",
         "remove": "Eliminar",
         "reset": "Restablecer",
+        "invite": "Invitar",
         "save": "Guardar",
+        "sendInvite": "Enviar invitación",
         "saveChanges": "Guardar cambios",
         "submit": "Enviar",
         "clear": "Borrar",
@@ -528,7 +530,8 @@
         "edit": "Editar",
         "editPermissions": "Editar permisos",
         "editUserPermissions": "Editar permisos de usuario",
-        "addState": "Agregar estado / jurisdiccion"
+        "addState": "Agregar estado / jurisdiccion",
+        "inviteNewUser": "Invitar nuevo usuario"
     },
     "styleGuide": {
         "headerPlaceholder": "Contenido del encabezado",

--- a/webroot/src/models/StaffUser/StaffUser.model.spec.ts
+++ b/webroot/src/models/StaffUser/StaffUser.model.spec.ts
@@ -290,6 +290,11 @@ describe('User model', () => {
                     ],
                 },
             ],
+            attributes: {
+                email: 'test@example.com',
+                firstName: 'Test',
+                lastName: 'User',
+            },
         };
         const requestData = StaffUserSerializer.toServer(data);
 
@@ -309,6 +314,11 @@ describe('User model', () => {
                         },
                     },
                 },
+            },
+            attributes: {
+                email: data.attributes.email,
+                givenName: data.attributes.firstName,
+                familyName: data.attributes.lastName,
             },
         });
     });

--- a/webroot/src/models/StaffUser/StaffUser.model.ts
+++ b/webroot/src/models/StaffUser/StaffUser.model.ts
@@ -353,6 +353,20 @@ export class StaffUserSerializer {
             });
         }
 
+        if (data?.attributes) {
+            serverData.attributes = {};
+
+            if (data.attributes.email) {
+                serverData.attributes.email = data.attributes.email;
+            }
+            if (data.attributes.firstName) {
+                serverData.attributes.givenName = data.attributes.firstName;
+            }
+            if (data.attributes.lastName) {
+                serverData.attributes.familyName = data.attributes.lastName;
+            }
+        }
+
         return serverData;
     }
 }

--- a/webroot/src/network/userApi/data.api.ts
+++ b/webroot/src/network/userApi/data.api.ts
@@ -141,11 +141,8 @@ export class UserDataApi implements DataApiInterface {
      * @return {Promise<User>}         A User model instance.
      */
     public async createUser(compact: string, data: any) {
-        // const serverResponse = await this.api.post(`/v1/compacts/${compact}/staff-users`, data);
-        // const response = StaffUserSerializer.fromServer(serverResponse);
-        // @TODO
-        console.log(data);
-        const response = StaffUserSerializer.fromServer(data);
+        const serverResponse = await this.api.post(`/v1/compacts/${compact}/staff-users`, data);
+        const response = StaffUserSerializer.fromServer(serverResponse);
 
         return response;
     }

--- a/webroot/src/network/userApi/data.api.ts
+++ b/webroot/src/network/userApi/data.api.ts
@@ -141,8 +141,11 @@ export class UserDataApi implements DataApiInterface {
      * @return {Promise<User>}         A User model instance.
      */
     public async createUser(compact: string, data: any) {
-        const serverResponse = await this.api.post(`/v1/compacts/${compact}/staff-users`, data);
-        const response = StaffUserSerializer.fromServer(serverResponse);
+        // const serverResponse = await this.api.post(`/v1/compacts/${compact}/staff-users`, data);
+        // const response = StaffUserSerializer.fromServer(serverResponse);
+        // @TODO
+        console.log(data);
+        const response = StaffUserSerializer.fromServer(data);
 
         return response;
     }


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Small backend fix to avoid 502s when inviting users
- Updated the form mixin to make disabled inputs configurable
- Enable User list in the main nav for admins
- Lay some groundwork for upcoming read-permission changes
- Added a new UserInvite component to the UserList
- Minor updates to the UserRowEdit component based on business reqs learned during user invite
- Update the StaffUser serializer to include email / firstName / lastName attributes for invites

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Licensee-only users
    - Shouldn't see the Users link in the main nav
- Staff users
    - Staff users **without** any type of admin privilege (compact or state) should _not_ see the Users link in the main nav
    - Staff users **with** any type of admin privilege (compact or state) should see the Users link in the main nav
        - Should be able to click the new Invite button and successfully invite users
        - Users without compact-admin privileges should _not_ be able to select the compact permission
        - Users with state-only-admin privileges should only be able to select states for which they are an admin

Closes #189 
