### PR TITLE
Feat/standardize timezone used to track datetimes

### DIFF
--- a/backend/compact-connect/lambdas/common-python/cc_common/config.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/config.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from functools import cached_property
 
 import boto3
@@ -128,6 +128,13 @@ class _Config:
         so we have a configuration value for it.
         """
         return timezone(offset=timedelta(hours=-4))
+
+    @property
+    def current_standard_datetime(self):
+        """
+        Standardized way to get the current datetime with the microseconds stripped off.
+        """
+        return datetime.now(tz=UTC).replace(microsecond=0)
 
 
 config = _Config()

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/client.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/client.py
@@ -1,10 +1,11 @@
-from datetime import UTC, date, datetime
+from datetime import date, datetime
 from urllib.parse import quote
 from uuid import uuid4
 
 from boto3.dynamodb.conditions import Attr, Key
 from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
+
 from cc_common.config import _Config, config, logger
 from cc_common.data_model.query_paginator import paginated_query
 from cc_common.data_model.schema import PrivilegeRecordSchema

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/client.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/client.py
@@ -350,7 +350,7 @@ class DataClient:
             # will trigger another lambda to update the status to active
             'status': MilitaryAffiliationStatus.INITIALIZING.value,
             'documentKeys': document_keys,
-            'dateOfUpload': datetime.now(tz=UTC),
+            'dateOfUpload': config.current_standard_datetime,
         }
 
         schema = MilitaryAffiliationRecordSchema()

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/client.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/client.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 from boto3.dynamodb.conditions import Attr, Key
 from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
-
 from cc_common.config import _Config, config, logger
 from cc_common.data_model.query_paginator import paginated_query
 from cc_common.data_model.schema import PrivilegeRecordSchema
@@ -174,15 +173,15 @@ class DataClient:
         jurisdiction_postal_abbreviation: str,
         license_expiration_date: date,
         compact_transaction_id: str,
-        original_issuance_date: date | None = None,
+        original_issuance_date: datetime | None = None,
     ):
-        today = datetime.now(tz=self.config.expiration_date_resolution_timezone).date()
+        current_datetime = config.current_standard_datetime
         privilege_object = {
             'providerId': provider_id,
             'compact': compact_name,
             'jurisdiction': jurisdiction_postal_abbreviation.lower(),
-            'dateOfIssuance': original_issuance_date if original_issuance_date else today,
-            'dateOfRenewal': today,
+            'dateOfIssuance': original_issuance_date if original_issuance_date else current_datetime,
+            'dateOfRenewal': current_datetime,
             'dateOfExpiration': license_expiration_date,
             'compactTransactionId': compact_transaction_id,
         }

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/base_record.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/base_record.py
@@ -57,7 +57,7 @@ class BaseRecordSchema(StrictSchema, ABC):
     type = String(required=True, allow_none=False)
 
     @pre_load
-    def pre_load_initialization(self, in_data, **kwargs):
+    def ensure_date_of_update_is_datetime(self, in_data, **kwargs):
         # for backwards compatibility with the old data model, which was using a Date value
         in_data['dateOfUpdate'] = ensure_value_is_datetime(in_data['dateOfUpdate'])
 

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/base_record.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/base_record.py
@@ -9,9 +9,8 @@ from marshmallow.fields import UUID, DateTime, List, String
 from marshmallow.validate import OneOf, Regexp
 
 from cc_common.config import config
-from cc_common.exceptions import CCInternalException
 from cc_common.data_model.schema.common import ensure_value_is_datetime
-
+from cc_common.exceptions import CCInternalException
 
 
 class StrictSchema(Schema):

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/common.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/common.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from enum import Enum
 
 from marshmallow import Schema
@@ -24,3 +25,34 @@ class S3PresignedPostSchema(Schema):
 
     url = Url(schemes=['https'], required=True, allow_none=False)
     fields = Dict(keys=String(), values=String(), required=True, allow_none=False)
+
+
+def ensure_value_is_datetime(value: str):
+    """
+    Checks a string value is always returned as a datetime string, even if it is a date string.
+
+    Historically, many of our records were using Date fields to track when records in the system were created.
+    This was not sufficient for handling the many different timezone requirements of different states. We have
+    since moved to using DateTime fields most of those date fields, except in the case of licenses uploaded by states,
+    since states do not specify a time of day for when the license was issued.
+
+    This function is used to ensure that all date fields are converted to datetime fields when they are loaded from the
+    database. If an old record is using a date field, it will be converted to a datetime field with the time set to the
+    end of the day in UTC time. This is done to ensure that all records are treated consistently by the system.
+
+    :param value: The value to check, should be either a valid date or datetime string
+    :return: A datetime string
+    :raises: ValueError if the value is not a valid date or datetime string
+    """
+    # check if string is the same length as date format 'YYYY-MM-DD'
+    if len(value) == 10:
+        # parse the date string
+        dt = datetime.fromisoformat(value)
+        # convert it to a datetime
+        # we set it to the end of the day UTC time for overlap with U.S. timezones
+        value_dt = datetime.combine(dt, datetime.max.time(), tzinfo=UTC).replace(microsecond=0)
+        # return the datetime as a string
+        return value_dt.isoformat()
+
+    # Not a date string, return the original
+    return value

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/common.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/common.py
@@ -44,10 +44,11 @@ def ensure_value_is_datetime(value: str):
     :return: A datetime string
     :raises: ValueError if the value is not a valid date or datetime string
     """
+    # Confirm that the value is either a valid date or datetime string
+    # this will raise a ValueError if the string is not a valid datetime
+    dt = datetime.fromisoformat(value)
     # check if string is the same length as date format 'YYYY-MM-DD'
     if len(value) == 10:
-        # parse the date string
-        dt = datetime.fromisoformat(value)
         # convert it to a datetime
         # we set it to the end of the day UTC time for overlap with U.S. timezones
         value_dt = datetime.combine(dt, datetime.max.time(), tzinfo=UTC).replace(microsecond=0)

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/compact.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/compact.py
@@ -49,8 +49,8 @@ class CompactRecordSchema(BaseRecordSchema):
     @pre_dump
     def generate_pk_sk(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
         # the pk and sk are the same for the root compact record
-        in_data['pk'] = f'{in_data['compact']}#CONFIGURATION'
-        in_data['sk'] = f'{in_data['compact']}#CONFIGURATION'
+        in_data['pk'] = f'{in_data['compactName']}#CONFIGURATION'
+        in_data['sk'] = f'{in_data['compactName']}#CONFIGURATION'
         return in_data
 
 

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/jurisdiction.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/jurisdiction.py
@@ -60,7 +60,7 @@ class JurisdictionRecordSchema(BaseRecordSchema):
     @pre_dump
     def generate_pk_sk(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
         in_data['pk'] = f'{in_data['compact']}#CONFIGURATION'
-        in_data['sk'] = f'{in_data['compact']}#JURISDICTION#{in_data['postalAbbreviation']}'
+        in_data['sk'] = f'{in_data['compact']}#JURISDICTION#{in_data['postalAbbreviation'].lower()}'
         return in_data
 
 

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/license.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/license.py
@@ -30,6 +30,8 @@ class LicenseCommonSchema(LicensePublicSchema):
     middleName = String(required=False, allow_none=False, validate=Length(1, 100))
     familyName = String(required=True, allow_none=False, validate=Length(1, 100))
     suffix = String(required=False, allow_none=False, validate=Length(1, 100))
+    # These date values are determined by the license records uploaded by a state
+    # they do not include a timestamp, so we use the Date field type
     dateOfIssuance = Date(required=True, allow_none=False)
     dateOfRenewal = Date(required=True, allow_none=False)
     dateOfExpiration = Date(required=True, allow_none=False)

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/military_affiliation.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/military_affiliation.py
@@ -1,7 +1,7 @@
 # ruff: noqa: N801, N815, ARG002  invalid-name unused-argument
 
 from marshmallow import pre_dump
-from marshmallow.fields import UUID, Date, DateTime, List, Nested, String
+from marshmallow.fields import UUID, DateTime, List, Nested, String
 from marshmallow.validate import Length, OneOf
 
 from cc_common.config import config
@@ -60,7 +60,7 @@ class PostMilitaryAffiliationResponseSchema(ForgivingSchema):
 
     fileNames = List(String(required=True, allow_none=False), required=True, allow_none=False)
     dateOfUpload = DateTime(required=True, allow_none=False)
-    dateOfUpdate = Date(required=True, allow_none=False)
+    dateOfUpdate = DateTime(required=True, allow_none=False)
     status = String(required=True, allow_none=False, validate=OneOf([e.value for e in MilitaryAffiliationStatus]))
     affiliationType = String(
         required=True, allow_none=False, validate=OneOf([e.value for e in MilitaryAffiliationType])

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
@@ -36,6 +36,7 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
 
     @pre_load
     def pre_load_initialization(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
+        in_data = super().pre_load_initialization(in_data, **kwargs)
         return self._enforce_datetimes(in_data)
 
     def _enforce_datetimes(self, in_data, **kwargs):

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
@@ -1,11 +1,11 @@
 # ruff: noqa: N801, N815, ARG002  invalid-name unused-argument
 
-from marshmallow import pre_dump, pre_load
-from marshmallow.fields import UUID, Date, String
-from marshmallow.validate import Length, OneOf
-
 from cc_common.config import config
 from cc_common.data_model.schema.base_record import BaseRecordSchema, CalculatedStatusRecordSchema
+from cc_common.data_model.schema.common import ensure_value_is_datetime
+from marshmallow import pre_dump, pre_load
+from marshmallow.fields import UUID, Date, DateTime, String
+from marshmallow.validate import Length, OneOf
 
 
 @BaseRecordSchema.register_schema('privilege')
@@ -18,8 +18,9 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
     providerId = UUID(required=True, allow_none=False)
     compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
     jurisdiction = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
-    dateOfIssuance = Date(required=True, allow_none=False)
-    dateOfRenewal = Date(required=True, allow_none=False)
+    dateOfIssuance = DateTime(required=True, allow_none=False)
+    dateOfRenewal = DateTime(required=True, allow_none=False)
+    # this is determined by the license expiration date, which is a date field, so this is also a date field
     dateOfExpiration = Date(required=True, allow_none=False)
     compactTransactionId = String(required=False, allow_none=False)
 
@@ -30,15 +31,18 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
     @pre_dump
     def generate_pk_sk(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
         in_data['pk'] = f'{in_data['compact']}#PROVIDER#{in_data['providerId']}'
-        in_data['sk'] = f'{in_data['compact']}#PROVIDER#privilege/{in_data['jurisdiction']}#{in_data['dateOfRenewal']}'
+        in_data['sk'] = f'{in_data['compact']}#PROVIDER#privilege/{in_data['jurisdiction']}#{in_data['dateOfRenewal'].date().isoformat()}'  # noqa: E501
         return in_data
 
     @pre_load
     def pre_load_initialization(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
-        return self._set_date_of_renewal(in_data)
+        return self._enforce_datetimes(in_data)
 
-    def _set_date_of_renewal(self, in_data, **kwargs):
+    def _enforce_datetimes(self, in_data, **kwargs):
         # for backwards compatibility with the old data model
-        # we set the dateOfRenewal to the dateOfIssuance if it does not exist
-        in_data['dateOfRenewal'] = in_data.get('dateOfRenewal', in_data['dateOfIssuance'])
+        # we convert any records that are using a Date value
+        # for dateOfRenewal and dateOfIssuance to DateTime values
+        in_data['dateOfRenewal'] = ensure_value_is_datetime(in_data.get('dateOfRenewal', in_data['dateOfIssuance']))
+        in_data['dateOfIssuance'] = ensure_value_is_datetime(in_data['dateOfIssuance'])
+
         return in_data

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
@@ -22,6 +22,7 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
     dateOfRenewal = DateTime(required=True, allow_none=False)
     # this is determined by the license expiration date, which is a date field, so this is also a date field
     dateOfExpiration = Date(required=True, allow_none=False)
+    # the id of the transaction that was made when the user purchased the privilege
     compactTransactionId = String(required=False, allow_none=False)
 
     # Generated fields

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
@@ -40,7 +40,6 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
 
     @pre_load
     def pre_load_initialization(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
-        in_data = super().pre_load_initialization(in_data, **kwargs)
         return self._enforce_datetimes(in_data)
 
     def _enforce_datetimes(self, in_data, **kwargs):

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/privilege.py
@@ -1,11 +1,12 @@
 # ruff: noqa: N801, N815, ARG002  invalid-name unused-argument
 
-from cc_common.config import config
-from cc_common.data_model.schema.base_record import BaseRecordSchema, CalculatedStatusRecordSchema
-from cc_common.data_model.schema.common import ensure_value_is_datetime
 from marshmallow import pre_dump, pre_load
 from marshmallow.fields import UUID, Date, DateTime, String
 from marshmallow.validate import Length, OneOf
+
+from cc_common.config import config
+from cc_common.data_model.schema.base_record import BaseRecordSchema, CalculatedStatusRecordSchema
+from cc_common.data_model.schema.common import ensure_value_is_datetime
 
 
 @BaseRecordSchema.register_schema('privilege')
@@ -32,7 +33,9 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
     @pre_dump
     def generate_pk_sk(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
         in_data['pk'] = f'{in_data['compact']}#PROVIDER#{in_data['providerId']}'
-        in_data['sk'] = f'{in_data['compact']}#PROVIDER#privilege/{in_data['jurisdiction']}#{in_data['dateOfRenewal'].date().isoformat()}'  # noqa: E501
+        in_data['sk'] = (
+            f'{in_data['compact']}#PROVIDER#privilege/{in_data['jurisdiction']}#{in_data['dateOfRenewal'].date().isoformat()}'  # noqa: E501
+        )
         return in_data
 
     @pre_load

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/provider.py
@@ -32,6 +32,8 @@ class ProviderPublicSchema(ForgivingSchema):
     middleName = String(required=False, allow_none=False, validate=Length(1, 100))
     familyName = String(required=True, allow_none=False, validate=Length(1, 100))
     suffix = String(required=False, allow_none=False, validate=Length(1, 100))
+    # these dates are determined by the license records uploaded by a state
+    # they do not include a timestamp, so we use the Date field type
     dateOfExpiration = Date(required=True, allow_none=False)
     dateOfBirth = Date(required=True, allow_none=False)
     homeAddressStreet1 = String(required=True, allow_none=False, validate=Length(2, 100))

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/provider.py
@@ -1,10 +1,6 @@
 # ruff: noqa: N801, N815, ARG002  invalid-name unused-argument
 from urllib.parse import quote
 
-from marshmallow import ValidationError, post_load, pre_dump, validates_schema
-from marshmallow.fields import UUID, Boolean, Date, Email, String
-from marshmallow.validate import Length, OneOf, Regexp
-
 from cc_common.config import config
 from cc_common.data_model.schema.base_record import (
     BaseRecordSchema,
@@ -14,6 +10,10 @@ from cc_common.data_model.schema.base_record import (
     Set,
     SocialSecurityNumber,
 )
+from cc_common.data_model.schema.common import ensure_value_is_datetime
+from marshmallow import ValidationError, post_load, pre_dump, pre_load, validates_schema
+from marshmallow.fields import UUID, Boolean, Date, DateTime, Email, String
+from marshmallow.validate import Length, OneOf, Regexp
 
 
 class ProviderPublicSchema(ForgivingSchema):
@@ -62,7 +62,14 @@ class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPublicSchema):
     # Generated fields
     privilegeJurisdictions = Set(String, required=False, allow_none=False, load_default=set())
     providerFamGivMid = String(required=False, allow_none=False, validate=Length(2, 400))
-    providerDateOfUpdate = Date(required=True, allow_none=False)
+    providerDateOfUpdate = DateTime(required=True, allow_none=False)
+
+    @pre_load
+    def pre_load_initialization(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
+        in_data = super().pre_load_initialization(in_data, **kwargs)
+        in_data['providerDateOfUpdate'] = ensure_value_is_datetime(in_data['providerDateOfUpdate'])
+
+        return in_data
 
     @pre_dump
     def generate_pk_sk(self, in_data, **kwargs):  # noqa: ARG001 unused-argument

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/provider.py
@@ -1,6 +1,10 @@
 # ruff: noqa: N801, N815, ARG002  invalid-name unused-argument
 from urllib.parse import quote
 
+from marshmallow import ValidationError, post_load, pre_dump, pre_load, validates_schema
+from marshmallow.fields import UUID, Boolean, Date, DateTime, Email, String
+from marshmallow.validate import Length, OneOf, Regexp
+
 from cc_common.config import config
 from cc_common.data_model.schema.base_record import (
     BaseRecordSchema,
@@ -11,9 +15,6 @@ from cc_common.data_model.schema.base_record import (
     SocialSecurityNumber,
 )
 from cc_common.data_model.schema.common import ensure_value_is_datetime
-from marshmallow import ValidationError, post_load, pre_dump, pre_load, validates_schema
-from marshmallow.fields import UUID, Boolean, Date, DateTime, Email, String
-from marshmallow.validate import Length, OneOf, Regexp
 
 
 class ProviderPublicSchema(ForgivingSchema):

--- a/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/common-python/cc_common/data_model/schema/provider.py
@@ -69,7 +69,6 @@ class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPublicSchema):
 
     @pre_load
     def pre_load_initialization(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
-        in_data = super().pre_load_initialization(in_data, **kwargs)
         in_data['providerDateOfUpdate'] = ensure_value_is_datetime(in_data['providerDateOfUpdate'])
 
         return in_data

--- a/backend/compact-connect/lambdas/common-python/tests/resources/api/provider-detail-response.json
+++ b/backend/compact-connect/lambdas/common-python/tests/resources/api/provider-detail-response.json
@@ -60,8 +60,8 @@
       "compact": "aslp",
       "jurisdiction": "ne",
       "status": "active",
-      "dateOfIssuance": "2024-06-06",
-      "dateOfRenewal": "2024-11-08",
+      "dateOfIssuance": "2024-06-06T23:59:59+00:00",
+      "dateOfRenewal": "2024-11-08T23:59:59+00:00",
       "dateOfUpdate": "2024-07-01",
       "dateOfExpiration": "2050-06-06",
       "compactTransactionId": "1234567890"

--- a/backend/compact-connect/lambdas/common-python/tests/resources/api/provider-detail-response.json
+++ b/backend/compact-connect/lambdas/common-python/tests/resources/api/provider-detail-response.json
@@ -21,7 +21,7 @@
   "emailAddress": "björk@example.com",
   "phoneNumber": "+13213214321",
   "dateOfBirth": "2024-06-06",
-  "dateOfUpdate": "2024-07-08",
+  "dateOfUpdate": "2024-07-08T23:59:59+00:00",
   "dateOfExpiration": "2050-06-06",
   "birthMonthDay": "06-06",
   "licenses": [
@@ -42,7 +42,7 @@
       "dateOfRenewal": "2024-06-06",
       "dateOfExpiration": "2050-06-06",
       "dateOfBirth": "2024-06-06",
-      "dateOfUpdate": "2024-07-08",
+      "dateOfUpdate": "2024-07-08T23:59:59+00:00",
       "homeAddressStreet1": "123 A St.",
       "homeAddressStreet2": "Apt 321",
       "homeAddressCity": "Columbus",
@@ -62,7 +62,7 @@
       "status": "active",
       "dateOfIssuance": "2024-06-06T23:59:59+00:00",
       "dateOfRenewal": "2024-11-08T23:59:59+00:00",
-      "dateOfUpdate": "2024-07-01",
+      "dateOfUpdate": "2024-07-01T23:59:59+00:00",
       "dateOfExpiration": "2050-06-06",
       "compactTransactionId": "1234567890"
     }
@@ -77,7 +77,7 @@
       "fileNames": ["military-waiver.pdf"],
       "status": "active",
       "dateOfUpload": "2024-07-08T13:34:59+00:00",
-      "dateOfUpdate": "2024-07-08"
+      "dateOfUpdate": "2024-07-08T23:59:59+00:00"
    }
   ]
 }

--- a/backend/compact-connect/lambdas/common-python/tests/resources/api/provider-detail-response.json
+++ b/backend/compact-connect/lambdas/common-python/tests/resources/api/provider-detail-response.json
@@ -76,8 +76,8 @@
       "affiliationType": "militaryMember",
       "fileNames": ["military-waiver.pdf"],
       "status": "active",
-      "dateOfUpload": "2024-07-08T13:34:59+00:00",
-      "dateOfUpdate": "2024-07-08T23:59:59+00:00"
+      "dateOfUpload": "2024-11-08T23:59:59+00:00",
+      "dateOfUpdate": "2024-11-08T23:59:59+00:00"
    }
   ]
 }

--- a/backend/compact-connect/lambdas/common-python/tests/resources/api/provider-response.json
+++ b/backend/compact-connect/lambdas/common-python/tests/resources/api/provider-response.json
@@ -21,7 +21,7 @@
   "emailAddress": "björk@example.com",
   "phoneNumber": "+13213214321",
   "dateOfBirth": "2024-06-06",
-  "dateOfUpdate": "2024-07-08",
+  "dateOfUpdate": "2024-07-08T23:59:59+00:00",
   "dateOfExpiration": "2050-06-06",
   "birthMonthDay": "06-06"
 }

--- a/backend/compact-connect/lambdas/common-python/tests/resources/dynamo/military-affiliation.json
+++ b/backend/compact-connect/lambdas/common-python/tests/resources/dynamo/military-affiliation.json
@@ -1,6 +1,6 @@
 {
       "pk": "aslp#PROVIDER#89a6377e-c3a5-40e5-bca5-317ec854c570",
-      "sk": "aslp#PROVIDER#military-affiliation#2024-07-08",
+      "sk": "aslp#PROVIDER#military-affiliation#2024-11-08",
       "providerId": "89a6377e-c3a5-40e5-bca5-317ec854c570",
       "compact": "aslp",
       "type": "militaryAffiliation",
@@ -8,6 +8,6 @@
       "affiliationType": "militaryMember",
       "fileNames": ["military-waiver.pdf"],
       "status": "active",
-      "dateOfUpload": "2024-07-08T13:34:59+00:00",
-      "dateOfUpdate": "2024-07-08"
+      "dateOfUpload": "2024-11-08T23:59:59+00:00",
+      "dateOfUpdate": "2024-11-08T23:59:59+00:00"
 }

--- a/backend/compact-connect/lambdas/common-python/tests/resources/dynamo/privilege.json
+++ b/backend/compact-connect/lambdas/common-python/tests/resources/dynamo/privilege.json
@@ -5,8 +5,8 @@
   "providerId": "89a6377e-c3a5-40e5-bca5-317ec854c570",
   "compact": "aslp",
   "jurisdiction": "ne",
-  "dateOfIssuance": "2024-06-06",
-  "dateOfRenewal": "2024-11-08",
+  "dateOfIssuance": "2024-06-06T23:59:59+00:00",
+  "dateOfRenewal": "2024-11-08T23:59:59+00:00",
   "dateOfUpdate": "2024-07-01",
   "dateOfExpiration": "2050-06-06",
   "compactTransactionId": "1234567890"

--- a/backend/compact-connect/lambdas/common-python/tests/unit/test_data_model/test_data_client.py
+++ b/backend/compact-connect/lambdas/common-python/tests/unit/test_data_model/test_data_client.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime
 from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError

--- a/backend/compact-connect/lambdas/common-python/tests/unit/test_data_model/test_data_client.py
+++ b/backend/compact-connect/lambdas/common-python/tests/unit/test_data_model/test_data_client.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError
 from cc_common.exceptions import CCAwsServiceException
@@ -8,6 +8,7 @@ from tests import TstLambdas
 
 
 class TestDataClient(TstLambdas):
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-11-08T23:59:59+00:00'))
     def test_data_client_deletes_records_if_exception_during_create_privilege_records(self):
         from cc_common.data_model import client
 
@@ -42,7 +43,6 @@ class TestDataClient(TstLambdas):
         mock_batch_writer.delete_item.assert_called_with(
             Key={
                 'pk': 'aslp#PROVIDER#test_provider_id',
-                'sk': f'aslp#PROVIDER#privilege/ca#{datetime
-                .now(tz=timezone(offset=timedelta(hours=-4))).date().isoformat()}',
+                'sk': 'aslp#PROVIDER#privilege/ca#2024-11-08',
             }
         )

--- a/backend/compact-connect/lambdas/common-python/tests/unit/test_data_model/test_data_client.py
+++ b/backend/compact-connect/lambdas/common-python/tests/unit/test_data_model/test_data_client.py
@@ -25,7 +25,6 @@ class TestDataClient(TstLambdas):
         )
 
         mock_config = MagicMock(spec=client._Config)  # noqa: SLF001 protected-access
-        mock_config.expiration_date_resolution_timezone = timezone(offset=timedelta(hours=-4))
         mock_config.provider_table = mock_dynamo_db_table
 
         test_data_client = client.DataClient(mock_config)

--- a/backend/compact-connect/lambdas/custom-resources/tests/__init__.py
+++ b/backend/compact-connect/lambdas/custom-resources/tests/__init__.py
@@ -14,6 +14,8 @@ class TstLambdas(TestCase):
                 'DEBUG': 'false',
                 'AWS_DEFAULT_REGION': 'us-east-1',
                 'COMPACT_CONFIGURATION_TABLE_NAME': 'compact-configuration-table',
+                'COMPACTS': '["aslp", "octp", "coun"]',
+                'JURISDICTIONS': '["ne", "oh", "ky"]',
             },
         )
         # Monkey-patch config object to be sure we have it based

--- a/backend/compact-connect/lambdas/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
+++ b/backend/compact-connect/lambdas/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
@@ -60,7 +60,6 @@ def generate_mock_compact_configuration():
 
 @mock_aws
 class TestCompactConfigurationUploader(TstFunction):
-
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat(MOCK_CURRENT_TIMESTAMP))
     def test_compact_configuration_uploader_store_all_config(self):
         from handlers.compact_config_uploader import on_event

--- a/backend/compact-connect/lambdas/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
+++ b/backend/compact-connect/lambdas/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from decimal import Decimal
+from unittest.mock import patch
 
 from boto3.dynamodb.conditions import Key
 from moto import mock_aws
@@ -8,6 +9,7 @@ from moto import mock_aws
 from .. import TstFunction
 
 TEST_ENVIRONMENT_NAME = 'test'
+MOCK_CURRENT_TIMESTAMP = '2024-11-08T23:59:59+00:00'
 
 
 def generate_single_root_compact_config(compact_name: str, active_environments: list):
@@ -58,12 +60,8 @@ def generate_mock_compact_configuration():
 
 @mock_aws
 class TestCompactConfigurationUploader(TstFunction):
-    def generate_date_string(self):
-        # yes, there is always a chance that the tests are run precisely at midnight
-        # which will cause the test to fail and will need to be rerun,
-        # but that's a risk we're willing to take.
-        return datetime.now(tz=self.config.expiration_date_resolution_timezone).strftime('%Y-%m-%d')
 
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat(MOCK_CURRENT_TIMESTAMP))
     def test_compact_configuration_uploader_store_all_config(self):
         from handlers.compact_config_uploader import on_event
 
@@ -97,14 +95,14 @@ class TestCompactConfigurationUploader(TstFunction):
                     'compactName': 'aslp',
                     'compactOperationsTeamEmails': [],
                     'compactSummaryReportNotificationEmails': [],
-                    'dateOfUpdate': self.generate_date_string(),
+                    'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'pk': 'aslp#CONFIGURATION',
                     'sk': 'aslp#CONFIGURATION',
                     'type': 'compact',
                 },
                 {
                     'compact': 'aslp',
-                    'dateOfUpdate': self.generate_date_string(),
+                    'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
                     'jurisdictionFee': Decimal('100'),
                     'jurisdictionName': 'nebraska',
@@ -119,7 +117,7 @@ class TestCompactConfigurationUploader(TstFunction):
                 },
                 {
                     'compact': 'aslp',
-                    'dateOfUpdate': self.generate_date_string(),
+                    'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
                     'jurisdictionFee': Decimal('100'),
                     'jurisdictionName': 'ohio',
@@ -138,14 +136,14 @@ class TestCompactConfigurationUploader(TstFunction):
                     'compactName': 'octp',
                     'compactOperationsTeamEmails': [],
                     'compactSummaryReportNotificationEmails': [],
-                    'dateOfUpdate': self.generate_date_string(),
+                    'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'pk': 'octp#CONFIGURATION',
                     'sk': 'octp#CONFIGURATION',
                     'type': 'compact',
                 },
                 {
                     'compact': 'octp',
-                    'dateOfUpdate': self.generate_date_string(),
+                    'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
                     'jurisdictionFee': Decimal('100'),
                     'jurisdictionName': 'nebraska',
@@ -160,7 +158,7 @@ class TestCompactConfigurationUploader(TstFunction):
                 },
                 {
                     'compact': 'octp',
-                    'dateOfUpdate': self.generate_date_string(),
+                    'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
                     'jurisdictionFee': Decimal('100'),
                     'jurisdictionName': 'ohio',

--- a/backend/compact-connect/lambdas/provider-data-v1/handlers/provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/handlers/provider_users.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-from datetime import UTC, datetime
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from cc_common.config import config, logger
@@ -72,7 +71,7 @@ def _post_provider_military_affiliation(event, context):  # noqa: ARG001 unused-
 
     s3_document_prefix = (
         f'compact/{compact}/provider/{provider_id}/document-type/'
-        f'{MILITARY_AFFILIATIONS_DOCUMENT_TYPE_KEY_NAME}/{datetime.now(tz=UTC).date().isoformat()}/'
+        f'{MILITARY_AFFILIATIONS_DOCUMENT_TYPE_KEY_NAME}/{config.current_standard_datetime.date().isoformat()}/'
     )
 
     event_body = json.loads(event['body'])

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/__init__.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from glob import glob
 from random import randint
@@ -133,12 +133,11 @@ class TstFunction(TstLambdas):
                 },
             )
 
-            # Create a new provider with a license
-            now = self.config.current_standard_datetime
             # This gives us some variation in dateOfUpdate values to sort by
-            with patch('cc_common.config._Config.current_standard_datetime',
-                       new_callable=lambda: now - timedelta( days=randint(1, 365))):
-
+            with patch(
+                'cc_common.config._Config.current_standard_datetime',
+                new_callable=lambda: datetime.now(tz=UTC).replace(microsecond=0) - timedelta(days=randint(1, 365)),
+            ):
                 ingest_license_message(
                     {'Records': [{'messageId': '123', 'body': json.dumps(ingest_message_copy)}]},
                     self.mock_context,

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/__init__.py
@@ -134,7 +134,7 @@ class TstFunction(TstLambdas):
             )
 
             # Create a new provider with a license
-            now = datetime.now(tz=self.config.expiration_date_resolution_timezone)
+            now = self.config.current_standard_datetime
             with patch('cc_common.data_model.schema.base_record.datetime') as mock:
                 # This gives us some variation in dateOfUpdate values to sort by
                 mock.now.side_effect = lambda tz: now - timedelta(  # noqa: ARG005, B023  unused-lambda-argument

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/__init__.py
@@ -135,11 +135,9 @@ class TstFunction(TstLambdas):
 
             # Create a new provider with a license
             now = self.config.current_standard_datetime
-            with patch('cc_common.data_model.schema.base_record.datetime') as mock:
-                # This gives us some variation in dateOfUpdate values to sort by
-                mock.now.side_effect = lambda tz: now - timedelta(  # noqa: ARG005, B023  unused-lambda-argument
-                    days=randint(1, 365),
-                )
+            # This gives us some variation in dateOfUpdate values to sort by
+            with patch('cc_common.config._Config.current_standard_datetime',
+                       new_callable=lambda: now - timedelta( days=randint(1, 365))):
 
                 ingest_license_message(
                     {'Records': [{'messageId': '123', 'body': json.dumps(ingest_message_copy)}]},

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/__init__.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from decimal import Decimal
 from glob import glob
 from random import randint

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_data_model/test_client.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_data_model/test_client.py
@@ -308,7 +308,6 @@ class TestClient(TstFunction):
         # This asserts that the records are sorted by dateOfUpload, from oldest to newest
         oldest_record = military_affiliation_record[0]
         newest_record = military_affiliation_record[1]
-        self.assertTrue(oldest_record['dateOfUpload'] < newest_record['dateOfUpload'],
-                        'Records are not sorted by date')
+        self.assertTrue(oldest_record['dateOfUpload'] < newest_record['dateOfUpload'], 'Records are not sorted by date')
         self.assertEqual('inactive', oldest_record['status'])
         self.assertEqual('active', newest_record['status'])

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
@@ -11,6 +11,7 @@ from .. import TstFunction
 @mock_aws
 class TestTransformations(TstFunction):
     # Yes, this is an excessively long method. We're going with it for sake of a single illustrative test.
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-11-08T23:59:59+00:00'))
     def test_transformations(self):
         """Provider data undergoes several transformations from when a license is first posted, stored into the
         database, then returned via the API. We will specifically test that chain, end to end, to make sure the
@@ -151,13 +152,7 @@ class TestTransformations(TstFunction):
         del records['privilege']['dateOfRenewal']
         del records['militaryAffiliation']['dateOfUpload']
 
-        # the sk is dynamic and will not match, but we can check its values to make sure the value of each is expected
-        self.assertEqual('aslp#PROVIDER#privilege/ne#2024-11-08', expected_privilege.pop('sk'))
-        self.assertEqual(
-            f'aslp#PROVIDER#privilege/ne#{datetime.now(tz=self.config.expiration_date_resolution_timezone)
-            .date().isoformat()}',
-            records['privilege'].pop('sk'),
-        )
+
         # check the sk of the military affiliation, which is also dynamic
         self.assertEqual('aslp#PROVIDER#military-affiliation#2024-07-08', expected_military_affiliation.pop('sk'))
         self.assertEqual(

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
@@ -152,15 +152,6 @@ class TestTransformations(TstFunction):
         del records['privilege']['dateOfRenewal']
         del records['militaryAffiliation']['dateOfUpload']
 
-
-        # check the sk of the military affiliation, which is also dynamic
-        self.assertEqual('aslp#PROVIDER#military-affiliation#2024-07-08', expected_military_affiliation.pop('sk'))
-        self.assertEqual(
-            f'aslp#PROVIDER#military-affiliation#{datetime.now(tz=self.config.expiration_date_resolution_timezone)
-            .date().isoformat()}',
-            records['militaryAffiliation'].pop('sk'),
-        )
-
         # Make sure each is represented the way we expect, in the db
         self.assertEqual(expected_provider, records['provider'])
         self.assertEqual(expected_license, records['license'])

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
@@ -102,6 +102,7 @@ class TestPostProviderMilitaryAffiliation(TstFunction):
         return event
 
     @patch('handlers.provider_users.uuid')
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-12-04T08:08:08+00:00'))
     def test_post_provider_military_affiliation_returns_affiliation_information(self, mock_uuid):
         from handlers.provider_users import provider_user_me_military_affiliation
 
@@ -120,7 +121,6 @@ class TestPostProviderMilitaryAffiliation(TstFunction):
         del military_affiliation_data['documentUploadFields'][0]['fields']['x-amz-date']
         del military_affiliation_data['documentUploadFields'][0]['fields']['x-amz-credential']
 
-        today = datetime.now(self.config.expiration_date_resolution_timezone).date().isoformat()
         provider_id = event['requestContext']['authorizer']['claims']['custom:providerId']
 
         # remove the dynamic dateOfUpload field
@@ -129,12 +129,12 @@ class TestPostProviderMilitaryAffiliation(TstFunction):
         self.assertEqual(
             {
                 'affiliationType': 'militaryMember',
-                'dateOfUpdate': today,
+                'dateOfUpdate': '2024-12-04T08:08:08+00:00',
                 'documentUploadFields': [
                     {
                         'fields': {
                             'key': f'compact/{TEST_COMPACT}/provider/{provider_id}/document-type/military-affiliations'
-                            f'/{today}/1234#military_affiliation.pdf',
+                            f'/2024-12-04/1234#military_affiliation.pdf',
                             'x-amz-algorithm': 'AWS4-HMAC-SHA256',
                         },
                         'url': 'https://provider-user-bucket.s3.amazonaws.com/',

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
@@ -198,8 +198,8 @@ class TestPostProviderMilitaryAffiliation(TstFunction):
         message = json.loads(resp['body'])['message']
 
         self.assertEqual(
-            'Invalid file type "guff" The following file types are supported: ' +
-            "('pdf', 'jpg', 'jpeg', 'png', 'docx')",
+            'Invalid file type "guff" The following file types are supported: '
+            + "('pdf', 'jpg', 'jpeg', 'png', 'docx')",
             message,
         )
 

--- a/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -1,5 +1,5 @@
 import json
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, patch
 
 from cc_common.config import config
@@ -158,9 +158,8 @@ class TestPostPurchasePrivileges(TstFunction):
         self, mock_purchase_client_constructor
     ):
         from handlers.privileges import post_purchase_privileges
-        self._when_purchase_client_successfully_processes_request(
-            mock_purchase_client_constructor
-        )
+
+        self._when_purchase_client_successfully_processes_request(mock_purchase_client_constructor)
         event = self._when_testing_provider_user_event_with_custom_claims()
         self._load_military_affiliation_record_data(status='initializing')
         event['body'] = _generate_test_request_body()
@@ -292,7 +291,7 @@ class TestPostPurchasePrivileges(TstFunction):
         test_expiration_date = date(2024, 10, 8).isoformat()
         event = self._when_testing_provider_user_event_with_custom_claims(license_expiration_date=test_expiration_date)
         event['body'] = _generate_test_request_body()
-        test_issuance_date = datetime(2023, 10, 8, hour=5).isoformat()
+        test_issuance_date = datetime(2023, 10, 8, hour=5, tzinfo=UTC).isoformat()
 
         # create an existing privilege record for the kentucky jurisdiction, simulating a previous purchase
         with open('../common-python/tests/resources/dynamo/privilege.json') as f:
@@ -327,10 +326,7 @@ class TestPostPurchasePrivileges(TstFunction):
 
         # ensure the date of renewal is updated
         updated_privilege_record = next(
-            record
-            for record in privilege_records
-            if record['dateOfRenewal'].isoformat()
-            == '2024-10-05T23:59:59+00:00'
+            record for record in privilege_records if record['dateOfRenewal'].isoformat() == '2024-10-05T23:59:59+00:00'
         )
         # ensure the expiration is updated
         self.assertEqual(updated_expiration_date, updated_privilege_record['dateOfExpiration'].isoformat())

--- a/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -369,6 +369,7 @@ class TestPostPurchasePrivileges(TstFunction):
         self.assertEqual({'message': 'No active license found for this user'}, response_body)
 
     @patch('handlers.privileges.PurchaseClient')
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-11-08T23:59:59+00:00'))
     def test_post_purchase_privileges_adds_privilege_record_if_transaction_successful(
         self, mock_purchase_client_constructor
     ):
@@ -392,13 +393,10 @@ class TestPostPurchasePrivileges(TstFunction):
         expected_expiration_date = date(2050, 1, 1)
         self.assertEqual(expected_expiration_date, license_record['dateOfExpiration'])
         self.assertEqual(expected_expiration_date, privilege_record['dateOfExpiration'])
-        # the date of issuance should be today
-        self.assertEqual(
-            datetime.now(tz=self.config.expiration_date_resolution_timezone).date(), privilege_record['dateOfIssuance'].date()
-        )
-        self.assertEqual(
-            datetime.now(tz=self.config.expiration_date_resolution_timezone).date(), privilege_record['dateOfUpdate']
-        )
+        # the date of issuance should be mocked timestamp
+        mock_datetime = datetime.fromisoformat('2024-11-08T23:59:59+00:00')
+        self.assertEqual(mock_datetime, privilege_record['dateOfIssuance'])
+        self.assertEqual(mock_datetime, privilege_record['dateOfUpdate'])
         self.assertEqual(TEST_COMPACT, privilege_record['compact'])
         self.assertEqual('ky', privilege_record['jurisdiction'])
         self.assertEqual(TEST_PROVIDER_ID, str(privilege_record['providerId']))

--- a/backend/compact-connect/lambdas/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -27,7 +27,7 @@ class TestPatchUser(TstFunction):
         self.assertEqual(
             {
                 'attributes': {'email': 'justin@example.org', 'familyName': 'Williams', 'givenName': 'Justin'},
-                'dateOfUpdate': '2024-09-12',
+                'dateOfUpdate': '2024-09-12T23:59:59+00:00',
                 'permissions': {
                     'aslp': {
                         'actions': {'read': True},

--- a/backend/compact-connect/lambdas/staff-users/tests/resources/api/user-response.json
+++ b/backend/compact-connect/lambdas/staff-users/tests/resources/api/user-response.json
@@ -1,6 +1,6 @@
 {
   "type": "user",
-  "dateOfUpdate": "2024-09-12",
+  "dateOfUpdate": "2024-09-12T23:59:59+00:00",
   "userId": "a4182428-d061-701c-82e5-a3d1d547d797",
   "attributes": {
     "email": "justin@example.org",

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -206,8 +206,7 @@ class ApiModel:
 
     @property
     def post_provider_military_affiliation_response_model(self) -> Model:
-        """Return the post provider military affiliation response model, which should only be created once per API
-        """
+        """Return the post provider military affiliation response model, which should only be created once per API"""
         if hasattr(self.api, '_v1_post_provider_military_affiliation_response_model'):
             return self.api._v1_post_provider_military_affiliation_response_model
         self.api._v1_post_provider_military_affiliation_response_model = self.api.add_model(

--- a/backend/compact-connect/tests/smoke/military_affiliation_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/military_affiliation_smoke_tests.py
@@ -15,6 +15,7 @@ API_URL = os.environ['API_URL']
 # browser's local storage.
 TEST_USER_COGNITO_ID_TOKEN = os.environ['TEST_PROVIDER_USER_ID_TOKEN']
 
+
 def test_military_affiliation_upload():
     # Step 1: Create a military affiliation record in the DB using the POST
     # '/v1/provider-users/me/military-affiliation' endpoint.
@@ -38,7 +39,7 @@ def test_military_affiliation_upload():
         post_api_response.status_code == 200
     ), f'Failed to POST military affiliations record. Response: {post_api_response.json()}'
 
-    '''
+    """
     The response body should include S3 pre-sign url form in this format:
     {
     ...
@@ -55,7 +56,7 @@ def test_military_affiliation_upload():
         'fileNames': ['military_affiliation.pdf'],
         'status': 'initializing',
     }
-    '''
+    """
     post_api_response_json = post_api_response.json()
     # Use the S3 pre-signed URL to upload a test file to the S3 bucket.
     with open('../resources/test_files/military_affiliation.pdf', 'rb') as test_file:


### PR DESCRIPTION
Previously, our system was using a non-standard timezone for recording when records were created/updated. This could
potentially cause problems in the future should the needs of the system change in regards to which timezone we need to
evaluate our records against. To correct this, this PR updates the system to always use standard UTC timestamps when writing records to the DB. This also converts the Date fields to DateTime fields, as this will provide the granularity we will need to flexibly support changing timezone requirements in the future.

The exception to this is license record fields, as these are defined by the states that upload the records, and they do not include timestamps, so we store whatever date value they give us.

We are releasing this change in a backwards compatible manner, in that if a record has these fields currently recorded as date strings 'YYYY-MM-DD' we convert them to datetimes using a consistent timestamp.

### Requirements List
- No new requirements. These changes should be backwards compatible with existing records.

### Description List
- using consistent UTC timezone to write records to the DB
- converting date fields to datetimes (except for license records)

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- Code review

Closes #356 
