### PR TITLE
Update frontend dependencies

### DIFF
--- a/webroot/package.json
+++ b/webroot/package.json
@@ -102,7 +102,8 @@
     "stylelint-config-rational-order/**/trim": "^0.0.3",
     "stylelint-config-rational-order/stylelint": "^13.3.0",
     "@vue/cli-plugin-unit-mocha/mocha/minimatch": "^3.0.5",
-    "@vue/cli-plugin-unit-mocha/mocha/nanoid": "^3.1.31"
+    "@vue/cli-plugin-unit-mocha/mocha/nanoid": "^3.1.31",
+    "@vue/cli-plugin-eslint/**/cross-spawn": "^6.0.6"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/webroot/yarn.lock
+++ b/webroot/yarn.lock
@@ -5032,19 +5032,10 @@ country-codes-flags-phone-codes@^1.0.4:
   resolved "https://registry.yarnpkg.com/country-codes-flags-phone-codes/-/country-codes-flags-phone-codes-1.0.4.tgz#c62268c4f7bac769036768d9215635f675aba123"
   integrity sha512-G3V7647qlJ7/kGDOQutjIQQCpTxLJJKqe9fQH/FxXrsjzD2etS3f/EAtboNfO7Xle/BxGZjehD/aFtzXXfCcAA==
 
-cross-spawn@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
-  dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
-cross-spawn@^6.0.0:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
-  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+cross-spawn@^5.0.1, cross-spawn@^6.0.0, cross-spawn@^6.0.6:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.6.tgz#30d0efa0712ddb7eb5a76e1e8721bffafa6b5d57"
+  integrity sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==
   dependencies:
     nice-try "^1.0.4"
     path-key "^2.0.1"
@@ -8663,7 +8654,7 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
   integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
-lru-cache@^4.0.1, lru-cache@^4.1.2:
+lru-cache@^4.1.2:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==

--- a/webroot/yarn.lock
+++ b/webroot/yarn.lock
@@ -5053,9 +5053,9 @@ cross-spawn@^6.0.0:
     which "^1.2.9"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
### Requirements List
- `yarn install --ignore-engines`

### Description List
- Updated `cross-spawn`
    - https://github.com/csg-org/CompactConnect/security/dependabot/56
    - `cross-spawn@7.x` & `cross-spawn@6.x` were able to be updated normally
    - `cross-spawn@5.x` required a new resolution + confirmation that the update to `6.x` for that case was not breaking
        - In addition to smoke testing, looking at the release notes for the parent dependency `execa` as it moved `cross-spawn` from v5 to v6 as part of the `execa@1.0.0` release, the [code & notes](https://github.com/sindresorhus/execa/releases/tag/v1.0.0) for the release suggest it was just a version bump to mark the release as stable and that there were no breaking changes.

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review

Closes #340 
