### PR TITLE
Feat/Record licensee id in privilege transactions

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -12,3 +12,5 @@ cdk.out
 # Save for local config
 cdk.context.json
 *-cdk.context.json
+# smoke test env
+smoke_tests_env.json

--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "LicenseApi",
-    "version": "2024-11-01T16:20:45Z"
+    "version": "2024-12-02T19:04:58Z"
   },
   "servers": [
     {
@@ -135,7 +135,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestALicen2DxWvSHGB8ZT"
+                "$ref": "#/components/schemas/SandboLicenM3v1DQsiYo0I"
               }
             }
           },
@@ -147,7 +147,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen7iusNLvek0yj"
+                  "$ref": "#/components/schemas/SandboLicennsxzW9stMafI"
                 }
               }
             }
@@ -155,10 +155,10 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
-              "aslp/write",
-              "octp/write",
-              "coun/write"
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+              "aslp/admin",
+              "octp/admin",
+              "coun/admin"
             ]
           }
         ]
@@ -236,6 +236,51 @@
         }
       }
     },
+    "/v1/compacts/{compact}/jurisdictions/{jurisdiction}": {
+      "options": {
+        "parameters": [
+          {
+            "name": "compact",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jurisdiction",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "204 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        }
+      }
+    },
     "/v1/compacts/{compact}/jurisdictions/{jurisdiction}/licenses": {
       "post": {
         "parameters": [
@@ -268,7 +313,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestALicenQnccteKO7FNN"
+                "$ref": "#/components/schemas/SandboLicenOBKe66xJrnUY"
               }
             }
           },
@@ -280,7 +325,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicenS9gR8xZuJOb4"
+                  "$ref": "#/components/schemas/SandboLicenZpJMDau4cDdN"
                 }
               }
             }
@@ -288,7 +333,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "aslp/write",
               "octp/write",
               "coun/write"
@@ -374,7 +419,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicenT3OCiUvjLlXl"
+                  "$ref": "#/components/schemas/SandboLicenC0IHjjHMelH4"
                 }
               }
             }
@@ -382,7 +427,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "aslp/write",
               "octp/write",
               "coun/write"
@@ -495,7 +540,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestALicengFI2IjAAwZc7"
+                "$ref": "#/components/schemas/SandboLicenZtKJxTXXg5UL"
               }
             }
           },
@@ -507,7 +552,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicennsvm2JbTZqEp"
+                  "$ref": "#/components/schemas/SandboLicenWHrz3Lh8eYZP"
                 }
               }
             }
@@ -515,7 +560,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "aslp/read",
               "octp/read",
               "coun/read"
@@ -593,7 +638,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen6fga18DSl6Sn"
+                  "$ref": "#/components/schemas/SandboLicenDdBuFYJj4W5C"
                 }
               }
             }
@@ -601,7 +646,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "aslp/read",
               "octp/read",
               "coun/read"
@@ -678,7 +723,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicenqqK4VgZ1dlWA"
+                  "$ref": "#/components/schemas/SandboLicenAYFFIt5ce2HI"
                 }
               }
             }
@@ -686,7 +731,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "aslp/admin",
               "octp/admin",
               "coun/admin"
@@ -709,7 +754,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestALicenj5DRkv2XbJUf"
+                "$ref": "#/components/schemas/SandboLicenzMeGyfqdYCbr"
               }
             }
           },
@@ -728,7 +773,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -736,7 +781,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "aslp/admin",
               "octp/admin",
               "coun/admin"
@@ -813,7 +858,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -821,7 +866,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "aslp/admin",
               "octp/admin",
               "coun/admin"
@@ -895,7 +940,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestALiceniunEmG0FUtea"
+                "$ref": "#/components/schemas/SandboLiceneEbMkNNP0wku"
               }
             }
           },
@@ -914,7 +959,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -922,7 +967,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "aslp/admin",
               "octp/admin",
               "coun/admin"
@@ -976,7 +1021,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen6fga18DSl6Sn"
+                  "$ref": "#/components/schemas/SandboLicenDdBuFYJj4W5C"
                 }
               }
             }
@@ -984,7 +1029,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiProviderUsersPoolAuthorizer835C0D15": []
+            "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
           }
         ]
       },
@@ -1012,6 +1057,111 @@
             "content": {}
           }
         }
+      }
+    },
+    "/v1/provider-users/me/military-affiliation": {
+      "post": {
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboLicencgqVAvZnWkMG"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboLicenKugXONwl77RZ"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
+          }
+        ]
+      },
+      "options": {
+        "responses": {
+          "204": {
+            "description": "204 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        }
+      },
+      "patch": {
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboLicenvclXpdeW3Y28"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
+          }
+        ]
       }
     },
     "/v1/purchases": {
@@ -1057,7 +1207,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestALicenr0uVXCmc87u6"
+                "$ref": "#/components/schemas/SandboLicenGA3a6Jf5sr6W"
               }
             }
           },
@@ -1069,7 +1219,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen65XdldxsvHUq"
+                  "$ref": "#/components/schemas/SandboLicen2gYLvhizuSaW"
                 }
               }
             }
@@ -1077,7 +1227,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiProviderUsersPoolAuthorizer835C0D15": []
+            "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
           }
         ]
       },
@@ -1125,7 +1275,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALiceniV1nHletAsLX"
+                  "$ref": "#/components/schemas/SandboLicenIlcgezTgAmMg"
                 }
               }
             }
@@ -1133,7 +1283,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiProviderUsersPoolAuthorizer835C0D15": []
+            "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
           }
         ]
       },
@@ -1205,7 +1355,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -1213,7 +1363,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "profile"
             ]
           }
@@ -1249,7 +1399,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestALicensJLzcZ2dT5m4"
+                "$ref": "#/components/schemas/SandboLicenj65itQcZP12q"
               }
             }
           },
@@ -1268,7 +1418,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestALicen8yCTSsT1DDdY"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -1276,7 +1426,7 @@
         },
         "security": [
           {
-            "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": [
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
               "profile"
             ]
           }
@@ -1286,131 +1436,31 @@
   },
   "components": {
     "schemas": {
-      "TestALicenT3OCiUvjLlXl": {
+      "SandboLicenWHrz3Lh8eYZP": {
         "required": [
-          "fields"
-        ],
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "url": {
-            "type": "string"
-          }
-        }
-      },
-      "TestALicenS9gR8xZuJOb4": {
-        "required": [
-          "message"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "TestALicengFI2IjAAwZc7": {
-        "required": [
-          "query"
+          "pagination"
         ],
         "type": "object",
         "properties": {
           "pagination": {
             "type": "object",
             "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
               "lastKey": {
                 "maxLength": 1024,
                 "minLength": 1,
-                "type": "string"
+                "type": "object"
               },
               "pageSize": {
                 "maximum": 100,
                 "minimum": 5,
                 "type": "integer"
               }
-            },
-            "additionalProperties": false
-          },
-          "query": {
-            "type": "object",
-            "properties": {
-              "providerId": {
-                "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
-                "type": "string",
-                "description": "Internal UUID for the provider"
-              },
-              "jurisdiction": {
-                "type": "string",
-                "description": "Filter for providers with privilege/license in a jurisdiction",
-                "enum": [
-                  "al",
-                  "ak",
-                  "az",
-                  "ar",
-                  "ca",
-                  "co",
-                  "ct",
-                  "de",
-                  "dc",
-                  "fl",
-                  "ga",
-                  "hi",
-                  "id",
-                  "il",
-                  "in",
-                  "ia",
-                  "ks",
-                  "ky",
-                  "la",
-                  "me",
-                  "md",
-                  "ma",
-                  "mi",
-                  "mn",
-                  "ms",
-                  "mo",
-                  "mt",
-                  "ne",
-                  "nv",
-                  "nh",
-                  "nj",
-                  "nm",
-                  "ny",
-                  "nc",
-                  "nd",
-                  "oh",
-                  "ok",
-                  "or",
-                  "pa",
-                  "pr",
-                  "ri",
-                  "sc",
-                  "sd",
-                  "tn",
-                  "tx",
-                  "ut",
-                  "vt",
-                  "va",
-                  "vi",
-                  "wa",
-                  "wv",
-                  "wi",
-                  "wy"
-                ]
-              },
-              "ssn": {
-                "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-                "type": "string",
-                "description": "Social security number to look up"
-              }
-            },
-            "description": "The query parameters"
+            }
           },
           "sorting": {
             "required": [
@@ -1436,143 +1486,937 @@
               }
             },
             "description": "How to sort results"
+          },
+          "providers": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "required": [
+                "birthMonthDay",
+                "compact",
+                "dateOfBirth",
+                "dateOfExpiration",
+                "dateOfUpdate",
+                "familyName",
+                "givenName",
+                "homeAddressCity",
+                "homeAddressPostalCode",
+                "homeAddressState",
+                "homeAddressStreet1",
+                "licenseJurisdiction",
+                "licenseType",
+                "privilegeJurisdictions",
+                "providerId",
+                "ssn",
+                "status",
+                "type"
+              ],
+              "type": "object",
+              "properties": {
+                "licenseJurisdiction": {
+                  "type": "string",
+                  "enum": [
+                    "al",
+                    "ak",
+                    "az",
+                    "ar",
+                    "ca",
+                    "co",
+                    "ct",
+                    "de",
+                    "dc",
+                    "fl",
+                    "ga",
+                    "hi",
+                    "id",
+                    "il",
+                    "in",
+                    "ia",
+                    "ks",
+                    "ky",
+                    "la",
+                    "me",
+                    "md",
+                    "ma",
+                    "mi",
+                    "mn",
+                    "ms",
+                    "mo",
+                    "mt",
+                    "ne",
+                    "nv",
+                    "nh",
+                    "nj",
+                    "nm",
+                    "ny",
+                    "nc",
+                    "nd",
+                    "oh",
+                    "ok",
+                    "or",
+                    "pa",
+                    "pr",
+                    "ri",
+                    "sc",
+                    "sd",
+                    "tn",
+                    "tx",
+                    "ut",
+                    "vt",
+                    "va",
+                    "vi",
+                    "wa",
+                    "wv",
+                    "wi",
+                    "wy"
+                  ]
+                },
+                "compact": {
+                  "type": "string",
+                  "enum": [
+                    "aslp",
+                    "octp",
+                    "coun"
+                  ]
+                },
+                "homeAddressStreet2": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "npi": {
+                  "pattern": "^[0-9]{10}$",
+                  "type": "string"
+                },
+                "homeAddressPostalCode": {
+                  "maxLength": 7,
+                  "minLength": 5,
+                  "type": "string"
+                },
+                "givenName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "homeAddressStreet1": {
+                  "maxLength": 100,
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "militaryWaiver": {
+                  "type": "boolean"
+                },
+                "dateOfBirth": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "privilegeJurisdictions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "al",
+                      "ak",
+                      "az",
+                      "ar",
+                      "ca",
+                      "co",
+                      "ct",
+                      "de",
+                      "dc",
+                      "fl",
+                      "ga",
+                      "hi",
+                      "id",
+                      "il",
+                      "in",
+                      "ia",
+                      "ks",
+                      "ky",
+                      "la",
+                      "me",
+                      "md",
+                      "ma",
+                      "mi",
+                      "mn",
+                      "ms",
+                      "mo",
+                      "mt",
+                      "ne",
+                      "nv",
+                      "nh",
+                      "nj",
+                      "nm",
+                      "ny",
+                      "nc",
+                      "nd",
+                      "oh",
+                      "ok",
+                      "or",
+                      "pa",
+                      "pr",
+                      "ri",
+                      "sc",
+                      "sd",
+                      "tn",
+                      "tx",
+                      "ut",
+                      "vt",
+                      "va",
+                      "vi",
+                      "wa",
+                      "wv",
+                      "wi",
+                      "wy"
+                    ]
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "provider"
+                  ]
+                },
+                "ssn": {
+                  "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+                  "type": "string"
+                },
+                "licenseType": {
+                  "type": "string",
+                  "enum": [
+                    "audiologist",
+                    "speech-language pathologist",
+                    "speech and language pathologist",
+                    "occupational therapist",
+                    "occupational therapy assistant",
+                    "licensed professional counselor",
+                    "licensed mental health counselor",
+                    "licensed clinical mental health counselor",
+                    "licensed professional clinical counselor"
+                  ]
+                },
+                "dateOfExpiration": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "homeAddressState": {
+                  "maxLength": 100,
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "providerId": {
+                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
+                  "type": "string"
+                },
+                "familyName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "homeAddressCity": {
+                  "maxLength": 100,
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "middleName": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "birthMonthDay": {
+                  "pattern": "^[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "dateOfUpdate": {
+                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+                  "type": "string",
+                  "format": "date"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "inactive"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "SandboLiceneEbMkNNP0wku": {
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "read": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jurisdictions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "write": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
           }
         },
         "additionalProperties": false
       },
-      "TestALicenofZ5WRAY94p1": {
+      "SandboLicennsxzW9stMafI": {
         "required": [
-          "query"
+          "message"
         ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the request"
+          }
+        }
+      },
+      "SandboLicenC0IHjjHMelH4": {
+        "required": [
+          "fields"
+        ],
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "SandboLicenOBKe66xJrnUY": {
+        "maxLength": 100,
+        "type": "array",
+        "items": {
+          "required": [
+            "dateOfBirth",
+            "dateOfExpiration",
+            "dateOfIssuance",
+            "dateOfRenewal",
+            "familyName",
+            "givenName",
+            "homeAddressCity",
+            "homeAddressPostalCode",
+            "homeAddressState",
+            "homeAddressStreet1",
+            "licenseType",
+            "ssn",
+            "status"
+          ],
+          "type": "object",
+          "properties": {
+            "homeAddressStreet2": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "npi": {
+              "pattern": "^[0-9]{10}$",
+              "type": "string"
+            },
+            "homeAddressPostalCode": {
+              "maxLength": 7,
+              "minLength": 5,
+              "type": "string"
+            },
+            "givenName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeAddressStreet1": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "militaryWaiver": {
+              "type": "boolean"
+            },
+            "dateOfBirth": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfIssuance": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "ssn": {
+              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+              "type": "string"
+            },
+            "licenseType": {
+              "type": "string",
+              "enum": [
+                "audiologist",
+                "speech-language pathologist",
+                "speech and language pathologist",
+                "occupational therapist",
+                "occupational therapy assistant",
+                "licensed professional counselor",
+                "licensed mental health counselor",
+                "licensed clinical mental health counselor",
+                "licensed professional clinical counselor"
+              ]
+            },
+            "dateOfExpiration": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "homeAddressState": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "dateOfRenewal": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "familyName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeAddressCity": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "middleName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "active",
+                "inactive"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "SandboLicenj65itQcZP12q": {
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenAYFFIt5ce2HI": {
         "type": "object",
         "properties": {
           "pagination": {
             "type": "object",
             "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
               "lastKey": {
                 "maxLength": 1024,
                 "minLength": 1,
-                "type": "string"
+                "type": "object"
               },
               "pageSize": {
                 "maximum": 100,
                 "minimum": 5,
                 "type": "integer"
               }
-            },
-            "additionalProperties": false
+            }
           },
-          "query": {
-            "type": "object",
-            "properties": {
-              "compact": {
-                "type": "string",
-                "description": "Required if 'ssn' not provided",
-                "enum": [
-                  "aslp",
-                  "octp",
-                  "coun"
-                ]
+          "users": {
+            "type": "array",
+            "items": {
+              "required": [
+                "attributes",
+                "permissions",
+                "userId"
+              ],
+              "type": "object",
+              "properties": {
+                "permissions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "read": {
+                            "type": "boolean"
+                          },
+                          "admin": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "jurisdictions": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "actions": {
+                              "type": "object",
+                              "properties": {
+                                "admin": {
+                                  "type": "boolean"
+                                },
+                                "write": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "attributes": {
+                  "required": [
+                    "email",
+                    "familyName",
+                    "givenName"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "givenName": {
+                      "maxLength": 100,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "familyName": {
+                      "maxLength": 100,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "email": {
+                      "maxLength": 100,
+                      "minLength": 5,
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "userId": {
+                  "type": "string"
+                }
               },
-              "providerId": {
-                "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
-                "type": "string",
-                "description": "Internal UUID for the provider"
-              },
-              "jurisdiction": {
-                "type": "string",
-                "description": "Required if 'ssn' not provided",
-                "enum": [
-                  "al",
-                  "ak",
-                  "az",
-                  "ar",
-                  "ca",
-                  "co",
-                  "ct",
-                  "de",
-                  "dc",
-                  "fl",
-                  "ga",
-                  "hi",
-                  "id",
-                  "il",
-                  "in",
-                  "ia",
-                  "ks",
-                  "ky",
-                  "la",
-                  "me",
-                  "md",
-                  "ma",
-                  "mi",
-                  "mn",
-                  "ms",
-                  "mo",
-                  "mt",
-                  "ne",
-                  "nv",
-                  "nh",
-                  "nj",
-                  "nm",
-                  "ny",
-                  "nc",
-                  "nd",
-                  "oh",
-                  "ok",
-                  "or",
-                  "pa",
-                  "pr",
-                  "ri",
-                  "sc",
-                  "sd",
-                  "tn",
-                  "tx",
-                  "ut",
-                  "vt",
-                  "va",
-                  "vi",
-                  "wa",
-                  "wv",
-                  "wi",
-                  "wy"
-                ]
-              },
-              "ssn": {
-                "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-                "type": "string",
-                "description": "Social security number to look up"
-              }
-            },
-            "description": "The query parameters"
-          },
-          "sorting": {
-            "required": [
-              "key"
-            ],
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "enum": [
-                  "dateOfUpdate",
-                  "familyName"
-                ]
-              },
-              "direction": {
-                "type": "string",
-                "enum": [
-                  "ascending",
-                  "descending"
-                ]
-              }
-            },
-            "description": "Required if ssn is not provided"
+              "additionalProperties": false
+            }
           }
         },
         "additionalProperties": false
       },
-      "TestALicen8yCTSsT1DDdY": {
+      "SandboLicenzMeGyfqdYCbr": {
+        "required": [
+          "attributes",
+          "permissions"
+        ],
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "read": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jurisdictions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "write": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "attributes": {
+            "required": [
+              "email",
+              "familyName",
+              "givenName"
+            ],
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "email": {
+                "maxLength": 100,
+                "minLength": 5,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenIlcgezTgAmMg": {
+        "required": [
+          "items",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "lastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
+              }
+            }
+          },
+          "items": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "required": [
+                    "compactCommissionFee",
+                    "compactName",
+                    "type"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "compactCommissionFee": {
+                      "required": [
+                        "feeAmount",
+                        "feeType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "feeAmount": {
+                          "type": "number"
+                        },
+                        "feeType": {
+                          "type": "string",
+                          "enum": [
+                            "FLAT_RATE"
+                          ]
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "compact"
+                      ]
+                    },
+                    "compactName": {
+                      "type": "string",
+                      "description": "The name of the compact"
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "jurisdictionFee",
+                    "jurisdictionName",
+                    "jurisprudenceRequirements",
+                    "postalAbbreviation",
+                    "type"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "militaryDiscount": {
+                      "required": [
+                        "active",
+                        "discountAmount",
+                        "discountType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the military discount is active"
+                        },
+                        "discountAmount": {
+                          "type": "number",
+                          "description": "The amount of the discount"
+                        },
+                        "discountType": {
+                          "type": "string",
+                          "description": "The type of discount",
+                          "enum": [
+                            "FLAT_RATE"
+                          ]
+                        }
+                      }
+                    },
+                    "postalAbbreviation": {
+                      "type": "string",
+                      "description": "The postal abbreviation of the jurisdiction"
+                    },
+                    "jurisprudenceRequirements": {
+                      "required": [
+                        "required"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether jurisprudence requirements exist"
+                        }
+                      }
+                    },
+                    "jurisdictionName": {
+                      "type": "string",
+                      "description": "The name of the jurisdiction"
+                    },
+                    "jurisdictionFee": {
+                      "type": "number",
+                      "description": "The fee for the jurisdiction"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "jurisdiction"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "SandboLicenKugXONwl77RZ": {
+        "required": [
+          "affiliationType",
+          "dateOfUpdate",
+          "dateOfUpload",
+          "documentUploadFields",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfUpload": {
+            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+            "type": "string",
+            "description": "The date the document was uploaded",
+            "format": "date"
+          },
+          "affiliationType": {
+            "type": "string",
+            "description": "The type of military affiliation",
+            "enum": [
+              "militaryMember",
+              "militaryMemberSpouse"
+            ]
+          },
+          "fileNames": {
+            "type": "array",
+            "description": "List of military affiliation file names",
+            "items": {
+              "type": "string",
+              "description": "The name of the file being uploaded"
+            }
+          },
+          "dateOfUpdate": {
+            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+            "type": "string",
+            "description": "The date the document was last updated",
+            "format": "date"
+          },
+          "status": {
+            "type": "string",
+            "description": "The status of the military affiliation"
+          },
+          "documentUploadFields": {
+            "type": "array",
+            "description": "The fields used to upload documents",
+            "items": {
+              "type": "object",
+              "properties": {
+                "fields": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "The form fields used to upload the document"
+                },
+                "url": {
+                  "type": "string",
+                  "description": "The url to upload the document to"
+                }
+              },
+              "description": "The fields used to upload a specific document"
+            }
+          }
+        }
+      },
+      "SandboLicen2gYLvhizuSaW": {
+        "required": [
+          "transactionId"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the transaction"
+          },
+          "transactionId": {
+            "type": "string",
+            "description": "The transaction id for the purchase"
+          }
+        }
+      },
+      "SandboLicenM3v1DQsiYo0I": {
+        "required": [
+          "apiLoginId",
+          "processor",
+          "transactionKey"
+        ],
+        "type": "object",
+        "properties": {
+          "apiLoginId": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string",
+            "description": "The api login id for the payment processor"
+          },
+          "transactionKey": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string",
+            "description": "The transaction key for the payment processor"
+          },
+          "processor": {
+            "type": "string",
+            "description": "The type of payment processor",
+            "enum": [
+              "authorize.net"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenvclXpdeW3Y28": {
+        "required": [
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The status to set the military affiliation to.",
+            "enum": [
+              "inactive"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenUL01PEWATEUT": {
         "required": [
           "attributes",
           "permissions",
@@ -1621,6 +2465,11 @@
             }
           },
           "attributes": {
+            "required": [
+              "email",
+              "familyName",
+              "givenName"
+            ],
             "type": "object",
             "properties": {
               "givenName": {
@@ -1647,23 +2496,34 @@
         },
         "additionalProperties": false
       },
-      "TestALicen65XdldxsvHUq": {
+      "SandboLicencgqVAvZnWkMG": {
         "required": [
-          "transactionId"
+          "affiliationType",
+          "fileNames"
         ],
         "type": "object",
         "properties": {
-          "message": {
+          "affiliationType": {
             "type": "string",
-            "description": "A message about the transaction"
+            "description": "The type of military affiliation",
+            "enum": [
+              "militaryMember",
+              "militaryMemberSpouse"
+            ]
           },
-          "transactionId": {
-            "type": "string",
-            "description": "The transaction id for the purchase"
+          "fileNames": {
+            "type": "array",
+            "description": "List of military affiliation file names",
+            "items": {
+              "maxLength": 150,
+              "type": "string",
+              "description": "The name of the file being uploaded"
+            }
           }
-        }
+        },
+        "additionalProperties": false
       },
-      "TestALicen6fga18DSl6Sn": {
+      "SandboLicenDdBuFYJj4W5C": {
         "required": [
           "birthMonthDay",
           "compact",
@@ -2206,335 +3066,156 @@
           }
         }
       },
-      "TestALiceniunEmG0FUtea": {
+      "SandboLicenZpJMDau4cDdN": {
+        "required": [
+          "message"
+        ],
         "type": "object",
         "properties": {
-          "permissions": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "actions": {
-                  "type": "object",
-                  "properties": {
-                    "read": {
-                      "type": "boolean"
-                    },
-                    "admin": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "jurisdictions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
+          "message": {
+            "type": "string"
           }
         },
         "additionalProperties": false
       },
-      "TestALicenWppIphQZnnDs": {
-        "maxLength": 100,
-        "type": "array",
-        "items": {
-          "required": [
-            "dateOfBirth",
-            "dateOfExpiration",
-            "dateOfIssuance",
-            "dateOfRenewal",
-            "familyName",
-            "givenName",
-            "homeStateCity",
-            "homeStatePostalCode",
-            "homeStateStreet1",
-            "licenseType",
-            "ssn",
-            "status"
-          ],
-          "type": "object",
-          "properties": {
-            "homeStateStreet2": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeStateStreet1": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "npi": {
-              "pattern": "^[0-9]{10}$",
-              "type": "string"
-            },
-            "homeStatePostalCode": {
-              "maxLength": 7,
-              "minLength": 5,
-              "type": "string"
-            },
-            "givenName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "dateOfBirth": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "homeStateCity": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "dateOfIssuance": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "ssn": {
-              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-              "type": "string"
-            },
-            "licenseType": {
-              "type": "string",
-              "enum": [
-                "audiologist",
-                "speech-language pathologist",
-                "speech and language pathologist",
-                "occupational therapist",
-                "occupational therapy assistant",
-                "licensed professional counselor",
-                "licensed mental health counselor",
-                "licensed clinical mental health counselor",
-                "licensed professional clinical counselor"
-              ]
-            },
-            "dateOfExpiration": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfRenewal": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "familyName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "middleName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "active",
-                "inactive"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "TestALiceniV1nHletAsLX": {
+      "SandboLicenZtKJxTXXg5UL": {
         "required": [
-          "items",
-          "pagination"
+          "query"
         ],
         "type": "object",
         "properties": {
           "pagination": {
             "type": "object",
             "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
               "lastKey": {
                 "maxLength": 1024,
                 "minLength": 1,
-                "type": "object"
+                "type": "string"
               },
               "pageSize": {
                 "maximum": 100,
                 "minimum": 5,
                 "type": "integer"
               }
-            }
+            },
+            "additionalProperties": false
           },
-          "items": {
-            "maxLength": 100,
-            "type": "array",
-            "items": {
-              "type": "object",
-              "oneOf": [
-                {
-                  "required": [
-                    "compactCommissionFee",
-                    "compactName",
-                    "type"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "compactCommissionFee": {
-                      "required": [
-                        "feeAmount",
-                        "feeType"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "feeAmount": {
-                          "type": "number"
-                        },
-                        "feeType": {
-                          "type": "string",
-                          "enum": [
-                            "FLAT_RATE"
-                          ]
-                        }
-                      }
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "compact"
-                      ]
-                    },
-                    "compactName": {
-                      "type": "string",
-                      "description": "The name of the compact"
-                    }
-                  }
-                },
-                {
-                  "required": [
-                    "jurisdictionFee",
-                    "jurisdictionName",
-                    "jurisprudenceRequirements",
-                    "postalAbbreviation",
-                    "type"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "militaryDiscount": {
-                      "required": [
-                        "active",
-                        "discountAmount",
-                        "discountType"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "active": {
-                          "type": "boolean",
-                          "description": "Whether the military discount is active"
-                        },
-                        "discountAmount": {
-                          "type": "number",
-                          "description": "The amount of the discount"
-                        },
-                        "discountType": {
-                          "type": "string",
-                          "description": "The type of discount",
-                          "enum": [
-                            "FLAT_RATE"
-                          ]
-                        }
-                      }
-                    },
-                    "postalAbbreviation": {
-                      "type": "string",
-                      "description": "The postal abbreviation of the jurisdiction"
-                    },
-                    "jurisprudenceRequirements": {
-                      "required": [
-                        "required"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "required": {
-                          "type": "boolean",
-                          "description": "Whether jurisprudence requirements exist"
-                        }
-                      }
-                    },
-                    "jurisdictionName": {
-                      "type": "string",
-                      "description": "The name of the jurisdiction"
-                    },
-                    "jurisdictionFee": {
-                      "type": "number",
-                      "description": "The fee for the jurisdiction"
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "jurisdiction"
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "TestALicen2DxWvSHGB8ZT": {
-        "type": "object",
-        "properties": {
           "query": {
             "type": "object",
             "properties": {
-              "apiLoginId": {
-                "maxLength": 100,
-                "minLength": 1,
+              "providerId": {
+                "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
                 "type": "string",
-                "description": "The api login id for the payment processor"
+                "description": "Internal UUID for the provider"
               },
-              "transactionKey": {
-                "maxLength": 100,
-                "minLength": 1,
+              "jurisdiction": {
                 "type": "string",
-                "description": "The transaction key for the payment processor"
-              },
-              "processor": {
-                "type": "string",
-                "description": "The type of payment processor",
+                "description": "Filter for providers with privilege/license in a jurisdiction",
                 "enum": [
-                  "authorize.net"
+                  "al",
+                  "ak",
+                  "az",
+                  "ar",
+                  "ca",
+                  "co",
+                  "ct",
+                  "de",
+                  "dc",
+                  "fl",
+                  "ga",
+                  "hi",
+                  "id",
+                  "il",
+                  "in",
+                  "ia",
+                  "ks",
+                  "ky",
+                  "la",
+                  "me",
+                  "md",
+                  "ma",
+                  "mi",
+                  "mn",
+                  "ms",
+                  "mo",
+                  "mt",
+                  "ne",
+                  "nv",
+                  "nh",
+                  "nj",
+                  "nm",
+                  "ny",
+                  "nc",
+                  "nd",
+                  "oh",
+                  "ok",
+                  "or",
+                  "pa",
+                  "pr",
+                  "ri",
+                  "sc",
+                  "sd",
+                  "tn",
+                  "tx",
+                  "ut",
+                  "vt",
+                  "va",
+                  "vi",
+                  "wa",
+                  "wv",
+                  "wi",
+                  "wy"
+                ]
+              },
+              "ssn": {
+                "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+                "type": "string",
+                "description": "Social security number to look up"
+              }
+            },
+            "description": "The query parameters"
+          },
+          "sorting": {
+            "required": [
+              "key"
+            ],
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key to sort results by",
+                "enum": [
+                  "dateOfUpdate",
+                  "familyName"
+                ]
+              },
+              "direction": {
+                "type": "string",
+                "description": "Direction to sort results by",
+                "enum": [
+                  "ascending",
+                  "descending"
                 ]
               }
             },
-            "description": "payment processor credentials"
+            "description": "How to sort results"
           }
         },
         "additionalProperties": false
       },
-      "TestALicenr0uVXCmc87u6": {
+      "SandboLicenYgKyaZjnxxpR": {
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the request"
+          }
+        }
+      },
+      "SandboLicenGA3a6Jf5sr6W": {
         "required": [
           "orderInformation",
           "selectedJurisdictions"
@@ -2689,899 +3370,16 @@
             }
           }
         }
-      },
-      "TestALicenQnccteKO7FNN": {
-        "maxLength": 100,
-        "type": "array",
-        "items": {
-          "required": [
-            "dateOfBirth",
-            "dateOfExpiration",
-            "dateOfIssuance",
-            "dateOfRenewal",
-            "familyName",
-            "givenName",
-            "homeAddressCity",
-            "homeAddressPostalCode",
-            "homeAddressState",
-            "homeAddressStreet1",
-            "licenseType",
-            "ssn",
-            "status"
-          ],
-          "type": "object",
-          "properties": {
-            "homeAddressStreet2": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "npi": {
-              "pattern": "^[0-9]{10}$",
-              "type": "string"
-            },
-            "homeAddressPostalCode": {
-              "maxLength": 7,
-              "minLength": 5,
-              "type": "string"
-            },
-            "givenName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeAddressStreet1": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "militaryWaiver": {
-              "type": "boolean"
-            },
-            "dateOfBirth": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfIssuance": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "ssn": {
-              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-              "type": "string"
-            },
-            "licenseType": {
-              "type": "string",
-              "enum": [
-                "audiologist",
-                "speech-language pathologist",
-                "speech and language pathologist",
-                "occupational therapist",
-                "occupational therapy assistant",
-                "licensed professional counselor",
-                "licensed mental health counselor",
-                "licensed clinical mental health counselor",
-                "licensed professional clinical counselor"
-              ]
-            },
-            "dateOfExpiration": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "homeAddressState": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "dateOfRenewal": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "familyName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeAddressCity": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "middleName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "active",
-                "inactive"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "TestALicennsvm2JbTZqEp": {
-        "required": [
-          "pagination"
-        ],
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "sorting": {
-            "required": [
-              "key"
-            ],
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "description": "The key to sort results by",
-                "enum": [
-                  "dateOfUpdate",
-                  "familyName"
-                ]
-              },
-              "direction": {
-                "type": "string",
-                "description": "Direction to sort results by",
-                "enum": [
-                  "ascending",
-                  "descending"
-                ]
-              }
-            },
-            "description": "How to sort results"
-          },
-          "providers": {
-            "maxLength": 100,
-            "type": "array",
-            "items": {
-              "required": [
-                "birthMonthDay",
-                "compact",
-                "dateOfBirth",
-                "dateOfExpiration",
-                "dateOfUpdate",
-                "familyName",
-                "givenName",
-                "homeAddressCity",
-                "homeAddressPostalCode",
-                "homeAddressState",
-                "homeAddressStreet1",
-                "licenseJurisdiction",
-                "licenseType",
-                "privilegeJurisdictions",
-                "providerId",
-                "ssn",
-                "status",
-                "type"
-              ],
-              "type": "object",
-              "properties": {
-                "licenseJurisdiction": {
-                  "type": "string",
-                  "enum": [
-                    "al",
-                    "ak",
-                    "az",
-                    "ar",
-                    "ca",
-                    "co",
-                    "ct",
-                    "de",
-                    "dc",
-                    "fl",
-                    "ga",
-                    "hi",
-                    "id",
-                    "il",
-                    "in",
-                    "ia",
-                    "ks",
-                    "ky",
-                    "la",
-                    "me",
-                    "md",
-                    "ma",
-                    "mi",
-                    "mn",
-                    "ms",
-                    "mo",
-                    "mt",
-                    "ne",
-                    "nv",
-                    "nh",
-                    "nj",
-                    "nm",
-                    "ny",
-                    "nc",
-                    "nd",
-                    "oh",
-                    "ok",
-                    "or",
-                    "pa",
-                    "pr",
-                    "ri",
-                    "sc",
-                    "sd",
-                    "tn",
-                    "tx",
-                    "ut",
-                    "vt",
-                    "va",
-                    "vi",
-                    "wa",
-                    "wv",
-                    "wi",
-                    "wy"
-                  ]
-                },
-                "compact": {
-                  "type": "string",
-                  "enum": [
-                    "aslp",
-                    "octp",
-                    "coun"
-                  ]
-                },
-                "homeAddressStreet2": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "npi": {
-                  "pattern": "^[0-9]{10}$",
-                  "type": "string"
-                },
-                "homeAddressPostalCode": {
-                  "maxLength": 7,
-                  "minLength": 5,
-                  "type": "string"
-                },
-                "givenName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "homeAddressStreet1": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "militaryWaiver": {
-                  "type": "boolean"
-                },
-                "dateOfBirth": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "privilegeJurisdictions": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "al",
-                      "ak",
-                      "az",
-                      "ar",
-                      "ca",
-                      "co",
-                      "ct",
-                      "de",
-                      "dc",
-                      "fl",
-                      "ga",
-                      "hi",
-                      "id",
-                      "il",
-                      "in",
-                      "ia",
-                      "ks",
-                      "ky",
-                      "la",
-                      "me",
-                      "md",
-                      "ma",
-                      "mi",
-                      "mn",
-                      "ms",
-                      "mo",
-                      "mt",
-                      "ne",
-                      "nv",
-                      "nh",
-                      "nj",
-                      "nm",
-                      "ny",
-                      "nc",
-                      "nd",
-                      "oh",
-                      "ok",
-                      "or",
-                      "pa",
-                      "pr",
-                      "ri",
-                      "sc",
-                      "sd",
-                      "tn",
-                      "tx",
-                      "ut",
-                      "vt",
-                      "va",
-                      "vi",
-                      "wa",
-                      "wv",
-                      "wi",
-                      "wy"
-                    ]
-                  }
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "provider"
-                  ]
-                },
-                "ssn": {
-                  "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-                  "type": "string"
-                },
-                "licenseType": {
-                  "type": "string",
-                  "enum": [
-                    "audiologist",
-                    "speech-language pathologist",
-                    "speech and language pathologist",
-                    "occupational therapist",
-                    "occupational therapy assistant",
-                    "licensed professional counselor",
-                    "licensed mental health counselor",
-                    "licensed clinical mental health counselor",
-                    "licensed professional clinical counselor"
-                  ]
-                },
-                "dateOfExpiration": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "homeAddressState": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "providerId": {
-                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
-                  "type": "string"
-                },
-                "familyName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "homeAddressCity": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "middleName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "birthMonthDay": {
-                  "pattern": "^[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "dateOfUpdate": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "active",
-                    "inactive"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "TestALicenqqK4VgZ1dlWA": {
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "users": {
-            "type": "array",
-            "items": {
-              "required": [
-                "attributes",
-                "permissions",
-                "userId"
-              ],
-              "type": "object",
-              "properties": {
-                "permissions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "read": {
-                            "type": "boolean"
-                          },
-                          "admin": {
-                            "type": "boolean"
-                          }
-                        }
-                      },
-                      "jurisdictions": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "object",
-                          "properties": {
-                            "actions": {
-                              "type": "object",
-                              "properties": {
-                                "admin": {
-                                  "type": "boolean"
-                                },
-                                "write": {
-                                  "type": "boolean"
-                                }
-                              },
-                              "additionalProperties": false
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                },
-                "attributes": {
-                  "type": "object",
-                  "properties": {
-                    "givenName": {
-                      "maxLength": 100,
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "maxLength": 100,
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "email": {
-                      "maxLength": 100,
-                      "minLength": 5,
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "userId": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "TestALicensOPeW9O2tyBj": {
-        "required": [
-          "items",
-          "pagination"
-        ],
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "sorting": {
-            "required": [
-              "key"
-            ],
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "enum": [
-                  "dateOfUpdate",
-                  "familyName"
-                ]
-              },
-              "direction": {
-                "type": "string",
-                "enum": [
-                  "ascending",
-                  "descending"
-                ]
-              }
-            },
-            "description": "Required if ssn is not provided"
-          },
-          "items": {
-            "maxLength": 100,
-            "type": "array",
-            "items": {
-              "required": [
-                "compact",
-                "dateOfBirth",
-                "dateOfExpiration",
-                "dateOfIssuance",
-                "dateOfRenewal",
-                "dateOfUpdate",
-                "familyName",
-                "givenName",
-                "homeStateCity",
-                "homeStatePostalCode",
-                "homeStateStreet1",
-                "jurisdiction",
-                "licenseType",
-                "providerId",
-                "ssn",
-                "status",
-                "type"
-              ],
-              "type": "object",
-              "properties": {
-                "compact": {
-                  "type": "string",
-                  "enum": [
-                    "aslp",
-                    "octp",
-                    "coun"
-                  ]
-                },
-                "homeStateStreet2": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "homeStateStreet1": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "npi": {
-                  "pattern": "^[0-9]{10}$",
-                  "type": "string"
-                },
-                "homeStatePostalCode": {
-                  "maxLength": 7,
-                  "minLength": 5,
-                  "type": "string"
-                },
-                "jurisdiction": {
-                  "type": "string",
-                  "enum": [
-                    "al",
-                    "ak",
-                    "az",
-                    "ar",
-                    "ca",
-                    "co",
-                    "ct",
-                    "de",
-                    "dc",
-                    "fl",
-                    "ga",
-                    "hi",
-                    "id",
-                    "il",
-                    "in",
-                    "ia",
-                    "ks",
-                    "ky",
-                    "la",
-                    "me",
-                    "md",
-                    "ma",
-                    "mi",
-                    "mn",
-                    "ms",
-                    "mo",
-                    "mt",
-                    "ne",
-                    "nv",
-                    "nh",
-                    "nj",
-                    "nm",
-                    "ny",
-                    "nc",
-                    "nd",
-                    "oh",
-                    "ok",
-                    "or",
-                    "pa",
-                    "pr",
-                    "ri",
-                    "sc",
-                    "sd",
-                    "tn",
-                    "tx",
-                    "ut",
-                    "vt",
-                    "va",
-                    "vi",
-                    "wa",
-                    "wv",
-                    "wi",
-                    "wy"
-                  ]
-                },
-                "givenName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "dateOfBirth": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "license-home"
-                  ]
-                },
-                "homeStateCity": {
-                  "maxLength": 100,
-                  "minLength": 2,
-                  "type": "string"
-                },
-                "dateOfIssuance": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "ssn": {
-                  "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-                  "type": "string"
-                },
-                "licenseType": {
-                  "type": "string",
-                  "enum": [
-                    "audiologist",
-                    "speech-language pathologist",
-                    "speech and language pathologist",
-                    "occupational therapist",
-                    "occupational therapy assistant",
-                    "licensed professional counselor",
-                    "licensed mental health counselor",
-                    "licensed clinical mental health counselor",
-                    "licensed professional clinical counselor"
-                  ]
-                },
-                "dateOfExpiration": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "providerId": {
-                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
-                  "type": "string"
-                },
-                "dateOfRenewal": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "familyName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "middleName": {
-                  "maxLength": 100,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "dateOfUpdate": {
-                  "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-                  "type": "string",
-                  "format": "date"
-                },
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "active",
-                    "inactive"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        }
-      },
-      "TestALicenj5DRkv2XbJUf": {
-        "required": [
-          "attributes",
-          "permissions"
-        ],
-        "type": "object",
-        "properties": {
-          "permissions": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "actions": {
-                  "type": "object",
-                  "properties": {
-                    "read": {
-                      "type": "boolean"
-                    },
-                    "admin": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "jurisdictions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "attributes": {
-            "type": "object",
-            "properties": {
-              "givenName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "familyName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "email": {
-                "maxLength": 100,
-                "minLength": 5,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      "TestALicen7iusNLvek0yj": {
-        "required": [
-          "message"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string",
-            "description": "A message about the request"
-          }
-        }
-      },
-      "TestALicensJLzcZ2dT5m4": {
-        "type": "object",
-        "properties": {
-          "attributes": {
-            "type": "object",
-            "properties": {
-              "givenName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "familyName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
       }
     },
     "securitySchemes": {
-      "PipelineStackTestAPIStackLicenseApiStaffPoolsAuthorizerEC884728": {
+      "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": {
         "type": "apiKey",
         "name": "Authorization",
         "in": "header",
         "x-amazon-apigateway-authtype": "cognito_user_pools"
       },
-      "PipelineStackTestAPIStackLicenseApiProviderUsersPoolAuthorizer835C0D15": {
+      "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": {
         "type": "apiKey",
         "name": "Authorization",
         "in": "header",

--- a/backend/compact-connect/lambdas/purchases/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/purchases/handlers/privileges.py
@@ -217,6 +217,7 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
     transaction_response = None
     try:
         transaction_response = purchase_client.process_charge_for_licensee_privileges(
+            licensee_id=provider_id,
             order_information=body['orderInformation'],
             compact_configuration=compact,
             selected_jurisdictions=selected_jurisdictions,

--- a/backend/compact-connect/lambdas/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/purchase_client.py
@@ -214,8 +214,9 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
         # Create order information
         order = apicontractsv1.orderType()
         # We store the LICENSEE ID in the description field, since the ID is a UUID that is 36 characters long
-        # and this is the only field that can store that length of data
-        order.description = f'LICENSEE#{licensee_id}#'
+        # and this is the only field that can store that length of data. The description field can hold up to 255
+        # characters.
+        order.description = json.dumps({'LICENSEE': licensee_id})
 
         line_items = apicontractsv1.ArrayOfLineItem()
         for jurisdiction in selected_jurisdictions:

--- a/backend/compact-connect/lambdas/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/purchase_client.py
@@ -73,6 +73,7 @@ class PaymentProcessorClient(ABC):
     @abstractmethod
     def process_charge_on_credit_card_for_privilege_purchase(
         self,
+        licensee_id: str,
         order_information: dict,
         compact_configuration: Compact,
         selected_jurisdictions: list[Jurisdiction],
@@ -81,6 +82,7 @@ class PaymentProcessorClient(ABC):
         """
         Process a charge on a credit card for a list of privileges within a compact.
 
+        :param licensee_id: The user ID of the Licensee for whom the privileges are being purchased.
         :param order_information: A dictionary containing the order information (billing, card, etc.)
         :param compact_configuration: The compact configuration.
         :param selected_jurisdictions: A list of selected jurisdictions to purchase privileges for.
@@ -188,6 +190,7 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
 
     def process_charge_on_credit_card_for_privilege_purchase(
         self,
+        licensee_id: str,
         order_information: dict,
         compact_configuration: Compact,
         selected_jurisdictions: list[Jurisdiction],
@@ -208,6 +211,12 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
         payment = apicontractsv1.paymentType()
         payment.creditCard = credit_card
 
+        # Create order information
+        order = apicontractsv1.orderType()
+        # We store the LICENSEE ID in the description field, since the ID is a UUID that is 36 characters long
+        # and this is the only field that can store that length of data
+        order.description = f'LICENSEE#{licensee_id}#'
+
         line_items = apicontractsv1.ArrayOfLineItem()
         for jurisdiction in selected_jurisdictions:
             jurisdiction_name_title_case = jurisdiction.jurisdiction_name.title()
@@ -227,7 +236,7 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
 
         # Add the compact fee to the line items
         compact_fee_line_item = apicontractsv1.lineItemType()
-        compact_fee_line_item.itemId = f'{compact_configuration.compact_name}-fee'
+        compact_fee_line_item.itemId = f'{compact_configuration.compact_name}-compact-fee'
         compact_fee_line_item.name = f'{compact_configuration.compact_name.upper()} Compact Fee'
         compact_fee_line_item.description = 'Compact fee applied for each privilege purchased'
         compact_fee_line_item.quantity = len(selected_jurisdictions)
@@ -264,6 +273,7 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
         transaction_request.payment = payment
         transaction_request.billTo = customer_address
         transaction_request.transactionSettings = settings
+        transaction_request.order = order
         transaction_request.lineItems = line_items
         transaction_request.taxExempt = True
 
@@ -423,6 +433,7 @@ class PurchaseClient:
 
     def process_charge_for_licensee_privileges(
         self,
+        licensee_id: str,
         order_information: dict,
         compact_configuration: Compact,
         selected_jurisdictions: list[Jurisdiction],
@@ -431,6 +442,7 @@ class PurchaseClient:
         """
         Process a charge on a credit card for a list of privileges within a compact.
 
+        :param licensee_id: The Licensee user ID.
         :param order_information: A dictionary containing the order information (billing, card, etc.)
         :param compact_configuration: The compact configuration.
         :param selected_jurisdictions: A list of selected jurisdictions to purchase privileges for.
@@ -443,6 +455,7 @@ class PurchaseClient:
             )
 
         return self.payment_processor_client.process_charge_on_credit_card_for_privilege_purchase(
+            licensee_id=licensee_id,
             order_information=order_information,
             compact_configuration=compact_configuration,
             selected_jurisdictions=selected_jurisdictions,

--- a/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
@@ -300,7 +300,9 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         call_args = mock_create_transaction_controller.call_args.args
         api_contract_v1_obj = call_args[0]
 
-        self.assertEqual(f'LICENSEE#{MOCK_LICENSEE_ID}#', api_contract_v1_obj.transactionRequest.order.description)
+        # the order description should be a json serialized string
+        deserialized_order_description = json.loads(api_contract_v1_obj.transactionRequest.order.description)
+        self.assertEqual({"LICENSEE": MOCK_LICENSEE_ID}, deserialized_order_description)
 
     @patch('purchase_client.createTransactionController')
     def test_purchase_client_sends_expected_line_items_when_purchasing_privileges_with_military_discount(

--- a/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
@@ -300,9 +300,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         call_args = mock_create_transaction_controller.call_args.args
         api_contract_v1_obj = call_args[0]
 
-        # the order description should be a json serialized string
-        deserialized_order_description = json.loads(api_contract_v1_obj.transactionRequest.order.description)
-        self.assertEqual({"LICENSEE": MOCK_LICENSEE_ID}, deserialized_order_description)
+        self.assertEqual(f'LICENSEE#{MOCK_LICENSEE_ID}#', api_contract_v1_obj.transactionRequest.order.description)
 
     @patch('purchase_client.createTransactionController')
     def test_purchase_client_sends_expected_line_items_when_purchasing_privileges_with_military_discount(

--- a/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/purchases/tests/unit/test_purchase_client.py
@@ -18,6 +18,8 @@ MOCK_ASLP_SECRET = {
 
 MOCK_TRANSACTION_ID = '123456'
 
+MOCK_LICENSEE_ID = '89a6377e-c3a5-40e5-bca5-317ec854c570'
+
 EXPECTED_TOTAL_FEE_AMOUNT = 150.50
 
 
@@ -170,6 +172,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
         response = test_purchase_client.process_charge_for_licensee_privileges(
+            licensee_id=MOCK_LICENSEE_ID,
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
@@ -192,6 +195,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
         test_purchase_client.process_charge_for_licensee_privileges(
+            licensee_id=MOCK_LICENSEE_ID,
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
@@ -239,6 +243,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
         test_purchase_client.process_charge_for_licensee_privileges(
+            licensee_id=MOCK_LICENSEE_ID,
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
@@ -258,7 +263,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             'Compact Privilege for Ohio', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].description
         )
         # second line item is the compact fee
-        self.assertEqual('aslp-fee', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].itemId)
+        self.assertEqual('aslp-compact-fee', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].itemId)
         self.assertEqual('ASLP Compact Fee', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].name)
         self.assertEqual(50.50, api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].unitPrice)
         self.assertEqual(1, api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].quantity)
@@ -284,6 +289,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
         test_purchase_client.process_charge_for_licensee_privileges(
+            licensee_id=MOCK_LICENSEE_ID,
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
@@ -322,6 +328,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
 
         with self.assertRaises(CCFailedTransactionException):
             test_purchase_client.process_charge_for_licensee_privileges(
+                licensee_id=MOCK_LICENSEE_ID,
                 order_information=_generate_default_order_information(),
                 compact_configuration=_generate_aslp_compact_configuration(),
                 selected_jurisdictions=_generate_selected_jurisdictions(),
@@ -341,6 +348,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
 
         with self.assertRaises(CCInternalException):
             test_purchase_client.process_charge_for_licensee_privileges(
+                licensee_id=MOCK_LICENSEE_ID,
                 order_information=_generate_default_order_information(),
                 compact_configuration=_generate_aslp_compact_configuration(),
                 selected_jurisdictions=_generate_selected_jurisdictions(),

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -357,7 +357,8 @@ class ApiModel:
                                         type=JsonSchemaType.STRING,
                                         description='The card number',
                                         max_length=19,
-                                        min_length=15,
+                                        # set a min length of acceptable card numbers
+                                        min_length=13,
                                     ),
                                     'expiration': JsonSchema(
                                         type=JsonSchemaType.STRING,

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
@@ -70,7 +70,7 @@
             "number": {
               "description": "The card number",
               "maxLength": 19,
-              "minLength": 15,
+              "minLength": 13,
               "type": "string"
             },
             "expiration": {

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -1,0 +1,105 @@
+# ruff: noqa: S101 T201  we use asserts and print statements for smoke testing
+import json
+import os
+from datetime import UTC, datetime
+
+import boto3
+import requests
+
+# This script can be run locally to test the privilege purchasing flow against a sandbox environment
+# of the Compact Connect API.
+# To run this script, create a smoke_tests_env.json file in the same directory as this script using the
+# 'smoke_tests_env_example.json' file as a template.
+
+def _call_users_me_endpoint(headers):
+    # Get the provider data from the GET '/v1/provider-users/me' endpoint.
+    get_provider_data_response = requests.get(url=os.environ['CC_TEST_API_BASE_URL'] + '/v1/provider-users/me',
+                                              headers=headers, timeout=10)
+    assert (
+            get_provider_data_response.status_code == 200
+    ), f'Failed to GET provider data. Response: {get_provider_data_response.json()}'
+    # check the response for a top level 'privileges' field and verify it has a new record with the correct
+    # jurisdiction and transaction id
+    return get_provider_data_response.json()
+
+def test_purchasing_privilege():
+    # Step 1: Purchase a privilege through the POST '/v1/purchases/privileges' endpoint.
+    # Step 2: Verify a transaction id is returned in the response body.
+    # Step 3: Load records for provider and verify that the privilege is added to the provider's record.
+
+    headers = {
+        'Authorization': 'Bearer ' + os.environ['TEST_PROVIDER_USER_ID_TOKEN'],
+    }
+
+    # first cleaning up user's existing privileges to start in a clean state
+    original_provider_data = _call_users_me_endpoint(headers)
+    original_privileges = original_provider_data.get('privileges')
+    if original_privileges:
+        provider_id = original_provider_data.get('providerId')
+        compact = original_provider_data.get('compact')
+        dynamodb_table_name = os.environ['CC_TEST_PROVIDER_DYNAMO_TABLE_NAME']
+        dynamodb_table = boto3.resource('dynamodb').Table(dynamodb_table_name)
+        for privilege in original_privileges:
+            print(f'Deleting privilege record: {privilege}')
+            dynamodb_table.delete_item(
+                Key={
+                    'pk': f'{compact}#PROVIDER#{provider_id}',
+                    'sk': f'{compact}#PROVIDER#privilege/{privilege["jurisdiction"]}'
+                          f'#{datetime.fromisoformat(privilege["dateOfRenewal"]).date().isoformat()}'
+                }
+            )
+
+    post_body = {
+      "orderInformation": {
+        "card": {
+        # This test card number is defined in authorize.net's testing documentation
+        # https://developer.authorize.net/hello_world/testing_guide.html
+          "number": "4007000000027",
+          "cvv": "123",
+          "expiration": "2050-12"
+        },
+        "billing": {
+          "zip": "44628",
+          "firstName": "Joe",
+          "lastName": "Dokes",
+          "streetAddress": "14 Main Street",
+          "streetAddress2": "Apt. 12J",
+          "state": "TX"
+        }
+      },
+      "selectedJurisdictions": [
+        "ne"
+      ]
+    }
+
+    post_api_response = requests.post(
+        url=os.environ['CC_TEST_API_BASE_URL'] + '/v1/purchases/privileges', headers=headers, json=post_body, timeout=20
+    )
+
+    assert (
+        post_api_response.status_code == 200
+    ), f'Failed to purchase privilege. Response: {post_api_response.json()}'
+
+    transaction_id = post_api_response.json().get('transactionId')
+
+    provider_data = _call_users_me_endpoint(headers)
+    privileges = provider_data.get('privileges')
+    assert privileges, 'No privileges found in provider data'
+    today = datetime.now(tz=UTC).date().isoformat()
+    matching_privilege = next(
+        (privilege for privilege in privileges
+         if datetime.fromisoformat(privilege['dateOfIssuance']).date().isoformat() == today),
+        None,
+    )
+    assert matching_privilege, f'No privilege record found for today ({today})'
+    assert matching_privilege['compactTransactionId'] == transaction_id, \
+        'Privilege record does not match transaction id'
+
+    print(f'Successfully purchased privilege record: {matching_privilege}')
+
+
+if __name__ == '__main__':
+    with open(os.path.join(os.path.dirname(__file__), 'smoke_tests_env.json')) as env_file:
+        env_vars = json.load(env_file)
+        os.environ.update(env_vars)
+    test_purchasing_privilege()

--- a/backend/compact-connect/tests/smoke/smoke_tests_env_example.json
+++ b/backend/compact-connect/tests/smoke/smoke_tests_env_example.json
@@ -1,0 +1,5 @@
+{
+  "CC_TEST_API_BASE_URL": "https://api.test.compactconnect.org",
+  "CC_TEST_PROVIDER_DYNAMO_TABLE_NAME": "Sandbox-PersistentStack-ProviderTable12345",
+  "TEST_PROVIDER_USER_ID_TOKEN": "This can be fetched by logging into the Compact Connect UI of your test environment and copying the value of 'id_token_licensee' from the browser's local storage."
+}


### PR DESCRIPTION
For reporting purposes, we must capture the user id of the licensee in the transaction record in authorize.net. Our user ids are generated as UUIDv4 strings, which are 36 characters long and contain dashes. Originally, we had intended to use the customer id field authorize.net provides for storing these. However, that field is limited to 20 alphanumeric characters (no dashes). The only field that will support the length and dashes of our user ids is the order description field. This field is readonly once the transaction is created, allows up to 255 characters, and is not restricted to alphanumeric characters. 

This PR updates the Purchase client to pass in the licensee id into the order description, so it can be referenced by our reporting which will be implemented in a future ticket.

### Requirements List
- no new requirements. Using existing information.

### Description List
- Add required 'licensee_id' field when processing privilege purchases.

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- Code review

Closes #287 
