### PR TITLE
Feat/read access updates

### DIFF
--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -166,7 +166,7 @@ class UserPool(CdkUserPool):
             'UIClient',
             auth_flows=AuthFlow(
                 # we allow this in test environments for automated testing
-                admin_user_password=False if self.security_profile == SecurityProfile.RECOMMENDED else True,
+                admin_user_password=self.security_profile == SecurityProfile.VULNERABLE,
                 custom=False,
                 user_srp=self.security_profile == SecurityProfile.VULNERABLE,
                 user_password=False,

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -165,7 +165,8 @@ class UserPool(CdkUserPool):
         return self.add_client(
             'UIClient',
             auth_flows=AuthFlow(
-                admin_user_password=False,
+                # we allow this in test environments for automated testing
+                admin_user_password=False if self.security_profile == SecurityProfile.RECOMMENDED else True,
                 custom=False,
                 user_srp=self.security_profile == SecurityProfile.VULNERABLE,
                 user_password=False,

--- a/backend/compact-connect/docs/design/README.md
+++ b/backend/compact-connect/docs/design/README.md
@@ -85,16 +85,19 @@ how permissions are stored and translated into scopes.
 
 #### Compact Executive Directors and Staff
 
-Compact ED level staff can have permission to read all compact data as well as to create and manage users and their
-permissions. They can grant other users the ability to write data for a particular jurisdiction and to create more
-users associated with a particular jurisdiction. They can also delete any user within their compact, so long as that
-user does not have permissions associated with a different compact.
+Compact ED level staff can have permission to read all generally available data for any compact, and if they have the 
+`readPrivate` permission they will be able to view all data for any licensee within the compact. They will also be able
+to create and manage users and their permissions. They can grant other users the ability to write data for a particular
+jurisdiction and to create more users associated with a particular jurisdiction. They can also delete any user within 
+their compact, so long as that user does not have permissions associated with a different compact.
 
 #### Board Executive Directors and Staff
 
-Board ED level staff can have permission to read all compact data, write data to for their own jurisdiction, and to
-create more users that have permissions within their own jurisdiction. They can also delete any user within their
-jurisdiction, so long as that user does not have permissions associated with a different compact or jurisdiction.
+Board ED level staff can have permission to read all generally available jurisdiction data, and if they have the 
+`readPrivate` permission they will be able to view all information for any licensee that has either a license or privilege
+within their jurisdiction. They can also write data to for their own jurisdiction, and to create more users that have 
+permissions within their own jurisdiction. They can also delete any user within their jurisdiction, so long as that user
+does not have permissions associated with a different compact or jurisdiction.
 
 #### Implementation of Scopes
 
@@ -109,17 +112,21 @@ require more than 100 scopes per resource server.
 
 To design around the 100 scope limit, we will have to split authorization into two layers: coarse- and fine-grained.
 We can rely on the Cognito authorizers to protect our API endpoints based on fewer coarse-grained scopes, then
-protect the more fine-grained access within the API endpoint logic. The Staff User pool resource servers will are
-configured with `read`, `write`, and `admin` scopes. `read` scopes indicate that the user is allowed to read the
-entire compact's licensee data. `write` and `admin` scopes, however, indicate only that the user is allowed to write
-or administrate _something_ in the compact respectively, thus giving them access to the write or administrative
-API endpoints. We will then rely on the API endpoint logic to refine their access based on the more fine-grained
-access scopes.
+protect the more fine-grained access within the API endpoint logic. The Staff User pool resource servers are
+configured with `readGeneral`, `write`, and `admin` scopes. The `readGeneral` scope is implicitly granted to all users in
+the system, and is used to indicate that the user is allowed to read any compact's licensee data that is not considered
+private. The `write` and `admin` scopes, however, indicate only that the user is allowed to write or administrate 
+_something_ in the compact respectively, thus giving them access to the write or administrative API endpoints. We will 
+then rely on the API endpoint logic to refine their access based on the more fine-grained access scopes.
 
-To compliment each of the `write` and `admin` scopes, there will be at least one, more specific, scope, to indicate
-_what_ within the compact they are allowed to write or administrate, respectively. In the case of `write` scopes,
-a jurisdiction-specific scope will control what jurisdiction they are able to write data for (i.e. `al.write` grants
-permission to write data for the Alabama jurisdiction). Similarly, `admin` scopes can have a jurisdiction-specific
+In addition to the `readGeneral` scope, there is a `readPrivate` scope that is used to indicate that the user is allowed
+to read all of a compact's licensee data, so long as that licensee is within their compact or jurisdiction for which
+they have that permission.
+
+To compliment each of the `write` and `admin` scopes, there will be at least one, more specific, scope, 
+to indicate _what_ within the compact they are allowed to write or administrate, respectively. In the case of `write` 
+scopes, a jurisdiction-specific scope will control what jurisdiction they are able to write data for (i.e. `al.write` 
+grants permission to write data for the Alabama jurisdiction). Similarly, `admin` scopes can have a jurisdiction-specific
 scope like `al.admin` and can also have a compact-wide scope like `aslp.admin`, which grants permission for a compact
 executive director to perform the administrative functions for the Audiology and Speech Language Pathology compact.
 

--- a/backend/compact-connect/docs/design/README.md
+++ b/backend/compact-connect/docs/design/README.md
@@ -136,9 +136,10 @@ private. The `write` and `admin` scopes, however, indicate only that the user is
 _something_ in the compact respectively, thus giving them access to the write or administrative API endpoints. We will 
 then rely on the API endpoint logic to refine their access based on the more fine-grained access scopes.
 
-In addition to the `readGeneral` scope, there is a `readPrivate` scope that is used to indicate that the user is allowed
-to read all of a compact's licensee data, so long as that licensee is within their compact or jurisdiction for which
-they have that permission.
+In addition to the `readGeneral` scope, there is a `readPrivate` scope, which can be granted at both compact and 
+jurisdiction levels. This permission indicates the user can read all of a compact's provider data (licenses and privileges),
+so long as the provider has at least one license or privilege within their jurisdiction or the user has compact-wide 
+permissions.
 
 To compliment each of the `write` and `admin` scopes, there will be at least one, more specific, scope, 
 to indicate _what_ within the compact they are allowed to write or administrate, respectively. In the case of `write` 

--- a/backend/compact-connect/docs/design/README.md
+++ b/backend/compact-connect/docs/design/README.md
@@ -95,7 +95,7 @@ their compact, so long as that user does not have permissions associated with a 
 
 Board ED level staff can have permission to read all generally available jurisdiction data, and if they have the 
 `readPrivate` permission they will be able to view all information for any licensee that has either a license or privilege
-within their jurisdiction. They can also write data to for their own jurisdiction, and to create more users that have 
+within their jurisdiction. They can also write data for their own jurisdiction, and create more users that have 
 permissions within their own jurisdiction. They can also delete any user within their jurisdiction, so long as that user
 does not have permissions associated with a different compact or jurisdiction.
 

--- a/backend/compact-connect/docs/design/README.md
+++ b/backend/compact-connect/docs/design/README.md
@@ -72,32 +72,49 @@ the accompanying [architecture diagram](./users-arch-diagram.pdf) for an illustr
 
 ### Staff Users
 
-Staff users come with a variety of different permissions, depending on their role. There are Compact Executive
-Directors, Compact ED Staff, Board Executive Directors, Board ED Staff, and CSG Admins, each with different levels
-of ability to read and write data, and to administrate users. Read permissions are granted to a user for an entire
-compact or not at all. Data writing and user administration permissions can each be granted to a user per
-compact/jurisdiction combination. All of a compact user's permissions are stored in a DynamoDB record that is associated
-with their own Cognito user id. That record will be used to generate scopes in the Oauth2 token issued to them on login.
-See [Implementation of scopes](#implementation-of-scopes) for a detailed explanation of the design for exactly how
-permissions will be represented by scopes in an access token. See
+Staff users will be granted a variety of different permissions, depending on their role. Read permissions are granted 
+to a user for an entire compact or not at all. Data writing and user administration permissions can each be granted to 
+a user per compact/jurisdiction combination. All of a compact user's permissions are stored in a DynamoDB record that is
+associated with their own Cognito user id. That record will be used to generate scopes in the Oauth2 token issued to them
+on login. See [Implementation of scopes](#implementation-of-scopes) for a detailed explanation of the design for exactly
+how permissions will be represented by scopes in an access token. See 
 [Implementation of permissions](#implementation-of-permissions) for a detailed explanation of the design for exactly
 how permissions are stored and translated into scopes.
 
-#### Compact Executive Directors and Staff
+#### Common Staff User Types
+The system permissions are designed around several common types of staff users. It is important to note that these user
+types are an abstraction which do not correlate directly to specific roles or access within the system. All access is
+controlled by the specific permissions associated with a user. Still, these abstractions are useful for understanding
+the system's design.
 
-Compact ED level staff can have permission to read all generally available data for any compact, and if they have the 
-`readPrivate` permission they will be able to view all data for any licensee within the compact. They will also be able
-to create and manage users and their permissions. They can grant other users the ability to write data for a particular
+##### Compact Executive Directors and Staff
+
+Compact ED level staff will typically be granted the following permissions at the compact level:
+
+- `admin` - grants access to administrative functions for the compact, such as creating and managing users and their
+  permissions.
+- `readPrivate` - grants access to view all data for any licensee within the compact.
+
+With the `admin` permission, they can grant other users the ability to write data for a particular
 jurisdiction and to create more users associated with a particular jurisdiction. They can also delete any user within 
-their compact, so long as that user does not have permissions associated with a different compact.
+their compact, so long as that user does not have permissions associated with a different compact, in which case the
+permissions from the other compact would have to be removed first.
 
-#### Board Executive Directors and Staff
+Users granted any of these permissions will also be implicitly granted the `readGeneral` scope for the associated compact,
+which allows them to read any licensee data within that compact that is not considered private.
 
-Board ED level staff can have permission to read all generally available jurisdiction data, and if they have the 
-`readPrivate` permission they will be able to view all information for any licensee that has either a license or privilege
-within their jurisdiction. They can also write data for their own jurisdiction, and create more users that have 
-permissions within their own jurisdiction. They can also delete any user within their jurisdiction, so long as that user
-does not have permissions associated with a different compact or jurisdiction.
+##### Board Executive Directors and Staff
+
+Board ED level staff may be granted the following permissions at a jurisdiction level:
+
+- `admin` - grants access to administrative functions for the jurisdiction, such as creating and managing users and 
+their permissions.
+- `write` - grants access to write data for their particular jurisdiction (ie uploading license information).
+- `readPrivate` - grants access to view all information for any licensee that has either a license or privilege
+within their jurisdiction. 
+
+Users granted any of these permissions will also be implicitly granted the `readGeneral` scope for the associated compact,
+which allows them to read any licensee data that is not considered private.
 
 #### Implementation of Scopes
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/license.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/license.py
@@ -14,21 +14,41 @@ from cc_common.data_model.schema.base_record import (
 )
 
 
-class LicensePublicSchema(ForgivingSchema):
-    """Schema for license data that can be shared with the public"""
+class LicenseReadGeneralSchema(ForgivingSchema):
+    """
+    License fields available for staff users with the 'readGeneral' permission.
 
-    birthMonthDay = String(required=False, allow_none=False, validate=Regexp('^[0-1]{1}[0-9]{1}-[0-3]{1}[0-9]{1}'))
+    This schema is explicitly separated from the common schema to ensure we know what
+    fields are being returned for users with this permission.
+    """
+
+    providerId = UUID(required=True, allow_none=False)
+    type = String(required=True, allow_none=False)
+    dateOfUpdate = DateTime(required=True, allow_none=False)
     compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
     jurisdiction = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
     licenseType = String(required=True, allow_none=False)
-    status = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
+    jurisdictionStatus = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
+    npi = String(required=False, allow_none=False, validate=Regexp('^[0-9]{10}$'))
     givenName = String(required=True, allow_none=False, validate=Length(1, 100))
     middleName = String(required=False, allow_none=False, validate=Length(1, 100))
     familyName = String(required=True, allow_none=False, validate=Length(1, 100))
     suffix = String(required=False, allow_none=False, validate=Length(1, 100))
+    # These date values are determined by the license records uploaded by a state
+    # they do not include a timestamp, so we use the Date field type
     dateOfIssuance = Date(required=True, allow_none=False)
     dateOfRenewal = Date(required=True, allow_none=False)
     dateOfExpiration = Date(required=True, allow_none=False)
+    homeAddressStreet1 = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressStreet2 = String(required=False, allow_none=False, validate=Length(1, 100))
+    homeAddressCity = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressState = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressPostalCode = String(required=True, allow_none=False, validate=Length(5, 7))
+    emailAddress = Email(required=False, allow_none=False, validate=Length(1, 100))
+    phoneNumber = ITUTE164PhoneNumber(required=False, allow_none=False)
+    status = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
+
+    militaryWaiver = Boolean(required=False, allow_none=False)
 
 
 class LicenseCommonSchema(ForgivingSchema):
@@ -131,40 +151,3 @@ class LicenseRecordSchema(CalculatedStatusRecordSchema, LicenseCommonSchema):
         in_data['pk'] = f'{in_data['compact']}#PROVIDER#{in_data['providerId']}'
         in_data['sk'] = f'{in_data['compact']}#PROVIDER#license/{in_data['jurisdiction']}#{in_data['dateOfRenewal']}'
         return in_data
-
-
-class LicenseGeneralResponseSchema(ForgivingSchema):
-    """
-    License fields available for staff users with the 'readGeneral' permission.
-
-    This schema includes all the fields of the common schema, but we explicitly separated them to ensure we know what
-    fields are being returned for users with this permission.
-    """
-
-    providerId = UUID(required=True, allow_none=False)
-    type = String(required=True, allow_none=False)
-    dateOfUpdate = DateTime(required=True, allow_none=False)
-    compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
-    jurisdiction = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
-    licenseType = String(required=True, allow_none=False)
-    jurisdictionStatus = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
-    npi = String(required=False, allow_none=False, validate=Regexp('^[0-9]{10}$'))
-    givenName = String(required=True, allow_none=False, validate=Length(1, 100))
-    middleName = String(required=False, allow_none=False, validate=Length(1, 100))
-    familyName = String(required=True, allow_none=False, validate=Length(1, 100))
-    suffix = String(required=False, allow_none=False, validate=Length(1, 100))
-    # These date values are determined by the license records uploaded by a state
-    # they do not include a timestamp, so we use the Date field type
-    dateOfIssuance = Date(required=True, allow_none=False)
-    dateOfRenewal = Date(required=True, allow_none=False)
-    dateOfExpiration = Date(required=True, allow_none=False)
-    homeAddressStreet1 = String(required=True, allow_none=False, validate=Length(2, 100))
-    homeAddressStreet2 = String(required=False, allow_none=False, validate=Length(1, 100))
-    homeAddressCity = String(required=True, allow_none=False, validate=Length(2, 100))
-    homeAddressState = String(required=True, allow_none=False, validate=Length(2, 100))
-    homeAddressPostalCode = String(required=True, allow_none=False, validate=Length(5, 7))
-    emailAddress = Email(required=False, allow_none=False, validate=Length(1, 100))
-    phoneNumber = ITUTE164PhoneNumber(required=False, allow_none=False)
-    status = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
-
-    militaryWaiver = Boolean(required=False, allow_none=False)

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/license.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/license.py
@@ -131,3 +131,41 @@ class LicenseRecordSchema(CalculatedStatusRecordSchema, LicenseCommonSchema):
         in_data['pk'] = f'{in_data['compact']}#PROVIDER#{in_data['providerId']}'
         in_data['sk'] = f'{in_data['compact']}#PROVIDER#license/{in_data['jurisdiction']}#{in_data['dateOfRenewal']}'
         return in_data
+
+
+class LicenseGeneralResponseSchema(ForgivingSchema):
+    """
+    License fields available for staff users with the 'readGeneral' permission.
+
+    This schema includes all the fields of the common schema, but we explicitly separated them to ensure we know what
+    fields are being returned for users with this permission.
+    """
+
+    providerId = UUID(required=True, allow_none=False)
+    type = String(required=True, allow_none=False)
+    dateOfUpdate = DateTime(required=True, allow_none=False)
+    compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
+    jurisdiction = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
+    licenseType = String(required=True, allow_none=False)
+    jurisdictionStatus = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
+    npi = String(required=False, allow_none=False, validate=Regexp('^[0-9]{10}$'))
+    givenName = String(required=True, allow_none=False, validate=Length(1, 100))
+    middleName = String(required=False, allow_none=False, validate=Length(1, 100))
+    familyName = String(required=True, allow_none=False, validate=Length(1, 100))
+    suffix = String(required=False, allow_none=False, validate=Length(1, 100))
+    # These date values are determined by the license records uploaded by a state
+    # they do not include a timestamp, so we use the Date field type
+    dateOfIssuance = Date(required=True, allow_none=False)
+    dateOfRenewal = Date(required=True, allow_none=False)
+    dateOfExpiration = Date(required=True, allow_none=False)
+    dateOfBirth = Date(required=True, allow_none=False)
+    homeAddressStreet1 = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressStreet2 = String(required=False, allow_none=False, validate=Length(1, 100))
+    homeAddressCity = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressState = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressPostalCode = String(required=True, allow_none=False, validate=Length(5, 7))
+    emailAddress = Email(required=False, allow_none=False, validate=Length(1, 100))
+    phoneNumber = ITUTE164PhoneNumber(required=False, allow_none=False)
+    status = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
+
+    militaryWaiver = Boolean(required=False, allow_none=False)

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/license.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/license.py
@@ -158,7 +158,6 @@ class LicenseGeneralResponseSchema(ForgivingSchema):
     dateOfIssuance = Date(required=True, allow_none=False)
     dateOfRenewal = Date(required=True, allow_none=False)
     dateOfExpiration = Date(required=True, allow_none=False)
-    dateOfBirth = Date(required=True, allow_none=False)
     homeAddressStreet1 = String(required=True, allow_none=False, validate=Length(2, 100))
     homeAddressStreet2 = String(required=False, allow_none=False, validate=Length(1, 100))
     homeAddressCity = String(required=True, allow_none=False, validate=Length(2, 100))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/military_affiliation.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/military_affiliation.py
@@ -68,3 +68,20 @@ class PostMilitaryAffiliationResponseSchema(ForgivingSchema):
     documentUploadFields = List(
         Nested(S3PresignedPostSchema(), required=True, allow_none=False), required=True, allow_none=False
     )
+
+
+class MilitaryAffiliationGeneralResponseSchema(ForgivingSchema):
+    """
+    Schema defining fields available to all staff users with the 'readGeneral' permission.
+    """
+
+    type = String(required=True, allow_none=False)
+    dateOfUpdate = DateTime(required=True, allow_none=False)
+    providerId = UUID(required=True, allow_none=False)
+    compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
+    fileNames = List(String(required=True, allow_none=False), required=True, allow_none=False)
+    affiliationType = String(
+        required=True, allow_none=False, validate=OneOf([e.value for e in MilitaryAffiliationType])
+    )
+    dateOfUpload = DateTime(required=True, allow_none=False)
+    status = String(required=True, allow_none=False, validate=OneOf([e.value for e in MilitaryAffiliationStatus]))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/privilege.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/privilege.py
@@ -5,7 +5,7 @@ from marshmallow.fields import UUID, Date, DateTime, String
 from marshmallow.validate import Length, OneOf
 
 from cc_common.config import config
-from cc_common.data_model.schema.base_record import BaseRecordSchema, CalculatedStatusRecordSchema
+from cc_common.data_model.schema.base_record import BaseRecordSchema, CalculatedStatusRecordSchema, ForgivingSchema
 from cc_common.data_model.schema.common import ensure_value_is_datetime
 
 
@@ -50,3 +50,18 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
         in_data['dateOfIssuance'] = ensure_value_is_datetime(in_data['dateOfIssuance'])
 
         return in_data
+
+
+class PrivilegeGeneralResponseSchema(ForgivingSchema):
+    type = String(required=True, allow_none=False)
+    dateOfUpdate = DateTime(required=True, allow_none=False)
+    providerId = UUID(required=True, allow_none=False)
+    compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
+    jurisdiction = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
+    dateOfIssuance = DateTime(required=True, allow_none=False)
+    dateOfRenewal = DateTime(required=True, allow_none=False)
+    # this is determined by the license expiration date, which is a date field, so this is also a date field
+    dateOfExpiration = Date(required=True, allow_none=False)
+    # the id of the transaction that was made when the user purchased the privilege
+    compactTransactionId = String(required=False, allow_none=False)
+    status = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
@@ -115,6 +115,9 @@ class SanitizedProviderReadGeneralSchema(ForgivingSchema):
     """
     Provider record fields that are sanitized for users with the 'readGeneral' permission.
 
+    This schema is intended to be used to dump records from the database in order to remove all fields not defined here.
+    It should NEVER be used to load data into the database. Use the ProviderRecordSchema for that.
+
     This schema should be used by any endpoint that returns provider information to staff users (ie the query provider
     and GET provider endpoints).
     """

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
@@ -110,6 +110,7 @@ class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPrivateSchema):
         del in_data['providerFamGivMid']
         return in_data
 
+
 class SanitizedProviderReadGeneralSchema(ForgivingSchema):
     """
     Provider record fields that are sanitized for users with the 'readGeneral' permission.
@@ -117,6 +118,7 @@ class SanitizedProviderReadGeneralSchema(ForgivingSchema):
     This schema should be used by any endpoint that returns provider information to staff users (ie the query provider
     and GET provider endpoints).
     """
+
     providerId = UUID(required=True, allow_none=False)
     type = String(required=True, allow_none=False)
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
@@ -110,10 +110,12 @@ class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPrivateSchema):
         del in_data['providerFamGivMid']
         return in_data
 
+
 class CommonProviderGeneralResponseSchema(ForgivingSchema):
     """
     Common Provider record fields that are available to view for users with the 'readGeneral' permission.
     """
+
     providerId = UUID(required=True, allow_none=False)
     type = String(required=True, allow_none=False)
 
@@ -146,10 +148,12 @@ class CommonProviderGeneralResponseSchema(ForgivingSchema):
     providerDateOfUpdate = DateTime(required=True, allow_none=False)
     birthMonthDay = String(required=False, allow_none=False, validate=Regexp('^[0-1]{1}[0-9]{1}-[0-3]{1}[0-9]{1}'))
 
+
 class QueryProvidersGeneralResponseSchema(CommonProviderGeneralResponseSchema):
     """
     Provider record fields that are returned from query endpoint for users with the 'readGeneral' permission.
     """
+
 
 class GetProviderReadGeneralResponseSchema(CommonProviderGeneralResponseSchema):
     """
@@ -158,6 +162,7 @@ class GetProviderReadGeneralResponseSchema(CommonProviderGeneralResponseSchema):
     This schema should be used by any endpoint that returns provider information to staff users (ie the query provider
     and GET provider endpoints).
     """
+
     licenses = List(Nested(LicenseGeneralResponseSchema(), required=True, allow_none=False))
     privileges = List(Nested(PrivilegeGeneralResponseSchema(), required=True, allow_none=False))
     militaryAffiliations = List(Nested(MilitaryAffiliationGeneralResponseSchema(), required=True, allow_none=False))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
@@ -2,7 +2,7 @@
 from urllib.parse import quote
 
 from marshmallow import ValidationError, post_load, pre_dump, pre_load, validates_schema
-from marshmallow.fields import UUID, Boolean, Date, DateTime, Email, String
+from marshmallow.fields import UUID, Boolean, Date, DateTime, Email, List, Nested, String
 from marshmallow.validate import Length, OneOf, Regexp
 
 from cc_common.config import config
@@ -15,10 +15,14 @@ from cc_common.data_model.schema.base_record import (
     SocialSecurityNumber,
 )
 from cc_common.data_model.schema.common import ensure_value_is_datetime
+from cc_common.data_model.schema.license import LicenseGeneralResponseSchema
+from cc_common.data_model.schema.military_affiliation import MilitaryAffiliationGeneralResponseSchema
+from cc_common.data_model.schema.privilege import PrivilegeGeneralResponseSchema
 
 
-class ProviderPublicSchema(ForgivingSchema):
-    """Schema for license data that can be shared with the public"""
+class ProviderPrivateSchema(ForgivingSchema):
+    """Schema for provider data that can be shared with the staff users with the appropriate permissions, as well as
+    the provider themselves"""
 
     # Provided fields
     providerId = UUID(required=True, allow_none=False)
@@ -57,7 +61,7 @@ class ProviderPublicSchema(ForgivingSchema):
 
 
 @BaseRecordSchema.register_schema('provider')
-class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPublicSchema):
+class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPrivateSchema):
     """Schema for license records in the license data table"""
 
     _record_type = 'provider'
@@ -105,3 +109,49 @@ class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPublicSchema):
     def drop_fam_giv_mid(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
         del in_data['providerFamGivMid']
         return in_data
+
+
+class ProviderReadGeneralResponseSchema(ForgivingSchema):
+    """
+    Provider record fields that are available to view for users with the 'readGeneral' permission.
+
+    This schema should be used by any endpoint that returns provider information to staff users (ie the query provider
+    and GET provider endpoints).
+    """
+
+    providerId = UUID(required=True, allow_none=False)
+    type = String(required=True, allow_none=False)
+
+    dateOfUpdate = DateTime(required=True, allow_none=False)
+    compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
+    licenseJurisdiction = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
+    npi = String(required=False, allow_none=False, validate=Regexp('^[0-9]{10}$'))
+    licenseType = String(required=True, allow_none=False)
+    jurisdictionStatus = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
+    givenName = String(required=True, allow_none=False, validate=Length(1, 100))
+    middleName = String(required=False, allow_none=False, validate=Length(1, 100))
+    familyName = String(required=True, allow_none=False, validate=Length(1, 100))
+    suffix = String(required=False, allow_none=False, validate=Length(1, 100))
+    # these dates are determined by the license records uploaded by a state
+    # they do not include a timestamp, so we use the Date field type
+    dateOfExpiration = Date(required=True, allow_none=False)
+    dateOfBirth = Date(required=True, allow_none=False)
+    homeAddressStreet1 = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressStreet2 = String(required=False, allow_none=False, validate=Length(1, 100))
+    homeAddressCity = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressState = String(required=True, allow_none=False, validate=Length(2, 100))
+    homeAddressPostalCode = String(required=True, allow_none=False, validate=Length(5, 7))
+    emailAddress = Email(required=False, allow_none=False, validate=Length(1, 100))
+    phoneNumber = ITUTE164PhoneNumber(required=False, allow_none=False)
+    status = String(required=True, allow_none=False, validate=OneOf(['active', 'inactive']))
+    militaryWaiver = Boolean(required=False, allow_none=False)
+
+    privilegeJurisdictions = Set(String, required=False, allow_none=False, load_default=set())
+    providerFamGivMid = String(required=False, allow_none=False, validate=Length(2, 400))
+    providerDateOfUpdate = DateTime(required=True, allow_none=False)
+    birthMonthDay = String(required=False, allow_none=False, validate=Regexp('^[0-1]{1}[0-9]{1}-[0-3]{1}[0-9]{1}'))
+
+    # license readGeneralSchema
+    licenses = List(Nested(LicenseGeneralResponseSchema(), required=True, allow_none=False))
+    privileges = List(Nested(PrivilegeGeneralResponseSchema(), required=True, allow_none=False))
+    militaryAffiliations = List(Nested(MilitaryAffiliationGeneralResponseSchema(), required=True, allow_none=False))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
@@ -110,12 +110,13 @@ class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPrivateSchema):
         del in_data['providerFamGivMid']
         return in_data
 
-
-class CommonProviderGeneralResponseSchema(ForgivingSchema):
+class SanitizedProviderReadGeneralSchema(ForgivingSchema):
     """
-    Common Provider record fields that are available to view for users with the 'readGeneral' permission.
-    """
+    Provider record fields that are sanitized for users with the 'readGeneral' permission.
 
+    This schema should be used by any endpoint that returns provider information to staff users (ie the query provider
+    and GET provider endpoints).
+    """
     providerId = UUID(required=True, allow_none=False)
     type = String(required=True, allow_none=False)
 
@@ -129,10 +130,9 @@ class CommonProviderGeneralResponseSchema(ForgivingSchema):
     middleName = String(required=False, allow_none=False, validate=Length(1, 100))
     familyName = String(required=True, allow_none=False, validate=Length(1, 100))
     suffix = String(required=False, allow_none=False, validate=Length(1, 100))
-    # these dates are determined by the license records uploaded by a state
+    # This date is determined by the license records uploaded by a state
     # they do not include a timestamp, so we use the Date field type
     dateOfExpiration = Date(required=True, allow_none=False)
-    dateOfBirth = Date(required=True, allow_none=False)
     homeAddressStreet1 = String(required=True, allow_none=False, validate=Length(2, 100))
     homeAddressStreet2 = String(required=False, allow_none=False, validate=Length(1, 100))
     homeAddressCity = String(required=True, allow_none=False, validate=Length(2, 100))
@@ -145,24 +145,11 @@ class CommonProviderGeneralResponseSchema(ForgivingSchema):
 
     privilegeJurisdictions = Set(String, required=False, allow_none=False, load_default=set())
     providerFamGivMid = String(required=False, allow_none=False, validate=Length(2, 400))
-    providerDateOfUpdate = DateTime(required=True, allow_none=False)
+    providerDateOfUpdate = DateTime(required=False, allow_none=False)
     birthMonthDay = String(required=False, allow_none=False, validate=Regexp('^[0-1]{1}[0-9]{1}-[0-3]{1}[0-9]{1}'))
 
-
-class QueryProvidersGeneralResponseSchema(CommonProviderGeneralResponseSchema):
-    """
-    Provider record fields that are returned from query endpoint for users with the 'readGeneral' permission.
-    """
-
-
-class GetProviderReadGeneralResponseSchema(CommonProviderGeneralResponseSchema):
-    """
-    Provider record fields that are available to view for users with the 'readGeneral' permission.
-
-    This schema should be used by any endpoint that returns provider information to staff users (ie the query provider
-    and GET provider endpoints).
-    """
-
-    licenses = List(Nested(LicenseGeneralResponseSchema(), required=True, allow_none=False))
-    privileges = List(Nested(PrivilegeGeneralResponseSchema(), required=True, allow_none=False))
-    militaryAffiliations = List(Nested(MilitaryAffiliationGeneralResponseSchema(), required=True, allow_none=False))
+    # these records are present when getting provider information from the GET endpoint
+    # so we check for them here and sanitize them if they are present
+    licenses = List(Nested(LicenseGeneralResponseSchema(), required=False, allow_none=False))
+    privileges = List(Nested(PrivilegeGeneralResponseSchema(), required=False, allow_none=False))
+    militaryAffiliations = List(Nested(MilitaryAffiliationGeneralResponseSchema(), required=False, allow_none=False))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
@@ -15,7 +15,7 @@ from cc_common.data_model.schema.base_record import (
     SocialSecurityNumber,
 )
 from cc_common.data_model.schema.common import ensure_value_is_datetime
-from cc_common.data_model.schema.license import LicenseGeneralResponseSchema
+from cc_common.data_model.schema.license import LicenseReadGeneralSchema
 from cc_common.data_model.schema.military_affiliation import MilitaryAffiliationGeneralResponseSchema
 from cc_common.data_model.schema.privilege import PrivilegeGeneralResponseSchema
 
@@ -152,6 +152,6 @@ class SanitizedProviderReadGeneralSchema(ForgivingSchema):
 
     # these records are present when getting provider information from the GET endpoint
     # so we check for them here and sanitize them if they are present
-    licenses = List(Nested(LicenseGeneralResponseSchema(), required=False, allow_none=False))
+    licenses = List(Nested(LicenseReadGeneralSchema(), required=False, allow_none=False))
     privileges = List(Nested(PrivilegeGeneralResponseSchema(), required=False, allow_none=False))
     militaryAffiliations = List(Nested(MilitaryAffiliationGeneralResponseSchema(), required=False, allow_none=False))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
@@ -111,7 +111,7 @@ class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPrivateSchema):
         return in_data
 
 
-class ProviderReadGeneralResponseSchema(ForgivingSchema):
+class GetProviderReadGeneralResponseSchema(ForgivingSchema):
     """
     Provider record fields that are available to view for users with the 'readGeneral' permission.
 
@@ -151,7 +151,6 @@ class ProviderReadGeneralResponseSchema(ForgivingSchema):
     providerDateOfUpdate = DateTime(required=True, allow_none=False)
     birthMonthDay = String(required=False, allow_none=False, validate=Regexp('^[0-1]{1}[0-9]{1}-[0-3]{1}[0-9]{1}'))
 
-    # license readGeneralSchema
     licenses = List(Nested(LicenseGeneralResponseSchema(), required=True, allow_none=False))
     privileges = List(Nested(PrivilegeGeneralResponseSchema(), required=True, allow_none=False))
     militaryAffiliations = List(Nested(MilitaryAffiliationGeneralResponseSchema(), required=True, allow_none=False))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider.py
@@ -110,15 +110,10 @@ class ProviderRecordSchema(CalculatedStatusRecordSchema, ProviderPrivateSchema):
         del in_data['providerFamGivMid']
         return in_data
 
-
-class GetProviderReadGeneralResponseSchema(ForgivingSchema):
+class CommonProviderGeneralResponseSchema(ForgivingSchema):
     """
-    Provider record fields that are available to view for users with the 'readGeneral' permission.
-
-    This schema should be used by any endpoint that returns provider information to staff users (ie the query provider
-    and GET provider endpoints).
+    Common Provider record fields that are available to view for users with the 'readGeneral' permission.
     """
-
     providerId = UUID(required=True, allow_none=False)
     type = String(required=True, allow_none=False)
 
@@ -151,6 +146,18 @@ class GetProviderReadGeneralResponseSchema(ForgivingSchema):
     providerDateOfUpdate = DateTime(required=True, allow_none=False)
     birthMonthDay = String(required=False, allow_none=False, validate=Regexp('^[0-1]{1}[0-9]{1}-[0-3]{1}[0-9]{1}'))
 
+class QueryProvidersGeneralResponseSchema(CommonProviderGeneralResponseSchema):
+    """
+    Provider record fields that are returned from query endpoint for users with the 'readGeneral' permission.
+    """
+
+class GetProviderReadGeneralResponseSchema(CommonProviderGeneralResponseSchema):
+    """
+    Provider record fields that are available to view for users with the 'readGeneral' permission.
+
+    This schema should be used by any endpoint that returns provider information to staff users (ie the query provider
+    and GET provider endpoints).
+    """
     licenses = List(Nested(LicenseGeneralResponseSchema(), required=True, allow_none=False))
     privileges = List(Nested(PrivilegeGeneralResponseSchema(), required=True, allow_none=False))
     militaryAffiliations = List(Nested(MilitaryAffiliationGeneralResponseSchema(), required=True, allow_none=False))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/user_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/user_client.py
@@ -96,10 +96,10 @@ class UserClient:
         ```json
         {
           "permissions": {
-            "actions": { "admin" }
+            "actions": { "admin", "readPrivate" },
             "jurisdictions": {
               "oh": {
-                "actions": { "admin", "write" }
+                "actions": { "admin", "write", "readPrivate" }
               }
             }
           }

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -391,3 +391,13 @@ def get_sub_from_user_attributes(attributes: list):
         if attribute['Name'] == 'sub':
             return attribute['Value']
     raise ValueError('Failed to find user sub!')
+
+
+def get_scopes_list_from_event(event: dict) -> list[str]:
+    """
+    Get the scopes from the event object and return them as a list.
+
+    :param dict event: The event object passed to the lambda function.
+    :return: The scopes from the event object.
+    """
+    return event['requestContext']['authorizer']['claims']['scope'].split(' ')

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from botocore.exceptions import ClientError
+
 from cc_common.config import logger
 from cc_common.data_model.schema.provider import SanitizedProviderReadGeneralSchema
 from cc_common.exceptions import (
@@ -434,11 +435,15 @@ def _user_has_private_read_access_for_provider(compact: str, provider_informatio
 
 def sanitize_provider_data_based_on_caller_scopes(compact: str, provider: dict, scopes: set[str]) -> dict:
     """
-    Take a provider and a set of user scopes, then return a provider, with information sanitized, based on what the user is authorized to view.
+    Take a provider and a set of user scopes, then return a provider, with information sanitized based on what
+    the user is authorized to view.
+
+    :param str compact: The compact the user is trying to access.
+    :param dict provider: The provider record to be sanitized.
+    :param set scopes: The user's scopes from the request.
+    :return: The provider record, sanitized based on the user's scopes.
     """
-    if _user_has_private_read_access_for_provider(
-        compact=compact, provider_information=provider, scopes=scopes
-    ):
+    if _user_has_private_read_access_for_provider(compact=compact, provider_information=provider, scopes=scopes):
         # return full object since caller has 'readPrivate' access for provider
         return provider
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -345,6 +345,13 @@ def collect_and_authorize_changes(*, path_compact: str, scopes: set, compact_cha
     for action, value in compact_changes.get('actions', {}).items():
         if action == 'admin' and f'{path_compact}/{path_compact}.admin' not in scopes:
             raise CCAccessDeniedException('Only compact admins can affect compact-level admin permissions')
+        if action == 'readPrivate' and f'{path_compact}/{path_compact}.admin' not in scopes:
+            raise CCAccessDeniedException('Only compact admins can affect compact-level access to private information')
+
+        # dropping the read action as this is now implicitly granted to all users
+        if action == 'read':
+            logger.info('Dropping "read" action as this is implicitly granted to all users')
+            continue
         # Any admin in the compact can affect read permissions, so no read-specific check is necessary here
         if value:
             compact_action_additions.add(action)
@@ -360,6 +367,11 @@ def collect_and_authorize_changes(*, path_compact: str, scopes: set, compact_cha
             )
 
         for action, value in jurisdiction_changes.get('actions', {}).items():
+            # dropping the read action as this is now implicitly granted to all users
+            if action == 'read':
+                logger.info('Dropping "read" action as this is implicitly granted to all users')
+                continue
+
             if value:
                 jurisdiction_action_additions.setdefault(jurisdiction, set()).add(action)
             else:

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -120,7 +120,7 @@ def api_handler(fn: Callable):
 
 
 class authorize_compact:  # noqa: N801 invalid-name
-    """Authorize endpoint by matching path parameter compact to the expected scope, (i.e. aslp/read)"""
+    """Authorize endpoint by matching path parameter compact to the expected scope, (i.e. aslp/readGeneral)"""
 
     def __init__(self, action: str):
         super().__init__()
@@ -165,8 +165,9 @@ def _authorize_compact_with_scope(event: dict, resource_parameter: str, scope_pa
     For each of these actions, specific rules apply to the scope required to perform the action, which are
     as follows:
 
-    Read - granted at compact level, allows read access to all jurisdictions within the compact.
-    i.e. aslp/read would allow read access to all jurisdictions within the aslp compact.
+    ReadGeneral - granted at compact level, allows read access to all generally available (not private) jurisdiction
+    data within the compact.
+    i.e. aslp/readGeneral would allow read access to all generally available jurisdiction data within the aslp compact.
 
     Write - granted at jurisdiction level, allows write access to a specific jurisdiction within the compact.
     i.e. aslp/oh.write would allow write access to the ohio jurisdiction within the aslp compact.

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -310,6 +310,12 @@ def get_allowed_jurisdictions(*, compact: str, scopes: set[str]) -> list[str] | 
 
 
 def get_event_scopes(event: dict):
+    """
+    Get the scopes from the event object and return them as a list.
+
+    :param dict event: The event object passed to the lambda function.
+    :return: The scopes from the event object.
+    """
     return set(event['requestContext']['authorizer']['claims']['scope'].split(' '))
 
 
@@ -391,13 +397,3 @@ def get_sub_from_user_attributes(attributes: list):
         if attribute['Name'] == 'sub':
             return attribute['Value']
     raise ValueError('Failed to find user sub!')
-
-
-def get_scopes_list_from_event(event: dict) -> list[str]:
-    """
-    Get the scopes from the event object and return them as a list.
-
-    :param dict event: The event object passed to the lambda function.
-    :return: The scopes from the event object.
-    """
-    return event['requestContext']['authorizer']['claims']['scope'].split(' ')

--- a/backend/compact-connect/lambdas/python/common/tests/resources/api/provider-response.json
+++ b/backend/compact-connect/lambdas/python/common/tests/resources/api/provider-response.json
@@ -1,7 +1,6 @@
 {
   "type": "provider",
   "providerId": "89a6377e-c3a5-40e5-bca5-317ec854c570",
-  "ssn": "123-12-1234",
   "npi": "0608337260",
   "givenName": "Björk",
   "middleName": "Gunnar",
@@ -20,7 +19,6 @@
   "militaryWaiver": false,
   "emailAddress": "björk@example.com",
   "phoneNumber": "+13213214321",
-  "dateOfBirth": "2024-06-06",
   "dateOfUpdate": "2024-07-08T23:59:59+00:00",
   "dateOfExpiration": "2050-06-06",
   "birthMonthDay": "06-06"

--- a/backend/compact-connect/lambdas/python/common/tests/unit/test_authorize_compact_jurisdiction.py
+++ b/backend/compact-connect/lambdas/python/common/tests/unit/test_authorize_compact_jurisdiction.py
@@ -83,14 +83,14 @@ class TestAuthorizeCompact(TstLambdas):
     def test_authorize_compact(self):
         from cc_common.utils import authorize_compact
 
-        @authorize_compact(action='read')
+        @authorize_compact(action='readGeneral')
         def example_entrypoint(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
             return {'body': 'Hurray!'}
 
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
 
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
         event['pathParameters'] = {
             'compact': 'aslp',
         }
@@ -101,13 +101,13 @@ class TestAuthorizeCompact(TstLambdas):
         from cc_common.exceptions import CCInvalidRequestException
         from cc_common.utils import authorize_compact
 
-        @authorize_compact(action='read')
+        @authorize_compact(action='readGeneral')
         def example_entrypoint(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
             return {'body': 'Hurray!'}
 
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
         event['pathParameters'] = {}
 
         with self.assertRaises(CCInvalidRequestException):
@@ -117,7 +117,7 @@ class TestAuthorizeCompact(TstLambdas):
         from cc_common.exceptions import CCUnauthorizedException
         from cc_common.utils import authorize_compact
 
-        @authorize_compact(action='read')
+        @authorize_compact(action='readGeneral')
         def example_entrypoint(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
             return {'body': 'Hurray!'}
 
@@ -133,7 +133,7 @@ class TestAuthorizeCompact(TstLambdas):
         from cc_common.exceptions import CCAccessDeniedException
         from cc_common.utils import authorize_compact
 
-        @authorize_compact(action='read')
+        @authorize_compact(action='readGeneral')
         def example_entrypoint(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
             return {'body': 'Hurray!'}
 

--- a/backend/compact-connect/lambdas/python/common/tests/unit/test_sanitize_provider_data.py
+++ b/backend/compact-connect/lambdas/python/common/tests/unit/test_sanitize_provider_data.py
@@ -1,37 +1,39 @@
 import json
+
 from tests import TstLambdas
 
 
 class TestSanitizeProviderData(TstLambdas):
-
     def when_expecting_full_provider_record_returned(self, scopes: set[str]):
         from cc_common.utils import sanitize_provider_data_based_on_caller_scopes
+
         with open('tests/resources/api/provider-detail-response.json') as f:
             expected_provider = json.load(f)
 
         test_provider = expected_provider.copy()
 
-        resp = sanitize_provider_data_based_on_caller_scopes(compact='aslp', provider=test_provider,
-                                                             scopes=scopes)
+        resp = sanitize_provider_data_based_on_caller_scopes(compact='aslp', provider=test_provider, scopes=scopes)
 
         self.assertEqual(resp, expected_provider)
 
     def test_full_provider_record_returned_if_caller_has_compact_read_private_permissions(self):
-        self.when_expecting_full_provider_record_returned(scopes={'openid', 'email', 'aslp/readGeneral',
-                                                              'aslp/aslp.readPrivate'})
+        self.when_expecting_full_provider_record_returned(
+            scopes={'openid', 'email', 'aslp/readGeneral', 'aslp/aslp.readPrivate'}
+        )
 
     def test_full_provider_record_returned_if_caller_has_read_private_permissions_for_license_jurisdiction(self):
-        self.when_expecting_full_provider_record_returned(scopes={'openid', 'email', 'aslp/readGeneral',
-                                                              'aslp/oh.readPrivate'})
+        self.when_expecting_full_provider_record_returned(
+            scopes={'openid', 'email', 'aslp/readGeneral', 'aslp/oh.readPrivate'}
+        )
 
     def test_full_provider_record_returned_if_caller_has_read_private_permissions_for_privileges_jurisdiction(self):
-        self.when_expecting_full_provider_record_returned(scopes={'openid', 'email', 'aslp/readGeneral',
-                                                              'aslp/ne.readPrivate'})
-
+        self.when_expecting_full_provider_record_returned(
+            scopes={'openid', 'email', 'aslp/readGeneral', 'aslp/ne.readPrivate'}
+        )
 
     def when_testing_general_provider_info_returned(self, scopes: set[str]):
-        from cc_common.utils import sanitize_provider_data_based_on_caller_scopes
         from cc_common.data_model.schema.provider import SanitizedProviderReadGeneralSchema
+        from cc_common.utils import sanitize_provider_data_based_on_caller_scopes
 
         with open('tests/resources/api/provider-detail-response.json') as f:
             full_provider = json.load(f)
@@ -48,8 +50,7 @@ class TestSanitizeProviderData(TstLambdas):
             loaded_provider['licenses'][0]['dateOfBirth'] = mock_dob
 
         # test provider has a license in oh and privilege in ne
-        resp = sanitize_provider_data_based_on_caller_scopes(compact='aslp', provider=loaded_provider,
-                                                             scopes=scopes)
+        resp = sanitize_provider_data_based_on_caller_scopes(compact='aslp', provider=loaded_provider, scopes=scopes)
 
         # now create expected provider record with the ssn and dob removed
         expected_provider.pop('ssn')
@@ -64,11 +65,10 @@ class TestSanitizeProviderData(TstLambdas):
 
         self.assertEqual(expected_provider, resp)
 
-
     def test_sanitized_provider_record_returned_if_caller_does_not_have_read_private_permissions_for_jurisdiction(self):
-        self.when_testing_general_provider_info_returned(scopes={'openid', 'email', 'aslp/readGeneral',
-                                                                     'aslp/az.readPrivate'})
+        self.when_testing_general_provider_info_returned(
+            scopes={'openid', 'email', 'aslp/readGeneral', 'aslp/az.readPrivate'}
+        )
 
     def test_sanitized_provider_record_returned_if_caller_does_not_have_any_read_private_permissions(self):
         self.when_testing_general_provider_info_returned(scopes={'openid', 'email', 'aslp/readGeneral'})
-

--- a/backend/compact-connect/lambdas/python/common/tests/unit/test_sanitize_provider_data.py
+++ b/backend/compact-connect/lambdas/python/common/tests/unit/test_sanitize_provider_data.py
@@ -1,0 +1,74 @@
+import json
+from tests import TstLambdas
+
+
+class TestSanitizeProviderData(TstLambdas):
+
+    def when_expecting_full_provider_record_returned(self, scopes: set[str]):
+        from cc_common.utils import sanitize_provider_data_based_on_caller_scopes
+        with open('tests/resources/api/provider-detail-response.json') as f:
+            expected_provider = json.load(f)
+
+        test_provider = expected_provider.copy()
+
+        resp = sanitize_provider_data_based_on_caller_scopes(compact='aslp', provider=test_provider,
+                                                             scopes=scopes)
+
+        self.assertEqual(resp, expected_provider)
+
+    def test_full_provider_record_returned_if_caller_has_compact_read_private_permissions(self):
+        self.when_expecting_full_provider_record_returned(scopes={'openid', 'email', 'aslp/readGeneral',
+                                                              'aslp/aslp.readPrivate'})
+
+    def test_full_provider_record_returned_if_caller_has_read_private_permissions_for_license_jurisdiction(self):
+        self.when_expecting_full_provider_record_returned(scopes={'openid', 'email', 'aslp/readGeneral',
+                                                              'aslp/oh.readPrivate'})
+
+    def test_full_provider_record_returned_if_caller_has_read_private_permissions_for_privileges_jurisdiction(self):
+        self.when_expecting_full_provider_record_returned(scopes={'openid', 'email', 'aslp/readGeneral',
+                                                              'aslp/ne.readPrivate'})
+
+
+    def when_testing_general_provider_info_returned(self, scopes: set[str]):
+        from cc_common.utils import sanitize_provider_data_based_on_caller_scopes
+        from cc_common.data_model.schema.provider import SanitizedProviderReadGeneralSchema
+
+        with open('tests/resources/api/provider-detail-response.json') as f:
+            full_provider = json.load(f)
+            expected_provider = full_provider.copy()
+            mock_ssn = full_provider['ssn']
+            mock_dob = full_provider['dateOfBirth']
+            mock_doc_keys = full_provider['militaryAffiliations'][0]['documentKeys']
+            # simplest way to set up mock test user as returned from the db
+            loaded_provider = SanitizedProviderReadGeneralSchema().load(full_provider)
+            loaded_provider['ssn'] = mock_ssn
+            loaded_provider['dateOfBirth'] = mock_dob
+            loaded_provider['militaryAffiliations'][0]['documentKeys'] = mock_doc_keys
+            loaded_provider['licenses'][0]['ssn'] = mock_ssn
+            loaded_provider['licenses'][0]['dateOfBirth'] = mock_dob
+
+        # test provider has a license in oh and privilege in ne
+        resp = sanitize_provider_data_based_on_caller_scopes(compact='aslp', provider=loaded_provider,
+                                                             scopes=scopes)
+
+        # now create expected provider record with the ssn and dob removed
+        expected_provider.pop('ssn')
+        expected_provider.pop('dateOfBirth')
+        # we do not return the military affiliation document keys if the caller does not have read private scope
+        expected_provider['militaryAffiliations'][0].pop('documentKeys')
+        # also remove the ssn from the license record
+        expected_provider['licenses'][0].pop('ssn')
+        expected_provider['licenses'][0].pop('dateOfBirth')
+        # cast to set to match schema
+        expected_provider['privilegeJurisdictions'] = set(expected_provider['privilegeJurisdictions'])
+
+        self.assertEqual(expected_provider, resp)
+
+
+    def test_sanitized_provider_record_returned_if_caller_does_not_have_read_private_permissions_for_jurisdiction(self):
+        self.when_testing_general_provider_info_returned(scopes={'openid', 'email', 'aslp/readGeneral',
+                                                                     'aslp/az.readPrivate'})
+
+    def test_sanitized_provider_record_returned_if_caller_does_not_have_any_read_private_permissions(self):
+        self.when_testing_general_provider_info_returned(scopes={'openid', 'email', 'aslp/readGeneral'})
+

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/bulk_upload.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/bulk_upload.py
@@ -7,7 +7,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from botocore.exceptions import ClientError
 from botocore.response import StreamingBody
 from cc_common.config import config, logger
-from cc_common.data_model.schema.license import LicensePostSchema, LicensePublicSchema
+from cc_common.data_model.schema.license import LicensePostSchema, LicenseReadGeneralSchema
 from cc_common.exceptions import CCInternalException
 from cc_common.utils import ResponseEncoder, api_handler, authorize_compact_jurisdiction
 from event_batch_writer import EventBatchWriter
@@ -114,7 +114,7 @@ def process_bulk_upload_file(
     """
     Stream each line of the new CSV file, validating it then publishing an ingest event for each line.
     """
-    public_schema = LicensePublicSchema()
+    general_schema = LicenseReadGeneralSchema()
     schema = LicensePostSchema()
     reader = LicenseCSVReader()
 
@@ -127,16 +127,16 @@ def process_bulk_upload_file(
             except ValidationError as e:
                 # This CSV line has failed validation. We will carefully collect what information we can
                 # and publish it as a failure event. Because this data may eventually be sent back over
-                # an email, we will only include the public values that we can still validate.
+                # an email, we will only include the generally available values that we can still validate.
                 try:
-                    public_license_data = public_schema.load(raw_license)
+                    general_license_data = general_schema.load(raw_license)
                 except ValidationError as exc_second_try:
-                    public_license_data = exc_second_try.valid_data
+                    general_license_data = exc_second_try.valid_data
                 logger.info(
                     'Invalid license in line %s uploaded: %s',
                     i + 1,
                     str(e),
-                    valid_data=public_license_data,
+                    valid_data=general_license_data,
                     exc_info=e,
                 )
                 event_writer.put_event(
@@ -149,7 +149,7 @@ def process_bulk_upload_file(
                                 'compact': compact,
                                 'jurisdiction': jurisdiction,
                                 'recordNumber': i + 1,
-                                'validData': public_license_data,
+                                'validData': general_license_data,
                                 'errors': e.messages,
                             },
                             cls=ResponseEncoder,

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
@@ -9,7 +9,7 @@ from . import get_provider_information
 
 
 @api_handler
-@authorize_compact(action='read')
+@authorize_compact(action='readGeneral')
 def query_providers(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
     """Query providers data
     :param event: Standard API Gateway event, API schema documented in the CDK ApiStack
@@ -90,7 +90,7 @@ def query_providers(event: dict, context: LambdaContext):  # noqa: ARG001 unused
 
 
 @api_handler
-@authorize_compact(action='read')
+@authorize_compact(action='readGeneral')
 def get_provider(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
     """Return one provider's data
     :param event: Standard API Gateway event, API schema documented in the CDK ApiStack

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
@@ -2,10 +2,67 @@ import json
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from cc_common.config import config, logger
+from cc_common.data_model.schema.provider import ProviderReadGeneralResponseSchema
 from cc_common.exceptions import CCInvalidRequestException
-from cc_common.utils import api_handler, authorize_compact
+from cc_common.utils import api_handler, authorize_compact, get_scopes_list_from_event
 
 from . import get_provider_information
+
+
+def _filter_provider_record_based_on_caller_read_level_for_provider(
+    compact: str, provider_information: dict, scopes: list[str]
+) -> dict:
+    """Returns a provider record with private information removed if the caller does not have the relevant 'readPrivate'
+     action.
+
+    If a provider has either a license record or a privilege record that matches the jurisdiction of the caller's
+    'readPrivate' action, the full provider record is returned. Otherwise, the provider record is filtered to remove
+    private information.
+
+    caller can view the private information of the provider.
+    :param str compact: The compact the user is trying to access.
+    :param dict provider_information: The provider record to filter.
+    :param set scopes: The caller's scopes from the request.
+    :return: The provider record with private information removed if the caller does not have the relevant 'readPrivate'
+        action.
+    :rtype: dict
+    """
+
+    # if the caller has 'readPrivate' at the compact level, they can view the private information
+    if f'{compact}/{compact}.readPrivate' in scopes:
+        logger.info(
+            'User has readPrivate permission at compact level',
+            compact=compact,
+            provider_id=provider_information['providerId'],
+        )
+        return provider_information
+
+    provider_license_jurisdictions = [
+        license_record['jurisdiction'] for license_record in provider_information.get('licenses', [])
+    ]
+    provider_privilege_jurisdictions = [
+        privilege_record['jurisdiction'] for privilege_record in provider_information.get('privileges', [])
+    ]
+    provider_jurisdictions = set(provider_license_jurisdictions + provider_privilege_jurisdictions)
+    for jurisdiction in provider_jurisdictions:
+        if f'{compact}/{jurisdiction}.readPrivate' in scopes:
+            logger.info(
+                'User has readPrivate permission at matching jurisdiction level',
+                compact=compact,
+                caller_jurisdiction_scope=f'{compact}/{jurisdiction}.readPrivate',
+                provider_id=provider_information['providerId'],
+                provider_jurisdictions=provider_jurisdictions,
+            )
+            # user has 'readPrivate' at matching jurisdiction level, they can view all information for provider.
+            return provider_information
+
+    logger.debug(
+        'Caller does not have readPrivate at compact or jurisdiction level, removing private information',
+        provider_id=provider_information['providerId'],
+    )
+    provider_read_general_schema = ProviderReadGeneralResponseSchema()
+    # we dump the record to ensure that the schema is applied to the record to remove private fields
+    return provider_read_general_schema.dump(provider_information)
 
 
 @api_handler
@@ -104,4 +161,8 @@ def get_provider(event: dict, context: LambdaContext):  # noqa: ARG001 unused-ar
         logger.error(f'Missing parameter: {e}')
         raise CCInvalidRequestException('Missing required field') from e
 
-    return get_provider_information(compact=compact, provider_id=provider_id)
+    provider_information = get_provider_information(compact=compact, provider_id=provider_id)
+
+    return _filter_provider_record_based_on_caller_read_level_for_provider(
+        compact=compact, provider_information=provider_information, scopes=get_scopes_list_from_event(event)
+    )

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
@@ -7,7 +7,7 @@ from cc_common.data_model.schema.provider import (
     QueryProvidersGeneralResponseSchema,
 )
 from cc_common.exceptions import CCInvalidRequestException
-from cc_common.utils import api_handler, authorize_compact, get_scopes_list_from_event
+from cc_common.utils import api_handler, authorize_compact, get_event_scopes
 
 from . import get_provider_information
 
@@ -121,7 +121,7 @@ def query_providers(event: dict, context: LambdaContext):  # noqa: ARG001 unused
     # Convert generic field to more specific one for this API and filter data based on caller's
     # permissions
     pre_sanitized_providers = resp.pop('items', [])
-    caller_scopes = get_scopes_list_from_event(event)
+    caller_scopes = get_event_scopes(event)
     sanitized_providers = []
     for provider in pre_sanitized_providers:
         # check if the caller has readPrivate permission for each provider
@@ -157,7 +157,7 @@ def get_provider(event: dict, context: LambdaContext):  # noqa: ARG001 unused-ar
     provider_information = get_provider_information(compact=compact, provider_id=provider_id)
 
     if _user_had_private_read_access_for_provider(
-        compact=compact, provider_information=provider_information, scopes=get_scopes_list_from_event(event)
+        compact=compact, provider_information=provider_information, scopes=get_event_scopes(event)
     ):
         # return full object since caller has 'readPrivate' access for provider
         return provider_information

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
@@ -4,7 +4,12 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from cc_common.config import config, logger
 from cc_common.data_model.schema.provider import SanitizedProviderReadGeneralSchema
 from cc_common.exceptions import CCInvalidRequestException
-from cc_common.utils import api_handler, authorize_compact, get_event_scopes, sanitize_provider_data_based_on_caller_scopes
+from cc_common.utils import (
+    api_handler,
+    authorize_compact,
+    get_event_scopes,
+    sanitize_provider_data_based_on_caller_scopes,
+)
 
 from . import get_provider_information
 
@@ -114,6 +119,6 @@ def get_provider(event: dict, context: LambdaContext):  # noqa: ARG001 unused-ar
 
     provider_information = get_provider_information(compact=compact, provider_id=provider_id)
 
-    return sanitize_provider_data_based_on_caller_scopes(compact=compact,
-                                                         provider=provider_information,
-                                                         scopes=get_event_scopes(event))
+    return sanitize_provider_data_based_on_caller_scopes(
+        compact=compact, provider=provider_information, scopes=get_event_scopes(event)
+    )

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
@@ -90,8 +90,7 @@ def query_providers(event: dict, context: LambdaContext):  # noqa: ARG001 unused
             case _:
                 # This shouldn't happen unless our api validation gets misconfigured
                 raise CCInvalidRequestException(f"Invalid sort key: '{sorting_key}'")
-    # Convert generic field to more specific one for this API and filter data based on caller's
-    # permissions
+    # Convert generic field to more specific one for this API and sanitize data
     pre_sanitized_providers = resp.pop('items', [])
     # for the query endpoint, we only return generally available data, regardless of the caller's scopes
     general_schema = SanitizedProviderReadGeneralSchema()

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/providers.py
@@ -2,8 +2,10 @@ import json
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from cc_common.config import config, logger
-from cc_common.data_model.schema.provider import GetProviderReadGeneralResponseSchema, \
-    QueryProvidersGeneralResponseSchema
+from cc_common.data_model.schema.provider import (
+    GetProviderReadGeneralResponseSchema,
+    QueryProvidersGeneralResponseSchema,
+)
 from cc_common.exceptions import CCInvalidRequestException
 from cc_common.utils import api_handler, authorize_compact, get_scopes_list_from_event
 
@@ -33,8 +35,10 @@ def _user_had_private_read_access_for_provider(compact: str, provider_informatio
             )
             return True
 
-    logger.debug('Caller does not have readPrivate permission at compact or jurisdiction level',
-                 provider_id=provider_information['providerId'])
+    logger.debug(
+        'Caller does not have readPrivate permission at compact or jurisdiction level',
+        provider_id=provider_information['providerId'],
+    )
     return False
 
 
@@ -122,14 +126,13 @@ def query_providers(event: dict, context: LambdaContext):  # noqa: ARG001 unused
     for provider in pre_sanitized_providers:
         # check if the caller has readPrivate permission for each provider
         # if not, we remove the private fields
-        if _user_had_private_read_access_for_provider(compact=compact,
-                                                          provider_information=provider,
-                                                          scopes=caller_scopes):
+        if _user_had_private_read_access_for_provider(
+            compact=compact, provider_information=provider, scopes=caller_scopes
+        ):
             sanitized_providers.append(provider)
         else:
             # passing the data through the schema to remove all fields not allowed by schema definition
             sanitized_providers.append(QueryProvidersGeneralResponseSchema().dump(provider))
-
 
     resp['providers'] = sanitized_providers
 
@@ -154,9 +157,7 @@ def get_provider(event: dict, context: LambdaContext):  # noqa: ARG001 unused-ar
     provider_information = get_provider_information(compact=compact, provider_id=provider_id)
 
     if _user_had_private_read_access_for_provider(
-            compact=compact,
-            provider_information=provider_information,
-            scopes=get_scopes_list_from_event(event)
+        compact=compact, provider_information=provider_information, scopes=get_scopes_list_from_event(event)
     ):
         # return full object since caller has 'readPrivate' access for provider
         return provider_information

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
@@ -165,7 +165,7 @@ class TestTransformations(TstFunction):
             event = json.load(f)
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
 
         resp = get_provider(event, self.mock_context)
 

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
@@ -165,7 +165,7 @@ class TestTransformations(TstFunction):
             event = json.load(f)
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral aslp/aslp.readPrivate'
 
         resp = get_provider(event, self.mock_context)
 

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
@@ -71,7 +71,9 @@ class TestIngest(TstFunction):
             event = json.load(f)
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
+        event['requestContext']['authorizer']['claims']['scope'] = (
+            'openid email stuff aslp/readGeneral ' 'aslp/aslp.readPrivate'
+        )
         resp = get_provider(event, self.mock_context)
         self.assertEqual(resp['statusCode'], 200)
 
@@ -131,7 +133,9 @@ class TestIngest(TstFunction):
             event = json.load(f)
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
+        event['requestContext']['authorizer']['claims']['scope'] = (
+            'openid email stuff aslp/readGeneral ' 'aslp/aslp.readPrivate'
+        )
         resp = get_provider(event, self.mock_context)
         self.assertEqual(resp['statusCode'], 200)
 

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
@@ -73,7 +73,7 @@ class TestIngest(TstFunction):
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
         event['requestContext']['authorizer']['claims']['scope'] = (
-            'openid email stuff aslp/readGeneral ' 'aslp/aslp.readPrivate'
+            'openid email stuff aslp/readGeneral aslp/aslp.readPrivate'
         )
         resp = get_provider(event, self.mock_context)
         self.assertEqual(resp['statusCode'], 200)
@@ -135,7 +135,7 @@ class TestIngest(TstFunction):
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
         event['requestContext']['authorizer']['claims']['scope'] = (
-            'openid email stuff aslp/readGeneral ' 'aslp/aslp.readPrivate'
+            'openid email stuff aslp/readGeneral aslp/aslp.readPrivate'
         )
         resp = get_provider(event, self.mock_context)
         self.assertEqual(resp['statusCode'], 200)

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
@@ -33,8 +33,6 @@ class TestIngest(TstFunction):
 
         with open('../common/tests/resources/api/provider-response.json') as f:
             expected_provider = json.load(f)
-            # caller does not have read private permission, so we expect the ssn field to be removed
-            del expected_provider['ssn']
 
         # The canned response resource assumes that the provider will be given a privilege in NE. We didn't do that,
         # so we'll reset the privilege array.

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
@@ -33,6 +33,9 @@ class TestIngest(TstFunction):
 
         with open('../common/tests/resources/api/provider-response.json') as f:
             expected_provider = json.load(f)
+            # caller does not have read private permission, so we expect the ssn field to be removed
+            del expected_provider['ssn']
+
         # The canned response resource assumes that the provider will be given a privilege in NE. We didn't do that,
         # so we'll reset the privilege array.
         expected_provider['privilegeJurisdictions'] = []

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
@@ -26,7 +26,7 @@ class TestIngest(TstFunction):
             event = json.load(f)
 
         event['pathParameters'] = {'compact': 'aslp'}
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
         event['body'] = json.dumps({'query': {'ssn': '123-12-1234'}})
         resp = query_providers(event, self.mock_context)
         self.assertEqual(resp['statusCode'], 200)
@@ -71,7 +71,7 @@ class TestIngest(TstFunction):
             event = json.load(f)
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
         resp = get_provider(event, self.mock_context)
         self.assertEqual(resp['statusCode'], 200)
 
@@ -131,7 +131,7 @@ class TestIngest(TstFunction):
             event = json.load(f)
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
         resp = get_provider(event, self.mock_context)
         self.assertEqual(resp['statusCode'], 200)
 
@@ -188,7 +188,7 @@ class TestIngest(TstFunction):
             event = json.load(f)
 
         event['pathParameters'] = {'compact': 'aslp', 'providerId': provider_id}
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
         resp = get_provider(event, self.mock_context)
         self.assertEqual(resp['statusCode'], 200)
 

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_licenses.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_licenses.py
@@ -14,7 +14,9 @@ class TestLicenses(TstFunction):
             event = json.load(f)
 
         # The user has write permission for aslp/oh
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral aslp/write aslp/oh.write'
+        event['requestContext']['authorizer']['claims']['scope'] = (
+            'openid email aslp/readGeneral aslp/write aslp/oh.write'
+        )
         event['pathParameters'] = {'compact': 'aslp', 'jurisdiction': 'oh'}
         with open('../common/tests/resources/api/license-post.json') as f:
             event['body'] = json.dumps([json.load(f)])
@@ -30,7 +32,9 @@ class TestLicenses(TstFunction):
             event = json.load(f)
 
         # The user has write permission for aslp/oh
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral aslp/write aslp/oh.write'
+        event['requestContext']['authorizer']['claims']['scope'] = (
+            'openid email aslp/readGeneral aslp/write aslp/oh.write'
+        )
         event['pathParameters'] = {'compact': 'aslp', 'jurisdiction': 'oh'}
         with open('../common/tests/resources/api/license-post.json') as f:
             license_data = json.load(f)

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_licenses.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_licenses.py
@@ -14,7 +14,7 @@ class TestLicenses(TstFunction):
             event = json.load(f)
 
         # The user has write permission for aslp/oh
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read aslp/write aslp/oh.write'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral aslp/write aslp/oh.write'
         event['pathParameters'] = {'compact': 'aslp', 'jurisdiction': 'oh'}
         with open('../common/tests/resources/api/license-post.json') as f:
             event['body'] = json.dumps([json.load(f)])
@@ -30,7 +30,7 @@ class TestLicenses(TstFunction):
             event = json.load(f)
 
         # The user has write permission for aslp/oh
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read aslp/write aslp/oh.write'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral aslp/write aslp/oh.write'
         event['pathParameters'] = {'compact': 'aslp', 'jurisdiction': 'oh'}
         with open('../common/tests/resources/api/license-post.json') as f:
             license_data = json.load(f)

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_providers.py
@@ -88,7 +88,6 @@ class TestQueryProviders(TstFunction):
 
         with open('../common/tests/resources/api/provider-response.json') as f:
             expected_provider = json.load(f)
-            expected_provider.pop('ssn')
 
         body = json.loads(resp['body'])
         self.assertEqual(
@@ -353,10 +352,12 @@ class TestGetProvider(TstFunction):
         with open('../common/tests/resources/api/provider-detail-response.json') as f:
             expected_provider = json.load(f)
             expected_provider.pop('ssn')
+            expected_provider.pop('dateOfBirth')
             # we do not return the military affiliation document keys if the caller does not have read private scope
             expected_provider['militaryAffiliations'][0].pop('documentKeys')
             # also remove the ssn from the license record
             expected_provider['licenses'][0].pop('ssn')
+            expected_provider['licenses'][0].pop('dateOfBirth')
 
         self._when_testing_get_provider_response_based_on_read_access(
             scopes='openid email aslp/readGeneral', expected_provider=expected_provider

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_providers.py
@@ -17,7 +17,7 @@ class TestQueryProviders(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps({'query': {'ssn': '123-12-1234'}})
 
@@ -48,7 +48,7 @@ class TestQueryProviders(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps({'query': {'providerId': '89a6377e-c3a5-40e5-bca5-317ec854c570'}})
 
@@ -80,7 +80,7 @@ class TestQueryProviders(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps(
             {'sorting': {'key': 'dateOfUpdate'}, 'query': {'jurisdiction': 'oh'}, 'pagination': {'pageSize': 10}},
@@ -109,7 +109,7 @@ class TestQueryProviders(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps(
             {'sorting': {'key': 'familyName'}, 'query': {'jurisdiction': 'oh'}, 'pagination': {'pageSize': 10}},
@@ -143,7 +143,7 @@ class TestQueryProviders(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps(
             {
@@ -175,7 +175,7 @@ class TestQueryProviders(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps(
             {
@@ -201,7 +201,7 @@ class TestQueryProviders(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps({'query': {}})
 
@@ -229,7 +229,7 @@ class TestQueryProviders(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps({'query': {'jurisdiction': 'oh'}, 'sorting': {'key': 'invalid'}})
 
@@ -251,7 +251,7 @@ class TestGetProvider(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp', 'providerId': '89a6377e-c3a5-40e5-bca5-317ec854c570'}
         event['queryStringParameters'] = None
 
@@ -274,7 +274,7 @@ class TestGetProvider(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'octp', 'providerId': '89a6377e-c3a5-40e5-bca5-317ec854c570'}
         event['queryStringParameters'] = None
 
@@ -289,7 +289,7 @@ class TestGetProvider(TstFunction):
             event = json.load(f)
 
         # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         # providerId _should_ be included in these pathParameters. We're leaving it out for this test.
         event['pathParameters'] = {'compact': 'aslp'}
         event['queryStringParameters'] = None

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_providers.py
@@ -39,7 +39,7 @@ class TestQueryProviders(TstFunction):
             body,
         )
 
-    def test_query_by_provider_id_with_read_private_permission(self):
+    def test_query_by_provider_id_sanitizes_data_even_with_read_private_permission(self):
         self._load_provider_data()
 
         from handlers.providers import query_providers
@@ -49,36 +49,6 @@ class TestQueryProviders(TstFunction):
 
         # The user has read permission for aslp
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral aslp/aslp.readPrivate'
-        event['pathParameters'] = {'compact': 'aslp'}
-        event['body'] = json.dumps({'query': {'providerId': '89a6377e-c3a5-40e5-bca5-317ec854c570'}})
-
-        resp = query_providers(event, self.mock_context)
-
-        self.assertEqual(200, resp['statusCode'])
-
-        with open('../common/tests/resources/api/provider-response.json') as f:
-            expected_provider = json.load(f)
-
-        body = json.loads(resp['body'])
-        self.assertEqual(
-            {
-                'providers': [expected_provider],
-                'pagination': {'pageSize': 100, 'lastKey': None, 'prevLastKey': None},
-                'query': {'providerId': '89a6377e-c3a5-40e5-bca5-317ec854c570'},
-            },
-            body,
-        )
-
-    def test_query_by_provider_id_without_read_private_permission(self):
-        self._load_provider_data()
-
-        from handlers.providers import query_providers
-
-        with open('../common/tests/resources/api-event.json') as f:
-            event = json.load(f)
-
-        # The user has read permission for aslp
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/readGeneral'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps({'query': {'providerId': '89a6377e-c3a5-40e5-bca5-317ec854c570'}})
 

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_main.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_main.py
@@ -33,7 +33,7 @@ class TestCustomizeScopes(TstLambdas):
         resp = customize_scopes(event, self.mock_context)
 
         self.assertEqual(
-            sorted(['profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write', 'aslp/al.readGeneral']),
+            sorted(['profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write']),
             sorted(resp['response']['claimsAndScopeOverrideDetails']['accessTokenGeneration']['scopesToAdd']),
         )
 

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_main.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_main.py
@@ -22,7 +22,6 @@ class TestCustomizeScopes(TstLambdas):
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
                 'permissions': {
-                    'actions': {'read'},
                     'jurisdictions': {
                         # should correspond to the 'aslp/write' and 'aslp/al.write' scopes
                         'al': {'write'}
@@ -34,7 +33,7 @@ class TestCustomizeScopes(TstLambdas):
         resp = customize_scopes(event, self.mock_context)
 
         self.assertEqual(
-            sorted(['profile', 'aslp/read', 'aslp/write', 'aslp/al.write']),
+            sorted(['profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write', 'aslp/al.readGeneral']),
             sorted(resp['response']['claimsAndScopeOverrideDetails']['accessTokenGeneration']['scopesToAdd']),
         )
 

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
@@ -43,8 +43,18 @@ class TestGetUserScopesFromDB(TstLambdas):
 
         scopes = UserScopes(self._user_sub)
 
-        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/write', 'aslp/al.admin',
-                          'aslp/al.write', 'aslp/al.readGeneral'}, scopes)
+        self.assertEqual(
+            {
+                'profile',
+                'aslp/readGeneral',
+                'aslp/admin',
+                'aslp/write',
+                'aslp/al.admin',
+                'aslp/al.write',
+                'aslp/al.readGeneral',
+            },
+            scopes,
+        )
 
     def test_board_ed_user_multi_compact(self):
         """
@@ -88,7 +98,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'octp/al.admin',
                 'octp/al.write',
                 'octp/al.readGeneral',
-             },
+            },
             scopes,
         )
 

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
@@ -26,7 +26,9 @@ class TestGetUserScopesFromDB(TstLambdas):
 
         scopes = UserScopes(self._user_sub)
 
-        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/aslp.admin', 'aslp/aslp.readPrivate'}, scopes)
+        self.assertEqual(
+            {'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/aslp.admin', 'aslp/aslp.readPrivate'}, scopes
+        )
 
     def test_board_ed_user(self):
         from user_scopes import UserScopes
@@ -95,7 +97,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'octp/admin',
                 'octp/write',
                 'octp/al.admin',
-                'octp/al.write'
+                'octp/al.write',
             },
             scopes,
         )

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
@@ -20,13 +20,13 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
-                'permissions': {'actions': {'read', 'admin'}, 'jurisdictions': {}},
+                'permissions': {'actions': {'read', 'admin', 'readPrivate'}, 'jurisdictions': {}},
             }
         )
 
         scopes = UserScopes(self._user_sub)
 
-        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/aslp.admin'}, scopes)
+        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/aslp.admin', 'aslp/aslp.readPrivate'}, scopes)
 
     def test_board_ed_user(self):
         from user_scopes import UserScopes
@@ -37,7 +37,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
-                'permissions': {'jurisdictions': {'al': {'write', 'admin'}}},
+                'permissions': {'jurisdictions': {'al': {'write', 'admin', 'readPrivate'}}},
             }
         )
 
@@ -51,7 +51,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'aslp/write',
                 'aslp/al.admin',
                 'aslp/al.write',
-                'aslp/al.readGeneral',
+                'aslp/al.readPrivate',
             },
             scopes,
         )
@@ -91,13 +91,11 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'aslp/write',
                 'aslp/al.admin',
                 'aslp/al.write',
-                'aslp/al.readGeneral',
                 'octp/readGeneral',
                 'octp/admin',
                 'octp/write',
                 'octp/al.admin',
-                'octp/al.write',
-                'octp/al.readGeneral',
+                'octp/al.write'
             },
             scopes,
         )
@@ -121,7 +119,7 @@ class TestGetUserScopesFromDB(TstLambdas):
 
         scopes = UserScopes(self._user_sub)
 
-        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write', 'aslp/al.readGeneral'}, scopes)
+        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write'}, scopes)
 
     def test_missing_user(self):
         from user_scopes import UserScopes

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
@@ -26,7 +26,7 @@ class TestGetUserScopesFromDB(TstLambdas):
 
         scopes = UserScopes(self._user_sub)
 
-        self.assertEqual({'profile', 'aslp/read', 'aslp/admin', 'aslp/aslp.admin'}, scopes)
+        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/aslp.admin'}, scopes)
 
     def test_board_ed_user(self):
         from user_scopes import UserScopes
@@ -37,13 +37,14 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
-                'permissions': {'actions': {'read'}, 'jurisdictions': {'al': {'write', 'admin'}}},
+                'permissions': {'jurisdictions': {'al': {'write', 'admin'}}},
             }
         )
 
         scopes = UserScopes(self._user_sub)
 
-        self.assertEqual({'profile', 'aslp/read', 'aslp/admin', 'aslp/write', 'aslp/al.admin', 'aslp/al.write'}, scopes)
+        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/write', 'aslp/al.admin',
+                          'aslp/al.write', 'aslp/al.readGeneral'}, scopes)
 
     def test_board_ed_user_multi_compact(self):
         """
@@ -58,7 +59,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
-                'permissions': {'actions': {'read'}, 'jurisdictions': {'al': {'write', 'admin'}}},
+                'permissions': {'jurisdictions': {'al': {'write', 'admin'}}},
             }
         )
         self._table.put_item(
@@ -66,7 +67,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#octp',
                 'compact': 'octp',
-                'permissions': {'actions': {'read'}, 'jurisdictions': {'al': {'write', 'admin'}}},
+                'permissions': {'jurisdictions': {'al': {'write', 'admin'}}},
             }
         )
 
@@ -75,17 +76,19 @@ class TestGetUserScopesFromDB(TstLambdas):
         self.assertEqual(
             {
                 'profile',
-                'aslp/read',
+                'aslp/readGeneral',
                 'aslp/admin',
                 'aslp/write',
                 'aslp/al.admin',
                 'aslp/al.write',
-                'octp/read',
+                'aslp/al.readGeneral',
+                'octp/readGeneral',
                 'octp/admin',
                 'octp/write',
                 'octp/al.admin',
                 'octp/al.write',
-            },
+                'octp/al.readGeneral',
+             },
             scopes,
         )
 
@@ -99,7 +102,6 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
                 'permissions': {
-                    'actions': {'read'},
                     'jurisdictions': {
                         'al': {'write'}  # should correspond to the 'aslp/al.write' scope
                     },
@@ -109,7 +111,7 @@ class TestGetUserScopesFromDB(TstLambdas):
 
         scopes = UserScopes(self._user_sub)
 
-        self.assertEqual({'profile', 'aslp/read', 'aslp/write', 'aslp/al.write'}, scopes)
+        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write', 'aslp/al.readGeneral'}, scopes)
 
     def test_missing_user(self):
         from user_scopes import UserScopes
@@ -131,7 +133,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
-                'permissions': {'actions': {'read'}, 'jurisdictions': {'al': {'write', 'admin'}}},
+                'permissions': {'jurisdictions': {'al': {'write', 'admin'}}},
             }
         )
         self._table.put_item(
@@ -139,7 +141,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'abc',
-                'permissions': {'actions': {'read'}, 'jurisdictions': {'al': {'write', 'admin'}}},
+                'permissions': {'jurisdictions': {'al': {'write', 'admin'}}},
             }
         )
 
@@ -161,7 +163,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'compact': 'aslp',
                 'permissions': {
                     # Write is jurisdiction-specific
-                    'actions': {'read', 'write'},
+                    'actions': {'write'},
                     'jurisdictions': {'al': {'write', 'admin'}},
                 },
             }
@@ -183,7 +185,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
-                'permissions': {'actions': {'read'}, 'jurisdictions': {'ab': {'write', 'admin'}}},
+                'permissions': {'jurisdictions': {'ab': {'write', 'admin'}}},
             }
         )
 
@@ -203,7 +205,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'pk': f'USER#{self._user_sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
-                'permissions': {'actions': {'read'}, 'jurisdictions': {'al': {'write', 'hack'}}},
+                'permissions': {'jurisdictions': {'al': {'write', 'hack'}}},
             }
         )
 

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
@@ -57,6 +57,10 @@ class UserScopes(set):
         # readGeneral is always added an implicit permission granted to all staff users at the compact level
         self.add(f'{compact_name}/readGeneral')
 
+        if 'readPrivate' in compact_actions:
+            # This action only has one level of authz, since there is no external scope for it
+            self.add(f'{compact_name}/{compact_name}.readPrivate')
+
         if 'admin' in compact_actions:
             # Two levels of authz for admin
             self.add(f'{compact_name}/admin')
@@ -82,9 +86,10 @@ class UserScopes(set):
                 f'{disallowed_actions}',
             )
         for action in jurisdiction_actions:
-            # Two levels of authz
-            self.add(f'{compact_name}/{action}')
-            self.add(f'{compact_name}/{jurisdiction_name}.{action}')
-
-        # readGeneral is always added an implicit permission granted to all staff users at their jurisdiction levels
-        self.add(f'{compact_name}/{jurisdiction_name}.readGeneral')
+            if action == 'readPrivate':
+                # This action only has one level of authz, since there is no external scope for it
+                self.add(f'{compact_name}/{jurisdiction_name}.readPrivate')
+            else:
+                # Two levels of authz
+                self.add(f'{compact_name}/{action}')
+                self.add(f'{compact_name}/{jurisdiction_name}.{action}')

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
@@ -88,5 +88,3 @@ class UserScopes(set):
 
         # readGeneral is always added an implicit permission granted to all staff users at their jurisdiction levels
         self.add(f'{compact_name}/{jurisdiction_name}.readGeneral')
-
-

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
@@ -87,7 +87,10 @@ class UserScopes(set):
             )
         for action in jurisdiction_actions:
             if action == 'readPrivate':
-                # This action only has one level of authz, since there is no external scope for it
+                # For other actions, if you are granted to fine-grain permission at the jurisdiction level,
+                # you are also granted the course-grain scope permission to grant you access to call the api itself.
+                # In the case of reading, all staff users are implicitly granted the 'readGeneral' scope,
+                # so we do not need to add the course-grain scope explicitly here.
                 self.add(f'{compact_name}/{jurisdiction_name}.readPrivate')
             else:
                 # Two levels of authz

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
@@ -86,13 +86,10 @@ class UserScopes(set):
                 f'{disallowed_actions}',
             )
         for action in jurisdiction_actions:
-            if action == 'readPrivate':
-                # For other actions, if you are granted to fine-grain permission at the jurisdiction level,
-                # you are also granted the course-grain scope permission to grant you access to call the api itself.
-                # In the case of reading, all staff users are implicitly granted the 'readGeneral' scope,
-                # so we do not need to add the course-grain scope explicitly here.
-                self.add(f'{compact_name}/{jurisdiction_name}.readPrivate')
-            else:
-                # Two levels of authz
+            self.add(f'{compact_name}/{jurisdiction_name}.{action}')
+
+            # Grant coarse-grain scope, which provides access to the API itself
+            # Since `readGeneral` is implicitly granted to all users, we do not
+            # need to grant a coarse-grain scope for the `readPrivate` action.
+            if action != 'readPrivate':
                 self.add(f'{compact_name}/{action}')
-                self.add(f'{compact_name}/{jurisdiction_name}.{action}')

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/user_scopes.py
@@ -21,7 +21,7 @@ class UserScopes(set):
         user_data = self._get_user_data(sub)
         permissions = {
             compact_record['compact']: {
-                'actions': set(compact_record['permissions']['actions']),
+                'actions': set(compact_record['permissions'].get('actions', [])),
                 'jurisdictions': compact_record['permissions']['jurisdictions'],
             }
             for compact_record in user_data
@@ -48,13 +48,14 @@ class UserScopes(set):
         compact_actions = compact_permissions.get('actions', set())
 
         # Ensure included actions are limited to supported values
-        disallowed_actions = compact_actions - {'read', 'admin'}
+        # Note we are keeping in the 'read' permission for backwards compatibility
+        # Though we are not using it in the codebase
+        disallowed_actions = compact_actions - {'read', 'admin', 'readPrivate'}
         if disallowed_actions:
             raise ValueError(f'User {compact_name} permissions include disallowed actions: {disallowed_actions}')
 
-        # Read is the only truly compact-level permission
-        if 'read' in compact_actions:
-            self.add(f'{compact_name}/read')
+        # readGeneral is always added an implicit permission granted to all staff users at the compact level
+        self.add(f'{compact_name}/readGeneral')
 
         if 'admin' in compact_actions:
             # Two levels of authz for admin
@@ -74,7 +75,7 @@ class UserScopes(set):
 
     def _process_jurisdiction_permissions(self, compact_name, jurisdiction_name, jurisdiction_actions):
         # Ensure included actions are limited to supported values
-        disallowed_actions = jurisdiction_actions - {'write', 'admin'}
+        disallowed_actions = jurisdiction_actions - {'write', 'admin', 'readPrivate'}
         if disallowed_actions:
             raise ValueError(
                 f'User {compact_name}/{jurisdiction_name} permissions include disallowed actions: '
@@ -84,3 +85,8 @@ class UserScopes(set):
             # Two levels of authz
             self.add(f'{compact_name}/{action}')
             self.add(f'{compact_name}/{jurisdiction_name}.{action}')
+
+        # readGeneral is always added an implicit permission granted to all staff users at their jurisdiction levels
+        self.add(f'{compact_name}/{jurisdiction_name}.readGeneral')
+
+

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_data_model/test_client.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_data_model/test_client.py
@@ -142,7 +142,7 @@ class TestClient(TstFunction):
 
         self.assertEqual(user_id, resp['userId'])
         self.assertEqual(
-            {'actions': {'read'}, 'jurisdictions': {'oh': {'admin'}, 'ky': {'write'}}},
+            {'actions': {'readPrivate'}, 'jurisdictions': {'oh': {'admin'}, 'ky': {'write'}}},
             resp['permissions'],
         )
         # Just checking that we're getting the whole object, not just changes
@@ -164,7 +164,7 @@ class TestClient(TstFunction):
         )
 
         self.assertEqual(user_id, resp['userId'])
-        self.assertEqual({'actions': {'read', 'admin'}, 'jurisdictions': {}}, resp['permissions'])
+        self.assertEqual({'actions': {'readPrivate', 'admin'}, 'jurisdictions': {}}, resp['permissions'])
         # Checking that we're getting the whole object, not just changes
         self.assertFalse({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'} - resp.keys())
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -128,7 +128,7 @@ class TestPatchUser(TstFunction):
         # Add compact read and oh admin permissions to the user
         event['pathParameters'] = {'compact': 'aslp', 'userId': user_id}
         api_user['permissions'] = {
-            'aslp': {'actions': {'read': True}, 'jurisdictions': {'oh': {'actions': {'admin': True}}}}
+            'aslp': {'actions': {'readPrivate': True}, 'jurisdictions': {'oh': {'actions': {'admin': True}}}}
         }
         event['body'] = json.dumps(api_user)
 
@@ -163,7 +163,7 @@ class TestPatchUser(TstFunction):
         # Remove all the permissions from the user
         event['pathParameters'] = {'compact': 'aslp', 'userId': user_id}
         api_user['permissions'] = {
-            'aslp': {'actions': {'read': False}, 'jurisdictions': {'oh': {'actions': {'write': False}}}}
+            'aslp': {'actions': {'readPrivate': False}, 'jurisdictions': {'oh': {'actions': {'write': False}}}}
         }
         event['body'] = json.dumps(api_user)
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -30,7 +30,7 @@ class TestPatchUser(TstFunction):
                 'dateOfUpdate': '2024-09-12T23:59:59+00:00',
                 'permissions': {
                     'aslp': {
-                        'actions': {'read': True},
+                        'actions': {'readPrivate': True},
                         'jurisdictions': {'oh': {'actions': {'admin': True, 'write': True}}},
                     },
                 },

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -215,7 +215,7 @@ class TestPatchUser(TstFunction):
                         'actions': {
                             'readPrivate': True,
                         },
-                        'jurisdictions': {'oh': {'actions': {'admin': True, 'readPrivate': True}}},
+                        'jurisdictions': {'oh': {'actions': {'readPrivate': True}}},
                     }
                 }
             }
@@ -232,7 +232,8 @@ class TestPatchUser(TstFunction):
                 'permissions': {
                     'aslp': {
                         'actions': {'readPrivate': True},
-                        'jurisdictions': {'oh': {'actions': {'admin': True, 'write': True, 'readPrivate': True}}},
+                        # test user starts with the write permission, so it should still be there
+                        'jurisdictions': {'oh': {'actions': {'write': True, 'readPrivate': True}}},
                     },
                 },
                 'type': 'user',

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -194,3 +194,38 @@ class TestPatchUser(TstFunction):
         resp = patch_user(event, self.mock_context)
 
         self.assertEqual(403, resp['statusCode'])
+
+    def test_patch_user_allows_adding_read_private_permission(self):
+        self._load_user_data()
+
+        from handlers.users import patch_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for aslp/oh
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/oh.admin aslp/aslp.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = json.dumps({
+            'permissions': {'aslp': {"actions": {'readPrivate': True,},
+                                     'jurisdictions': {'oh': {'actions': {'admin': True, 'readPrivate': True}}}}}})
+
+        resp = patch_user(event, self.mock_context)
+
+        self.assertEqual(200, resp['statusCode'])
+        user = json.loads(resp['body'])
+        self.assertEqual(
+            {
+                'attributes': {'email': 'justin@example.org', 'familyName': 'Williams', 'givenName': 'Justin'},
+                'dateOfUpdate': '2024-09-12T23:59:59+00:00',
+                'permissions': {
+                    'aslp': {
+                        'actions': {'readPrivate': True},
+                        'jurisdictions': {'oh': {'actions': {'admin': True, 'write': True, 'readPrivate': True}}},
+                    },
+                },
+                'type': 'user',
+                'userId': 'a4182428-d061-701c-82e5-a3d1d547d797',
+            },
+            user,
+        )

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -204,11 +204,22 @@ class TestPatchUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for aslp/oh
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/oh.admin aslp/aslp.admin'
+        event['requestContext']['authorizer']['claims']['scope'] = (
+            'openid email aslp/admin aslp/oh.admin aslp/aslp.admin'
+        )
         event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
-        event['body'] = json.dumps({
-            'permissions': {'aslp': {"actions": {'readPrivate': True,},
-                                     'jurisdictions': {'oh': {'actions': {'admin': True, 'readPrivate': True}}}}}})
+        event['body'] = json.dumps(
+            {
+                'permissions': {
+                    'aslp': {
+                        'actions': {
+                            'readPrivate': True,
+                        },
+                        'jurisdictions': {'oh': {'actions': {'admin': True, 'readPrivate': True}}},
+                    }
+                }
+            }
+        )
 
         resp = patch_user(event, self.mock_context)
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
@@ -19,7 +19,8 @@ class TestPostUser(TstFunction):
             api_user = json.load(f)
 
         # The user has admin permission for aslp/oh
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/oh.admin'
+        event['requestContext']['authorizer']['claims']['scope'] = ('openid email aslp/admin aslp/aslp.admin '
+                                                                    'aslp/oh.admin')
         event['pathParameters'] = {'compact': 'aslp'}
 
         resp = post_user(event, self.mock_context)

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
@@ -20,7 +20,7 @@ class TestPostUser(TstFunction):
 
         # The user has admin permission for aslp/oh
         event['requestContext']['authorizer']['claims']['scope'] = (
-            'openid email aslp/admin aslp/aslp.admin ' 'aslp/oh.admin'
+            'openid email aslp/admin aslp/aslp.admin aslp/oh.admin'
         )
         event['pathParameters'] = {'compact': 'aslp'}
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
@@ -19,8 +19,9 @@ class TestPostUser(TstFunction):
             api_user = json.load(f)
 
         # The user has admin permission for aslp/oh
-        event['requestContext']['authorizer']['claims']['scope'] = ('openid email aslp/admin aslp/aslp.admin '
-                                                                    'aslp/oh.admin')
+        event['requestContext']['authorizer']['claims']['scope'] = (
+            'openid email aslp/admin aslp/aslp.admin ' 'aslp/oh.admin'
+        )
         event['pathParameters'] = {'compact': 'aslp'}
 
         resp = post_user(event, self.mock_context)

--- a/backend/compact-connect/lambdas/python/staff-users/tests/resources/api/user-post.json
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/resources/api/user-post.json
@@ -8,7 +8,7 @@
   "permissions": {
     "aslp": {
       "actions": {
-        "read": true
+        "readPrivate": true
       },
       "jurisdictions": {
         "oh": {

--- a/backend/compact-connect/lambdas/python/staff-users/tests/resources/api/user-response.json
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/resources/api/user-response.json
@@ -10,7 +10,7 @@
   "permissions": {
     "aslp": {
       "actions": {
-        "read": true
+        "readPrivate": true
       },
       "jurisdictions": {
         "oh": {

--- a/backend/compact-connect/lambdas/python/staff-users/tests/resources/dynamo/user.json
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/resources/dynamo/user.json
@@ -37,7 +37,7 @@
     "M": {
       "actions": {
         "SS": [
-          "read"
+          "readPrivate"
         ]
       },
       "jurisdictions": {

--- a/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_authorize_compact.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_authorize_compact.py
@@ -9,14 +9,14 @@ class TestAuthorizeCompact(TstLambdas):
     def test_authorize_compact(self):
         from cc_common.utils import authorize_compact
 
-        @authorize_compact(action='read')
+        @authorize_compact(action='readGeneral')
         def example_entrypoint(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
             return {'body': 'Hurray!'}
 
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
 
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
         event['pathParameters'] = {
             'compact': 'aslp',
         }
@@ -27,13 +27,13 @@ class TestAuthorizeCompact(TstLambdas):
         from cc_common.exceptions import CCInvalidRequestException
         from cc_common.utils import authorize_compact
 
-        @authorize_compact(action='read')
+        @authorize_compact(action='readGeneral')
         def example_entrypoint(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
             return {'body': 'Hurray!'}
 
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
-        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/read'
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email stuff aslp/readGeneral'
         event['pathParameters'] = {}
 
         with self.assertRaises(CCInvalidRequestException):
@@ -43,7 +43,7 @@ class TestAuthorizeCompact(TstLambdas):
         from cc_common.exceptions import CCUnauthorizedException
         from cc_common.utils import authorize_compact
 
-        @authorize_compact(action='read')
+        @authorize_compact(action='readGeneral')
         def example_entrypoint(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
             return {'body': 'Hurray!'}
 
@@ -59,7 +59,7 @@ class TestAuthorizeCompact(TstLambdas):
         from cc_common.exceptions import CCAccessDeniedException
         from cc_common.utils import authorize_compact
 
-        @authorize_compact(action='read')
+        @authorize_compact(action='readGeneral')
         def example_entrypoint(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
             return {'body': 'Hurray!'}
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_collect_changes.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_collect_changes.py
@@ -10,12 +10,12 @@ class TestCollectChanges(TstLambdas):
         resp = collect_and_authorize_changes(
             path_compact='aslp',
             scopes={'openid', 'email', 'aslp/admin', 'aslp/aslp.admin'},
-            compact_changes={'actions': {'admin': True, 'read': False}, 'jurisdictions': {}},
+            compact_changes={'actions': {'admin': True, 'readPrivate': False}, 'jurisdictions': {}},
         )
         self.assertEqual(
             {
                 'compact_action_additions': {'admin'},
-                'compact_action_removals': {'read'},
+                'compact_action_removals': {'readPrivate'},
                 'jurisdiction_action_additions': {},
                 'jurisdiction_action_removals': {},
             },
@@ -69,14 +69,14 @@ class TestCollectChanges(TstLambdas):
             path_compact='aslp',
             scopes={'openid', 'email', 'aslp/admin', 'aslp/aslp.admin'},
             compact_changes={
-                'actions': {'admin': True, 'read': False},
+                'actions': {'admin': True, 'readPrivate': False},
                 'jurisdictions': {'oh': {'actions': {'admin': True, 'write': False}}},
             },
         )
         self.assertEqual(
             {
                 'compact_action_additions': {'admin'},
-                'compact_action_removals': {'read'},
+                'compact_action_removals': {'readPrivate'},
                 'jurisdiction_action_additions': {'oh': {'admin'}},
                 'jurisdiction_action_removals': {'oh': {'write'}},
             },

--- a/backend/compact-connect/stacks/api_stack/v1_api/api.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api.py
@@ -25,7 +25,7 @@ class V1Api:
         self.api: cc_api.CCApi = root.api
         self.api_model = ApiModel(api=self.api)
         read_scopes = [
-            f'{resource_server}/read' for resource_server in persistent_stack.staff_users.resource_servers.keys()
+            f'{resource_server}/readGeneral' for resource_server in persistent_stack.staff_users.resource_servers.keys()
         ]
         write_scopes = [
             f'{resource_server}/write' for resource_server in persistent_stack.staff_users.resource_servers.keys()

--- a/backend/compact-connect/stacks/api_stack/v1_api/api.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api.py
@@ -112,17 +112,17 @@ class V1Api:
         )
 
         # /v1/staff-users
-        staff_users_admin_resource = self.compact_resource.add_resource('staff-users')
-        staff_users_self_resource = self.resource.add_resource('staff-users')
+        self.staff_users_admin_resource = self.compact_resource.add_resource('staff-users')
+        self.staff_users_self_resource = self.resource.add_resource('staff-users')
         # GET    /v1/staff-users/me
         # PATCH  /v1/staff-users/me
         # GET    /v1/compacts/{compact}/staff-users
         # POST   /v1/compacts/{compact}/staff-users
         # GET    /v1/compacts/{compact}/staff-users/{userId}
         # PATCH  /v1/compacts/{compact}/staff-users/{userId}
-        StaffUsers(
-            admin_resource=staff_users_admin_resource,
-            self_resource=staff_users_self_resource,
+        self.staff_users = StaffUsers(
+            admin_resource=self.staff_users_admin_resource,
+            self_resource=self.staff_users_self_resource,
             admin_scopes=admin_scopes,
             persistent_stack=persistent_stack,
             api_model=self.api_model,

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -294,8 +294,11 @@ class ApiModel:
                     'actions': JsonSchema(
                         type=JsonSchemaType.OBJECT,
                         properties={
-                            'read': JsonSchema(type=JsonSchemaType.BOOLEAN),
+                            'readPrivate': JsonSchema(type=JsonSchemaType.BOOLEAN),
                             'admin': JsonSchema(type=JsonSchemaType.BOOLEAN),
+                            # TODO keeping 'read' action for backwards compatibility
+                            #  this should be removed after the frontend is updated
+                            'read': JsonSchema(type=JsonSchemaType.BOOLEAN),
                         },
                     ),
                     'jurisdictions': JsonSchema(
@@ -309,6 +312,7 @@ class ApiModel:
                                     properties={
                                         'write': JsonSchema(type=JsonSchemaType.BOOLEAN),
                                         'admin': JsonSchema(type=JsonSchemaType.BOOLEAN),
+                                        'readPrivate': JsonSchema(type=JsonSchemaType.BOOLEAN),
                                     },
                                 ),
                             },

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -296,7 +296,7 @@ class ApiModel:
                         properties={
                             'readPrivate': JsonSchema(type=JsonSchemaType.BOOLEAN),
                             'admin': JsonSchema(type=JsonSchemaType.BOOLEAN),
-                            # TODO keeping 'read' action for backwards compatibility
+                            # TODO keeping 'read' action for backwards compatibility  # noqa: FIX002
                             #  this should be removed after the frontend is updated
                             'read': JsonSchema(type=JsonSchemaType.BOOLEAN),
                         },

--- a/backend/compact-connect/stacks/api_stack/v1_api/staff_users.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/staff_users.py
@@ -51,10 +51,10 @@ class StaffUsers:
         self._add_get_users(self.admin_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
         self._add_post_user(self.admin_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
 
-        user_id_resource = self.admin_resource.add_resource('{userId}')
+        self.user_id_resource = self.admin_resource.add_resource('{userId}')
         # <base-url>/{userId}
-        self._add_get_user(user_id_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
-        self._add_patch_user(user_id_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
+        self._add_get_user(self.user_id_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
+        self._add_patch_user(self.user_id_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
 
         self.me_resource = self_resource.add_resource('me')
         # <base-url>/me
@@ -301,7 +301,7 @@ class StaffUsers:
         env_vars: dict,
         persistent_stack: ps.PersistentStack,
     ):
-        patch_user_handler = self._patch_user_handler(
+        self.patch_user_handler = self._patch_user_handler(
             env_vars=env_vars,
             data_encryption_key=persistent_stack.shared_encryption_key,
             users_table=persistent_stack.staff_users.user_table,
@@ -310,7 +310,7 @@ class StaffUsers:
         # Add the PATCH method to the me_resource
         user_resource.add_method(
             'PATCH',
-            integration=LambdaIntegration(patch_user_handler),
+            integration=LambdaIntegration(self.patch_user_handler),
             request_validator=self.api.parameter_body_validator,
             request_models={'application/json': self.api_model.patch_staff_user_model},
             method_responses=[
@@ -359,7 +359,7 @@ class StaffUsers:
         env_vars: dict,
         persistent_stack: ps.PersistentStack,
     ):
-        post_user_handler = self._post_user_handler(
+        self.post_user_handler = self._post_user_handler(
             env_vars=env_vars,
             data_encryption_key=persistent_stack.shared_encryption_key,
             users_table=persistent_stack.staff_users.user_table,
@@ -369,7 +369,7 @@ class StaffUsers:
         # Add the POST method to the me_resource
         users_resource.add_method(
             'POST',
-            integration=LambdaIntegration(post_user_handler),
+            integration=LambdaIntegration(self.post_user_handler),
             request_validator=self.api.parameter_body_validator,
             request_models={'application/json': self.api_model.post_staff_user_model},
             method_responses=[

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -85,7 +85,8 @@ class StaffUsers(UserPool):
         )
         self.read_scope = ResourceServerScope(
             scope_name='readGeneral',
-            scope_description='Read access for generally available data (not private) in the compact')
+            scope_description='Read access for generally available data (not private) in the compact',
+        )
 
         # One resource server for each compact
         self.resource_servers = {

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -70,11 +70,11 @@ class StaffUsers(UserPool):
 
     def _add_resource_servers(self):
         """Add scopes for all compact/jurisdictions"""
-        # {compact}.write, {compact}.admin, {compact}.read for every compact
-        # Note: the .write and .admin scopes will control access to API endpoints via the Cognito authorizer, however
-        # there will be a secondary level of authorization within the business logic that controls further granularity
-        # of authorization (i.e. 'aslp/write' will grant access to POST license data, but the business logic inside
-        # the endpoint also expects an 'aslp/co.write' if the POST includes data for Colorado.)
+        # {compact}.write, {compact}.admin, {compact}.readGeneral for every compact
+        # Note: the .readGeneral .write and .admin scopes will control access to API endpoints via the Cognito
+        # authorizer, however there will be a secondary level of authorization within the business logic that controls
+        # further granularity of authorization (i.e. 'aslp/write' will grant access to POST license data, but the
+        # business logic inside the endpoint also expects an 'aslp/co.write' if the POST includes data for Colorado.)
         self.write_scope = ResourceServerScope(
             scope_name='write',
             scope_description='Write access for the compact, paired with a more specific scope',
@@ -83,7 +83,9 @@ class StaffUsers(UserPool):
             scope_name='admin',
             scope_description='Admin access for the compact, paired with a more specific scope',
         )
-        self.read_scope = ResourceServerScope(scope_name='read', scope_description='Read access for the compact')
+        self.read_scope = ResourceServerScope(
+            scope_name='readGeneral',
+            scope_description='Read access for generally available data (not private) in the compact')
 
         # One resource server for each compact
         self.resource_servers = {

--- a/backend/compact-connect/tests/app/test_api/test_purchases_api.py
+++ b/backend/compact-connect/tests/app/test_api/test_purchases_api.py
@@ -86,15 +86,13 @@ class TestPurchasesApi(TestApi):
         )
 
         # We need to ensure the lambda can read these secrets, else all transactions will fail
+        # sort the compact names to ensure the order is consistent
+        self.context['compacts'].sort()
         self.assertIn(
             {
                 'Action': 'secretsmanager:GetSecretValue',
                 'Effect': 'Allow',
-                'Resource': [
-                    _generate_expected_secret_arn('aslp'),
-                    _generate_expected_secret_arn('coun'),
-                    _generate_expected_secret_arn('octp'),
-                ],
+                'Resource': [_generate_expected_secret_arn(compact) for compact in self.context['compacts']],
             },
             policy['Properties']['PolicyDocument']['Statement'],
         )

--- a/backend/compact-connect/tests/app/test_api/test_staff_users_api.py
+++ b/backend/compact-connect/tests/app/test_api/test_staff_users_api.py
@@ -59,17 +59,16 @@ class TestStaffUsersApi(TestApi):
             props={
                 'ParentId': {
                     # Verify the parent id matches the expected 'staff-users' resource
-                    'Ref': api_stack.get_logical_id(
-                        api_stack.api.v1_api.staff_users_admin_resource.node.default_child),
+                    'Ref': api_stack.get_logical_id(api_stack.api.v1_api.staff_users_admin_resource.node.default_child),
                 },
                 'PathPart': '{userId}',
             },
         )
 
-        patch_handler_properties = self.get_resource_properties_by_logical_id(logical_id=api_stack.get_logical_id(
-            api_stack.api.v1_api.staff_users.patch_user_handler.node.default_child
-        ),
-            resources=api_stack_template.find_resources(CfnFunction.CFN_RESOURCE_TYPE_NAME))
+        patch_handler_properties = self.get_resource_properties_by_logical_id(
+            logical_id=api_stack.get_logical_id(api_stack.api.v1_api.staff_users.patch_user_handler.node.default_child),
+            resources=api_stack_template.find_resources(CfnFunction.CFN_RESOURCE_TYPE_NAME),
+        )
 
         self.assertEqual(
             'handlers.users.patch_user',
@@ -132,10 +131,9 @@ class TestStaffUsersApi(TestApi):
         api_stack = self.app.sandbox_stage.api_stack
         api_stack_template = Template.from_stack(api_stack)
 
-        post_user_handler_properties = self.get_resource_properties_by_logical_id(logical_id=api_stack.get_logical_id(
-            api_stack.api.v1_api.staff_users.post_user_handler.node.default_child
-        ),
-            resources=api_stack_template.find_resources(CfnFunction.CFN_RESOURCE_TYPE_NAME)
+        post_user_handler_properties = self.get_resource_properties_by_logical_id(
+            logical_id=api_stack.get_logical_id(api_stack.api.v1_api.staff_users.post_user_handler.node.default_child),
+            resources=api_stack_template.find_resources(CfnFunction.CFN_RESOURCE_TYPE_NAME),
         )
 
         self.assertEqual(

--- a/backend/compact-connect/tests/app/test_api/test_staff_users_api.py
+++ b/backend/compact-connect/tests/app/test_api/test_staff_users_api.py
@@ -1,0 +1,196 @@
+from aws_cdk.assertions import Capture, Template
+from aws_cdk.aws_apigateway import CfnMethod, CfnModel, CfnResource
+from aws_cdk.aws_lambda import CfnFunction
+
+from tests.app.test_api import TestApi
+
+
+class TestStaffUsersApi(TestApi):
+    """These tests are focused on checking that the API endpoints for the `staff-users` path are
+    configured correctly.
+
+    When adding or modifying API resources, a test should be added to ensure that the
+    resource is created as expected. The pattern for these tests includes the following checks:
+    1. The path and parent id of the API Gateway resource matches expected values.
+    2. If the resource has a lambda function associated with it, the function is present with the expected
+    module and function.
+    3. Check the methods associated with the resource, ensuring they are all present and have the correct handlers.
+    4. Ensure the request and response models for the endpoint are present and match the expected schemas.
+    """
+
+    def test_synth_generates_staff_users_resources(self):
+        api_stack = self.app.sandbox_stage.api_stack
+        api_stack_template = Template.from_stack(api_stack)
+
+        # Ensure the resource is created with expected path for self-service endpoints
+        # /v1/staff-users
+        api_stack_template.has_resource_properties(
+            type=CfnResource.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'ParentId': {
+                    # Verify the parent id matches the expected 'v1' resource
+                    'Ref': api_stack.get_logical_id(api_stack.api.v1_api.resource.node.default_child),
+                },
+                'PathPart': 'staff-users',
+            },
+        )
+
+        # Ensure the resource is created with expected path for self-service endpoints
+        # /v1/compacts/{compact}/staff-users
+        api_stack_template.has_resource_properties(
+            type=CfnResource.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'ParentId': {
+                    # Verify the parent id matches the expected 'v1' resource
+                    'Ref': api_stack.get_logical_id(api_stack.api.v1_api.compact_resource.node.default_child),
+                },
+                'PathPart': 'staff-users',
+            },
+        )
+
+    def test_synth_generates_patch_staff_users_endpoint_resource(self):
+        api_stack = self.app.sandbox_stage.api_stack
+        api_stack_template = Template.from_stack(api_stack)
+
+        # Ensure the resource is created with expected path
+        # /v1/compacts/{compact}/staff-users/{userId}
+        api_stack_template.has_resource_properties(
+            type=CfnResource.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'ParentId': {
+                    # Verify the parent id matches the expected 'staff-users' resource
+                    'Ref': api_stack.get_logical_id(
+                        api_stack.api.v1_api.staff_users_admin_resource.node.default_child),
+                },
+                'PathPart': '{userId}',
+            },
+        )
+
+        patch_handler_properties = self.get_resource_properties_by_logical_id(logical_id=api_stack.get_logical_id(
+            api_stack.api.v1_api.staff_users.patch_user_handler.node.default_child
+        ),
+            resources=api_stack_template.find_resources(CfnFunction.CFN_RESOURCE_TYPE_NAME))
+
+        self.assertEqual(
+            'handlers.users.patch_user',
+            patch_handler_properties['Handler'],
+        )
+        patch_method_request_model_logical_id_capture = Capture()
+        patch_method_response_model_logical_id_capture = Capture()
+
+        # ensure the GET method is configured with the lambda integration and authorizer
+        api_stack_template.has_resource_properties(
+            type=CfnMethod.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'HttpMethod': 'PATCH',
+                # the provider users endpoints uses a separate authorizer from the staff endpoints
+                'AuthorizerId': {
+                    'Ref': api_stack.get_logical_id(api_stack.api.staff_users_authorizer.node.default_child),
+                },
+                # ensure the lambda integration is configured with the expected handler
+                'Integration': TestApi.generate_expected_integration_object(
+                    api_stack.get_logical_id(
+                        api_stack.api.v1_api.staff_users.patch_user_handler.node.default_child,
+                    ),
+                ),
+                'RequestModels': {
+                    'application/json': {'Ref': patch_method_request_model_logical_id_capture},
+                },
+                'MethodResponses': [
+                    {
+                        'ResponseModels': {'application/json': {'Ref': patch_method_response_model_logical_id_capture}},
+                        'StatusCode': '200',
+                    },
+                ],
+            },
+        )
+
+        # now check the model matches expected contract
+        patch_request_model = TestApi.get_resource_properties_by_logical_id(
+            patch_method_request_model_logical_id_capture.as_string(),
+            api_stack_template.find_resources(CfnModel.CFN_RESOURCE_TYPE_NAME),
+        )
+
+        self.compare_snapshot(
+            patch_request_model['Schema'],
+            'PATCH_STAFF_USERS_REQUEST_SCHEMA',
+            overwrite_snapshot=False,
+        )
+
+        patch_response_model = TestApi.get_resource_properties_by_logical_id(
+            patch_method_response_model_logical_id_capture.as_string(),
+            api_stack_template.find_resources(CfnModel.CFN_RESOURCE_TYPE_NAME),
+        )
+
+        self.compare_snapshot(
+            patch_response_model['Schema'],
+            'PATCH_STAFF_USERS_RESPONSE_SCHEMA',
+            overwrite_snapshot=False,
+        )
+
+    def test_synth_generates_post_staff_user_endpoint_resource(self):
+        api_stack = self.app.sandbox_stage.api_stack
+        api_stack_template = Template.from_stack(api_stack)
+
+        post_user_handler_properties = self.get_resource_properties_by_logical_id(logical_id=api_stack.get_logical_id(
+            api_stack.api.v1_api.staff_users.post_user_handler.node.default_child
+        ),
+            resources=api_stack_template.find_resources(CfnFunction.CFN_RESOURCE_TYPE_NAME)
+        )
+
+        self.assertEqual(
+            'handlers.users.post_user',
+            post_user_handler_properties['Handler'],
+        )
+        post_method_request_model_logical_id_capture = Capture()
+        post_method_response_model_logical_id_capture = Capture()
+
+        # ensure the GET method is configured with the lambda integration and authorizer
+        api_stack_template.has_resource_properties(
+            type=CfnMethod.CFN_RESOURCE_TYPE_NAME,
+            props={
+                'HttpMethod': 'POST',
+                # the provider users endpoints uses a separate authorizer from the staff endpoints
+                'AuthorizerId': {
+                    'Ref': api_stack.get_logical_id(api_stack.api.staff_users_authorizer.node.default_child),
+                },
+                # ensure the lambda integration is configured with the expected handler
+                'Integration': TestApi.generate_expected_integration_object(
+                    api_stack.get_logical_id(
+                        api_stack.api.v1_api.staff_users.post_user_handler.node.default_child,
+                    ),
+                ),
+                'RequestModels': {
+                    'application/json': {'Ref': post_method_request_model_logical_id_capture},
+                },
+                'MethodResponses': [
+                    {
+                        'ResponseModels': {'application/json': {'Ref': post_method_response_model_logical_id_capture}},
+                        'StatusCode': '200',
+                    },
+                ],
+            },
+        )
+
+        # now check the model matches expected contract
+        post_request_model = TestApi.get_resource_properties_by_logical_id(
+            post_method_request_model_logical_id_capture.as_string(),
+            api_stack_template.find_resources(CfnModel.CFN_RESOURCE_TYPE_NAME),
+        )
+
+        self.compare_snapshot(
+            post_request_model['Schema'],
+            'POST_STAFF_USERS_REQUEST_SCHEMA',
+            overwrite_snapshot=False,
+        )
+
+        post_response_model = TestApi.get_resource_properties_by_logical_id(
+            post_method_response_model_logical_id_capture.as_string(),
+            api_stack_template.find_resources(CfnModel.CFN_RESOURCE_TYPE_NAME),
+        )
+
+        self.compare_snapshot(
+            post_response_model['Schema'],
+            'POST_STAFF_USERS_RESPONSE_SCHEMA',
+            overwrite_snapshot=False,
+        )

--- a/backend/compact-connect/tests/app/test_pipeline.py
+++ b/backend/compact-connect/tests/app/test_pipeline.py
@@ -79,8 +79,10 @@ class TestPipeline(TstAppABC, TestCase):
                 )
 
         # Ensure the resource servers are created with the expected scopes
-        self.assertEqual(['admin', 'write', 'readGeneral'], [scope['ScopeName']
-                                             for scope in resource_server_cfn_properties[0]['Scopes']])
+        self.assertEqual(
+            ['admin', 'write', 'readGeneral'],
+            [scope['ScopeName'] for scope in resource_server_cfn_properties[0]['Scopes']],
+        )
 
     def test_cognito_using_recommended_security_in_prod(self):
         stack = self.app.pipeline_stack.prod_stage.persistent_stack

--- a/backend/compact-connect/tests/app/test_pipeline.py
+++ b/backend/compact-connect/tests/app/test_pipeline.py
@@ -65,7 +65,7 @@ class TestPipeline(TstAppABC, TestCase):
         # Get the resource servers created in the persistent stack
         resource_servers = persistent_stack.staff_users.resource_servers
         # We must confirm that these scopes are being explicitly created for each compact
-        # which are absolutely critical to for the system to function as expected.
+        # which are absolutely critical for the system to function as expected.
         self.assertEqual(self.context['compacts'], list(resource_servers.keys()))
 
         for compact, resource_server in resource_servers.items():

--- a/backend/compact-connect/tests/resources/snapshots/PATCH_STAFF_USERS_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PATCH_STAFF_USERS_REQUEST_SCHEMA.json
@@ -1,0 +1,53 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "permissions": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "properties": {
+              "readPrivate": {
+                "type": "boolean"
+              },
+              "admin": {
+                "type": "boolean"
+              },
+              "read": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "jurisdictions": {
+            "additionalProperties": {
+              "properties": {
+                "actions": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "write": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    },
+                    "readPrivate": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/backend/compact-connect/tests/resources/snapshots/PATCH_STAFF_USERS_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PATCH_STAFF_USERS_RESPONSE_SCHEMA.json
@@ -1,0 +1,87 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "userId": {
+      "type": "string"
+    },
+    "attributes": {
+      "additionalProperties": false,
+      "properties": {
+        "email": {
+          "maxLength": 100,
+          "minLength": 5,
+          "type": "string"
+        },
+        "givenName": {
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "familyName": {
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "givenName",
+        "familyName"
+      ],
+      "type": "object"
+    },
+    "permissions": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "properties": {
+              "readPrivate": {
+                "type": "boolean"
+              },
+              "admin": {
+                "type": "boolean"
+              },
+              "read": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "jurisdictions": {
+            "additionalProperties": {
+              "properties": {
+                "actions": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "write": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    },
+                    "readPrivate": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "userId",
+    "attributes",
+    "permissions"
+  ],
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/backend/compact-connect/tests/resources/snapshots/POST_STAFF_USERS_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/POST_STAFF_USERS_REQUEST_SCHEMA.json
@@ -1,0 +1,83 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "attributes": {
+      "additionalProperties": false,
+      "properties": {
+        "email": {
+          "maxLength": 100,
+          "minLength": 5,
+          "type": "string"
+        },
+        "givenName": {
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "familyName": {
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "givenName",
+        "familyName"
+      ],
+      "type": "object"
+    },
+    "permissions": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "properties": {
+              "readPrivate": {
+                "type": "boolean"
+              },
+              "admin": {
+                "type": "boolean"
+              },
+              "read": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "jurisdictions": {
+            "additionalProperties": {
+              "properties": {
+                "actions": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "write": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    },
+                    "readPrivate": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "attributes",
+    "permissions"
+  ],
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/backend/compact-connect/tests/resources/snapshots/POST_STAFF_USERS_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/POST_STAFF_USERS_RESPONSE_SCHEMA.json
@@ -1,0 +1,87 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "userId": {
+      "type": "string"
+    },
+    "attributes": {
+      "additionalProperties": false,
+      "properties": {
+        "email": {
+          "maxLength": 100,
+          "minLength": 5,
+          "type": "string"
+        },
+        "givenName": {
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "familyName": {
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "givenName",
+        "familyName"
+      ],
+      "type": "object"
+    },
+    "permissions": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "actions": {
+            "properties": {
+              "readPrivate": {
+                "type": "boolean"
+              },
+              "admin": {
+                "type": "boolean"
+              },
+              "read": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "jurisdictions": {
+            "additionalProperties": {
+              "properties": {
+                "actions": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "write": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    },
+                    "readPrivate": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "userId",
+    "attributes",
+    "permissions"
+  ],
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/backend/compact-connect/tests/smoke/config.py
+++ b/backend/compact-connect/tests/smoke/config.py
@@ -1,0 +1,66 @@
+import json
+import logging
+import os
+from functools import cached_property
+
+import boto3
+from aws_lambda_powertools import Logger
+
+
+logging.basicConfig()
+logger = Logger()
+logger.setLevel(logging.DEBUG if os.environ.get('DEBUG', 'false').lower() == 'true' else logging.INFO)
+
+
+class _Config():
+    @property
+    def api_base_url(self):
+        return os.environ['CC_TEST_API_BASE_URL']
+
+    @property
+    def provider_user_dynamodb_table(self):
+        return boto3.resource('dynamodb').Table(os.environ['CC_TEST_PROVIDER_DYNAMO_TABLE_NAME'])
+
+    @property
+    def data_events_dynamodb_table(self):
+        return boto3.resource('dynamodb').Table(os.environ['CC_TEST_DATA_EVENT_DYNAMO_TABLE_NAME'])
+
+    @property
+    def staff_users_dynamodb_table(self):
+        return boto3.resource('dynamodb').Table(os.environ['CC_TEST_STAFF_USER_DYNAMO_TABLE_NAME'])
+
+    @property
+    def cognito_staff_user_client_id(self):
+        return os.environ['CC_TEST_COGNITO_STAFF_USER_POOL_CLIENT_ID']
+
+    @property
+    def cognito_staff_user_pool_id(self):
+        return os.environ['CC_TEST_COGNITO_STAFF_USER_POOL_ID']
+
+    @property
+    def cognito_provider_user_client_id(self):
+        return os.environ['CC_TEST_COGNITO_PROVIDER_USER_POOL_CLIENT_ID']
+
+    @property
+    def cognito_provider_user_pool_id(self):
+        return os.environ['CC_TEST_COGNITO_PROVIDER_USER_POOL_ID']
+
+    @property
+    def test_provider_user_username(self):
+        return os.environ['CC_TEST_PROVIDER_USER_USERNAME']
+
+    @property
+    def test_provider_user_password(self):
+        return os.environ['CC_TEST_PROVIDER_USER_PASSWORD']
+
+    @cached_property
+    def cognito_client(self):
+        return boto3.client('cognito-idp')
+
+def load_smoke_test_env():
+    with open(os.path.join(os.path.dirname(__file__), 'smoke_tests_env.json')) as env_file:
+        env_vars = json.load(env_file)
+        os.environ.update(env_vars)
+
+load_smoke_test_env()
+config = _Config()

--- a/backend/compact-connect/tests/smoke/config.py
+++ b/backend/compact-connect/tests/smoke/config.py
@@ -6,13 +6,12 @@ from functools import cached_property
 import boto3
 from aws_lambda_powertools import Logger
 
-
 logging.basicConfig()
 logger = Logger()
 logger.setLevel(logging.DEBUG if os.environ.get('DEBUG', 'false').lower() == 'true' else logging.INFO)
 
 
-class _Config():
+class _Config:
     @property
     def api_base_url(self):
         return os.environ['CC_TEST_API_BASE_URL']
@@ -57,10 +56,12 @@ class _Config():
     def cognito_client(self):
         return boto3.client('cognito-idp')
 
+
 def load_smoke_test_env():
     with open(os.path.join(os.path.dirname(__file__), 'smoke_tests_env.json')) as env_file:
         env_vars = json.load(env_file)
         os.environ.update(env_vars)
+
 
 load_smoke_test_env()
 config = _Config()

--- a/backend/compact-connect/tests/smoke/license_upload_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/license_upload_smoke_tests.py
@@ -25,7 +25,7 @@ JURISDICTION = 'ne'
 # To run this script, create a smoke_tests_env.json file in the same directory as this script using the
 # 'smoke_tests_env_example.json' file as a template.
 
-TEST_STAFF_USER_EMAIL = 'testStaffUserLicenseUploader@fakeemail.com'
+TEST_STAFF_USER_EMAIL = 'testStaffUserLicenseUploader@smokeTestFakeEmail.com'
 
 
 def upload_licenses_record():

--- a/backend/compact-connect/tests/smoke/license_upload_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/license_upload_smoke_tests.py
@@ -155,9 +155,12 @@ def upload_licenses_record():
 if __name__ == '__main__':
     load_smoke_test_env()
     # Create staff user with permission to upload licenses
-    test_user_sub = create_test_staff_user(email=TEST_STAFF_USER_EMAIL, compact=COMPACT, jurisdiction=JURISDICTION,
-                                           permissions={'actions': {'admin'},
-                                                        'jurisdictions': {JURISDICTION: {'write', 'admin'}}})
+    test_user_sub = create_test_staff_user(
+        email=TEST_STAFF_USER_EMAIL,
+        compact=COMPACT,
+        jurisdiction=JURISDICTION,
+        permissions={'actions': {'admin'}, 'jurisdictions': {JURISDICTION: {'write', 'admin'}}},
+    )
     try:
         upload_licenses_record()
         print('License record upload smoke test passed')

--- a/backend/compact-connect/tests/smoke/license_upload_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/license_upload_smoke_tests.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime, timedelta
 import requests
 from smoke_common import (
     SmokeTestFailureException,
+    create_test_staff_user,
+    delete_test_staff_user,
     get_api_base_url,
     get_data_events_dynamodb_table,
     get_provider_user_dynamodb_table,
@@ -19,8 +21,11 @@ JURISDICTION = 'ne'
 
 # This script can be run locally to test the license upload/ingest flow against a sandbox environment
 # of the Compact Connect API.
+# Your sandbox account must be deployed with the "security_profile": "VULNERABLE" setting in your cdk.context.json
 # To run this script, create a smoke_tests_env.json file in the same directory as this script using the
 # 'smoke_tests_env_example.json' file as a template.
+
+TEST_STAFF_USER_EMAIL = 'testStaffUserLicenseUploader@fakeemail.com'
 
 
 def upload_licenses_record():
@@ -33,7 +38,7 @@ def upload_licenses_record():
     Step 3: Verify the license record is recorded in the data events table.
     """
 
-    headers = get_staff_user_auth_headers()
+    headers = get_staff_user_auth_headers(TEST_STAFF_USER_EMAIL)
 
     # Step 1: Upload a license record through the POST '/v1/compacts/aslp/jurisdictions/ne/licenses' endpoint.
     post_body = [
@@ -149,5 +154,15 @@ def upload_licenses_record():
 
 if __name__ == '__main__':
     load_smoke_test_env()
-    upload_licenses_record()
-    print('License record upload smoke test passed')
+    # Create staff user with permission to upload licenses
+    test_user_sub = create_test_staff_user(email=TEST_STAFF_USER_EMAIL, compact=COMPACT, jurisdiction=JURISDICTION,
+                                           permissions={'actions': {'admin'},
+                                                        'jurisdictions': {JURISDICTION: {'write', 'admin'}}})
+    try:
+        upload_licenses_record()
+        print('License record upload smoke test passed')
+    except SmokeTestFailureException as e:
+        print(f'License record upload smoke test failed: {str(e)}')
+    finally:
+        # Clean up the test staff user
+        delete_test_staff_user(TEST_STAFF_USER_EMAIL, user_sub=test_user_sub, compact=COMPACT)

--- a/backend/compact-connect/tests/smoke/military_affiliation_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/military_affiliation_smoke_tests.py
@@ -13,7 +13,8 @@ from smoke_common import (
 )
 
 # This script is used to test the military affiliations upload flow against a sandbox environment
-# # of the Compact Connect API.
+# of the Compact Connect API. It requires that you have a provider user set up in the sandbox environment.
+# Your sandbox account must also be deployed with the "security_profile": "VULNERABLE" setting in your cdk.context.json
 
 # To run this script, create a smoke_tests_env.json file in the same directory as this script using the
 # 'smoke_tests_env_example.json' file as a template.

--- a/backend/compact-connect/tests/smoke/military_affiliation_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/military_affiliation_smoke_tests.py
@@ -8,7 +8,7 @@ import requests
 from smoke_common import (
     SmokeTestFailureException,
     get_api_base_url,
-    get_provider_user_auth_headers,
+    get_provider_user_auth_headers_cached,
     load_smoke_test_env,
 )
 
@@ -27,7 +27,7 @@ def test_military_affiliation_upload():
     # Step 3: Verify that the test pdf file was uploaded successfully by checking the response status code.
     # Step 4: Get the provider data from the GET '/v1/provider-users/me' endpoint and verify that the military
     # affiliation record is active.
-    headers = get_provider_user_auth_headers()
+    headers = get_provider_user_auth_headers_cached()
 
     post_body = {
         'fileNames': ['military_affiliation.pdf'],
@@ -112,7 +112,7 @@ def test_military_affiliation_patch_update():
     # '/v1/provider-users/me/military-affiliation' endpoint.
     # Step 4: Get the provider data from the GET '/v1/provider-users/me' endpoint and verify that all the military
     # affiliation records are inactive.
-    headers = get_provider_user_auth_headers()
+    headers = get_provider_user_auth_headers_cached()
 
     patch_body = {
         'status': 'inactive',

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -8,7 +8,7 @@ from config import config
 from smoke_common import (
     SmokeTestFailureException,
     call_provider_users_me_endpoint,
-    get_provider_user_auth_headers,
+    get_provider_user_auth_headers_cached,
 )
 
 # This script can be run locally to test the privilege purchasing flow against a sandbox environment
@@ -66,7 +66,7 @@ def test_purchasing_privilege():
         'selectedJurisdictions': ['ne'],
     }
 
-    headers = get_provider_user_auth_headers()
+    headers = get_provider_user_auth_headers_cached()
     post_api_response = requests.post(
         url=config.api_base_url + '/v1/purchases/privileges', headers=headers, json=post_body, timeout=20
     )

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -31,8 +31,10 @@ def test_purchasing_privilege():
         dynamodb_table = config.provider_user_dynamodb_table
         for privilege in original_privileges:
             privilege_pk = f'{compact}#PROVIDER#{provider_id}'
-            privilege_sk = (f'{compact}#PROVIDER#privilege/{privilege["jurisdiction"]}#'
-                            f'{datetime.fromisoformat(privilege["dateOfRenewal"]).date().isoformat()}')
+            privilege_sk = (
+                f'{compact}#PROVIDER#privilege/{privilege["jurisdiction"]}#'
+                f'{datetime.fromisoformat(privilege["dateOfRenewal"]).date().isoformat()}'
+            )
             print(f'Deleting privilege record:\n{privilege_pk}\n{privilege_sk}')
             dynamodb_table.delete_item(
                 Key={

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -1,15 +1,14 @@
 # ruff: noqa: T201  we use print statements for smoke testing
 #!/usr/bin/env python3
+import time
 from datetime import UTC, datetime
 
 import requests
+from config import config
 from smoke_common import (
     SmokeTestFailureException,
     call_provider_users_me_endpoint,
-    get_api_base_url,
     get_provider_user_auth_headers,
-    get_provider_user_dynamodb_table,
-    load_smoke_test_env,
 )
 
 # This script can be run locally to test the privilege purchasing flow against a sandbox environment
@@ -29,16 +28,20 @@ def test_purchasing_privilege():
     if original_privileges:
         provider_id = original_provider_data.get('providerId')
         compact = original_provider_data.get('compact')
-        dynamodb_table = get_provider_user_dynamodb_table()
+        dynamodb_table = config.provider_user_dynamodb_table
         for privilege in original_privileges:
-            print(f'Deleting privilege record: {privilege}')
+            privilege_pk = f'{compact}#PROVIDER#{provider_id}'
+            privilege_sk = (f'{compact}#PROVIDER#privilege/{privilege["jurisdiction"]}#'
+                            f'{datetime.fromisoformat(privilege["dateOfRenewal"]).date().isoformat()}')
+            print(f'Deleting privilege record:\n{privilege_pk}\n{privilege_sk}')
             dynamodb_table.delete_item(
                 Key={
-                    'pk': f'{compact}#PROVIDER#{provider_id}',
-                    'sk': f'{compact}#PROVIDER#privilege/{privilege["jurisdiction"]}'
-                    f'#{datetime.fromisoformat(privilege["dateOfRenewal"]).date().isoformat()}',
+                    'pk': privilege_pk,
+                    'sk': privilege_sk,
                 }
             )
+            # give dynamodb time to propagate
+            time.sleep(1)
 
     post_body = {
         'orderInformation': {
@@ -63,7 +66,7 @@ def test_purchasing_privilege():
 
     headers = get_provider_user_auth_headers()
     post_api_response = requests.post(
-        url=get_api_base_url() + '/v1/purchases/privileges', headers=headers, json=post_body, timeout=20
+        url=config.api_base_url + '/v1/purchases/privileges', headers=headers, json=post_body, timeout=20
     )
 
     if post_api_response.status_code != 200:
@@ -93,5 +96,4 @@ def test_purchasing_privilege():
 
 
 if __name__ == '__main__':
-    load_smoke_test_env()
     test_purchasing_privilege()

--- a/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
@@ -20,6 +20,7 @@ from tests.smoke.smoke_common import SmokeTestFailureException, call_provider_us
 # To run this script, create a smoke_tests_env.json file in the same directory as this script using the
 # 'smoke_tests_env_example.json' file as a template.
 
+
 def get_provider_user_smoke_test():
     """
     Verifies that a provider record can be fetched from the GET provider users endpoint of the Compact Connect API.
@@ -39,7 +40,7 @@ def get_provider_user_smoke_test():
     get_provider_response = requests.get(
         url=get_api_base_url() + f'/v1/compacts/{provider_compact}/providers/{provider_id}',
         headers=staff_users_headers,
-        timeout=10
+        timeout=10,
     )
 
     if get_provider_response.status_code != 200:
@@ -61,10 +62,13 @@ def get_provider_user_smoke_test():
         military_affiliation.pop('documentKeys', None)
 
     if provider_object != provider_user_profile:
-        raise SmokeTestFailureException(f'Provider object does not match the profile.\n'
-                                        f'Profile response: {json.dumps(provider_user_profile)}\n'
-                                        f'Get Provider response: {json.dumps(provider_object)}')
+        raise SmokeTestFailureException(
+            f'Provider object does not match the profile.\n'
+            f'Profile response: {json.dumps(provider_user_profile)}\n'
+            f'Get Provider response: {json.dumps(provider_object)}'
+        )
     print('Successfully fetched expected provider records.')
+
 
 def query_provider_user_smoke_test():
     """
@@ -83,15 +87,13 @@ def query_provider_user_smoke_test():
 
     # Step 2: Have the staff user query for that provider using the profile information.
     staff_users_headers = get_staff_user_auth_headers()
-    post_body = {
-        'query': {'providerId': provider_id}
-    }
+    post_body = {'query': {'providerId': provider_id}}
 
     post_response = requests.post(
         url=get_api_base_url() + f'/v1/compacts/{provider_compact}/providers/query',
         headers=staff_users_headers,
         json=post_body,
-        timeout=10
+        timeout=10,
     )
 
     if post_response.status_code != 200:
@@ -111,13 +113,13 @@ def query_provider_user_smoke_test():
     provider_user_profile.pop('privileges')
 
     if provider_object != provider_user_profile:
-        raise SmokeTestFailureException(f'Provider object does not match the profile.\n'
-                                        f'Profile response: {provider_user_profile}\n'
-                                        f'Query Provider object: {provider_object}')
+        raise SmokeTestFailureException(
+            f'Provider object does not match the profile.\n'
+            f'Profile response: {provider_user_profile}\n'
+            f'Query Provider object: {provider_object}'
+        )
 
     print('Successfully queried expected provider record.')
-
-
 
 
 if __name__ == '__main__':

--- a/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
@@ -1,0 +1,127 @@
+# ruff: noqa: S101 T201  we use asserts and print statements for smoke testing
+import json
+
+import requests
+from smoke_common import (
+    get_api_base_url,
+    get_staff_user_auth_headers,
+    load_smoke_test_env,
+)
+
+from tests.smoke.smoke_common import SmokeTestFailureException, call_provider_users_me_endpoint
+
+# This script can be run locally to test the Query/Get Provider flow against a sandbox environment of the Compact
+# Connect API. It requires that you have both a staff user and a provider user set up in the same compact of the
+# sandbox environment.
+
+# The staff user should be created **without** any 'readPrivate' permissions, as this flow is intended to test
+# the general provider data retrieval flow.
+
+# To run this script, create a smoke_tests_env.json file in the same directory as this script using the
+# 'smoke_tests_env_example.json' file as a template.
+
+def get_provider_user_smoke_test():
+    """
+    Verifies that a provider record can be fetched from the GET provider users endpoint of the Compact Connect API.
+
+    Step 1: Get the provider id of the provider user profile information.
+    Step 2: The staff user calls the GET provider users endpoint with the provider id.
+    Step 3: Verify the Provider response matches the profile.
+    """
+    # Step 1: Get the provider id of the provider user profile information.
+    provider_user_profile = call_provider_users_me_endpoint()
+    provider_id = provider_user_profile['providerId']
+    provider_compact = provider_user_profile['compact']
+
+    # Step 2: The staff user calls the GET provider users endpoint with the provider id.
+    staff_users_headers = get_staff_user_auth_headers()
+
+    get_provider_response = requests.get(
+        url=get_api_base_url() + f'/v1/compacts/{provider_compact}/providers/{provider_id}',
+        headers=staff_users_headers,
+        timeout=10
+    )
+
+    if get_provider_response.status_code != 200:
+        raise SmokeTestFailureException(f'Failed to query provider. Response: {get_provider_response.json()}')
+    print('Received success response from GET endpoint')
+
+    # Step 3: Verify the Provider response matches the profile.
+    provider_object = get_provider_response.json()
+
+    # verify the ssn is NOT in the response
+    if 'ssn' in provider_object:
+        raise SmokeTestFailureException(f'unexpected ssn field returned. Response: {get_provider_response.json()}')
+
+    # remove the fields from the user profile that are not in the query response
+    provider_user_profile.pop('ssn', None)
+    for provider_license in provider_user_profile['licenses']:
+        provider_license.pop('ssn', None)
+    for military_affiliation in provider_user_profile['militaryAffiliations']:
+        military_affiliation.pop('documentKeys', None)
+
+    if provider_object != provider_user_profile:
+        raise SmokeTestFailureException(f'Provider object does not match the profile.\n'
+                                        f'Profile response: {json.dumps(provider_user_profile)}\n'
+                                        f'Get Provider response: {json.dumps(provider_object)}')
+    print('Successfully fetched expected provider records.')
+
+def query_provider_user_smoke_test():
+    """
+    Verifies that a provider record can be uploaded to the Compact Connect API and the appropriate
+    records are created in the provider table as well as the data events table.
+
+    Step 1: Get the provider id of the provider user profile information.
+    Step 2: Have the staff user query for that provider using the profile information.
+    Step 3: Verify the Provider response matches the profile.
+    """
+
+    # Step 1: Get the provider id of the provider user profile information.
+    provider_user_profile = call_provider_users_me_endpoint()
+    provider_id = provider_user_profile['providerId']
+    provider_compact = provider_user_profile['compact']
+
+    # Step 2: Have the staff user query for that provider using the profile information.
+    staff_users_headers = get_staff_user_auth_headers()
+    post_body = {
+        'query': {'providerId': provider_id}
+    }
+
+    post_response = requests.post(
+        url=get_api_base_url() + f'/v1/compacts/{provider_compact}/providers/query',
+        headers=staff_users_headers,
+        json=post_body,
+        timeout=10
+    )
+
+    if post_response.status_code != 200:
+        raise SmokeTestFailureException(f'Failed to query provider. Response: {post_response.json()}')
+    print('Received success response from query endpoint')
+    # Step 3: Verify the Provider response matches the profile.
+    provider_object = post_response.json()['providers'][0]
+
+    # verify the ssn is NOT in the response
+    if 'ssn' in provider_object:
+        raise SmokeTestFailureException(f'unexpected ssn field returned. Response: {post_response.json()}')
+
+    # remove the fields from the user profile that are not in the query response
+    provider_user_profile.pop('ssn', None)
+    provider_user_profile.pop('licenses')
+    provider_user_profile.pop('militaryAffiliations')
+    provider_user_profile.pop('privileges')
+
+    if provider_object != provider_user_profile:
+        raise SmokeTestFailureException(f'Provider object does not match the profile.\n'
+                                        f'Profile response: {provider_user_profile}\n'
+                                        f'Query Provider object: {provider_object}')
+
+    print('Successfully queried expected provider record.')
+
+
+
+
+if __name__ == '__main__':
+    load_smoke_test_env()
+    get_provider_user_smoke_test()
+    query_provider_user_smoke_test()
+    print('Query provider smoke tests passed')

--- a/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
@@ -2,17 +2,20 @@
 import json
 
 import requests
+from config import config, logger
 from smoke_common import (
-    get_api_base_url,
+    SmokeTestFailureException,
+    call_provider_users_me_endpoint,
+    create_test_staff_user,
+    delete_test_staff_user,
     get_staff_user_auth_headers,
     load_smoke_test_env,
 )
 
-from tests.smoke.smoke_common import SmokeTestFailureException, call_provider_users_me_endpoint
-
 # This script can be run locally to test the Query/Get Provider flow against a sandbox environment of the Compact
-# Connect API. It requires that you have both a staff user and a provider user set up in the same compact of the
-# sandbox environment.
+# Connect API. It requires that you have a provider user set up in the same compact of the sandbox environment.
+# Your sandbox account must also be deployed with the "security_profile": "VULNERABLE" setting in your cdk.context.json
+# file, which allows you to log in users using the boto3 Cognito client.
 
 # The staff user should be created **without** any 'readPrivate' permissions, as this flow is intended to test
 # the general provider data retrieval flow.
@@ -21,31 +24,35 @@ from tests.smoke.smoke_common import SmokeTestFailureException, call_provider_us
 # 'smoke_tests_env_example.json' file as a template.
 
 
-def get_provider_user_smoke_test():
+TEST_STAFF_USER_EMAIL = 'testStaffUser@fakeemail.com'
+
+
+def get_general_provider_user_data_smoke_test():
     """
-    Verifies that a provider record can be fetched from the GET provider users endpoint of the Compact Connect API.
+    Verifies that a provider record can be fetched from the GET provider users endpoint with private fields sanitized.
 
     Step 1: Get the provider id of the provider user profile information.
     Step 2: The staff user calls the GET provider users endpoint with the provider id.
     Step 3: Verify the Provider response matches the profile.
     """
     # Step 1: Get the provider id of the provider user profile information.
-    provider_user_profile = call_provider_users_me_endpoint()
+    test_user_profile = call_provider_users_me_endpoint()
     provider_id = provider_user_profile['providerId']
-    provider_compact = provider_user_profile['compact']
+    compact = provider_user_profile['compact']
 
     # Step 2: The staff user calls the GET provider users endpoint with the provider id.
-    staff_users_headers = get_staff_user_auth_headers()
+    # create staff user without 'readPrivate' permissions
+    staff_users_headers = get_staff_user_auth_headers(TEST_STAFF_USER_EMAIL)
 
     get_provider_response = requests.get(
-        url=get_api_base_url() + f'/v1/compacts/{provider_compact}/providers/{provider_id}',
+        url=config.api_base_url + f'/v1/compacts/{compact}/providers/{provider_id}',
         headers=staff_users_headers,
         timeout=10,
     )
 
     if get_provider_response.status_code != 200:
         raise SmokeTestFailureException(f'Failed to query provider. Response: {get_provider_response.json()}')
-    print('Received success response from GET endpoint')
+    logger.info('Received success response from GET endpoint')
 
     # Step 3: Verify the Provider response matches the profile.
     provider_object = get_provider_response.json()
@@ -55,19 +62,21 @@ def get_provider_user_smoke_test():
         raise SmokeTestFailureException(f'unexpected ssn field returned. Response: {get_provider_response.json()}')
 
     # remove the fields from the user profile that are not in the query response
-    provider_user_profile.pop('ssn', None)
-    for provider_license in provider_user_profile['licenses']:
+    test_user_profile.pop('ssn', None)
+    test_user_profile.pop('dateOfBirth', None)
+    for provider_license in test_user_profile['licenses']:
         provider_license.pop('ssn', None)
-    for military_affiliation in provider_user_profile['militaryAffiliations']:
+        provider_license.pop('dateOfBirth', None)
+    for military_affiliation in test_user_profile['militaryAffiliations']:
         military_affiliation.pop('documentKeys', None)
 
-    if provider_object != provider_user_profile:
+    if provider_object != test_user_profile:
         raise SmokeTestFailureException(
             f'Provider object does not match the profile.\n'
-            f'Profile response: {json.dumps(provider_user_profile)}\n'
+            f'Profile response: {json.dumps(test_user_profile)}\n'
             f'Get Provider response: {json.dumps(provider_object)}'
         )
-    print('Successfully fetched expected provider records.')
+    logger.info('Successfully fetched expected provider records.')
 
 
 def query_provider_user_smoke_test():
@@ -81,16 +90,16 @@ def query_provider_user_smoke_test():
     """
 
     # Step 1: Get the provider id of the provider user profile information.
-    provider_user_profile = call_provider_users_me_endpoint()
+    test_user_profile = call_provider_users_me_endpoint()
     provider_id = provider_user_profile['providerId']
-    provider_compact = provider_user_profile['compact']
+    compact = provider_user_profile['compact']
 
     # Step 2: Have the staff user query for that provider using the profile information.
-    staff_users_headers = get_staff_user_auth_headers()
+    staff_users_headers = get_staff_user_auth_headers(TEST_STAFF_USER_EMAIL)
     post_body = {'query': {'providerId': provider_id}}
 
     post_response = requests.post(
-        url=get_api_base_url() + f'/v1/compacts/{provider_compact}/providers/query',
+        url=config.api_base_url + f'/v1/compacts/{compact}/providers/query',
         headers=staff_users_headers,
         json=post_body,
         timeout=10,
@@ -98,7 +107,7 @@ def query_provider_user_smoke_test():
 
     if post_response.status_code != 200:
         raise SmokeTestFailureException(f'Failed to query provider. Response: {post_response.json()}')
-    print('Received success response from query endpoint')
+    logger.info('Received success response from query endpoint')
     # Step 3: Verify the Provider response matches the profile.
     provider_object = post_response.json()['providers'][0]
 
@@ -107,23 +116,36 @@ def query_provider_user_smoke_test():
         raise SmokeTestFailureException(f'unexpected ssn field returned. Response: {post_response.json()}')
 
     # remove the fields from the user profile that are not in the query response
-    provider_user_profile.pop('ssn', None)
-    provider_user_profile.pop('licenses')
-    provider_user_profile.pop('militaryAffiliations')
-    provider_user_profile.pop('privileges')
+    test_user_profile.pop('ssn', None)
+    test_user_profile.pop('dateOfBirth', None)
+    test_user_profile.pop('licenses')
+    test_user_profile.pop('militaryAffiliations')
+    test_user_profile.pop('privileges')
 
-    if provider_object != provider_user_profile:
+    if provider_object != test_user_profile:
         raise SmokeTestFailureException(
             f'Provider object does not match the profile.\n'
-            f'Profile response: {provider_user_profile}\n'
+            f'Profile response: {test_user_profile}\n'
             f'Query Provider object: {provider_object}'
         )
 
-    print('Successfully queried expected provider record.')
+    logger.info('Successfully queried expected provider record.')
+
 
 
 if __name__ == '__main__':
     load_smoke_test_env()
-    get_provider_user_smoke_test()
-    query_provider_user_smoke_test()
-    print('Query provider smoke tests passed')
+    provider_user_profile = call_provider_users_me_endpoint()
+    provider_compact = provider_user_profile['compact']
+    # ensure the test staff user is in the same compact as the test provider user without 'readPrivate' permissions
+    test_user_sub = create_test_staff_user(email=TEST_STAFF_USER_EMAIL, compact=provider_compact, jurisdiction='oh',
+                           permissions={'actions': {'admin'}, 'jurisdictions': {'oh': {'write', 'admin'}}})
+    try:
+        get_general_provider_user_data_smoke_test()
+        query_provider_user_smoke_test()
+        logger.info('Query provider smoke tests passed')
+    except SmokeTestFailureException as e:
+        logger.error(f'Query provider smoke tests failed: {str(e)}')
+    finally:
+        delete_test_staff_user(TEST_STAFF_USER_EMAIL, user_sub=test_user_sub, compact=provider_compact)
+

--- a/backend/compact-connect/tests/smoke/smoke_common.py
+++ b/backend/compact-connect/tests/smoke/smoke_common.py
@@ -1,8 +1,11 @@
 import json
 import os
+import sys
 
 import boto3
 import requests
+from botocore.exceptions import ClientError
+from config import config, logger
 
 
 class SmokeTestFailureException(Exception):
@@ -14,15 +17,157 @@ class SmokeTestFailureException(Exception):
         super().__init__(message)
 
 
+provider_data_path = os.path.join('lambdas', 'python', 'staff-users')
+common_lib_path = os.path.join('lambdas', 'python', 'common')
+sys.path.append(provider_data_path)
+sys.path.append(common_lib_path)
+
+with open('cdk.json') as context_file:
+    _context = json.load(context_file)['context']
+JURISDICTIONS = _context['jurisdictions']
+COMPACTS = _context['compacts']
+
+os.environ['COMPACTS'] = json.dumps(COMPACTS)
+os.environ['JURISDICTIONS'] = json.dumps(JURISDICTIONS)
+
+# We have to import this after we've added the common lib to our path and environment
+from cc_common.data_model.schema.user import UserRecordSchema  # noqa: E402
+
+
+TEST_STAFF_USER_PASSWORD = 'TestPass123!'  # noqa: S105 test credential for test staff user
+
+
+def _create_staff_user_in_cognito(*, email: str) -> str:
+    """
+    Creates a staff user in Cognito and returns the user's sub.
+    """
+    def get_sub_from_attributes(user_attributes: list):
+        for attribute in user_attributes:
+            if attribute['Name'] == 'sub':
+                return attribute['Value']
+        raise ValueError('Failed to find user sub!')
+
+    try:
+        user_data = config.cognito_client.admin_create_user(
+            UserPoolId=config.cognito_staff_user_pool_id,
+            Username=email,
+            UserAttributes=[{'Name': 'email', 'Value': email}],
+            TemporaryPassword='TempPass123!'
+        )
+        logger.info(f"Created staff user, '{email}'. Setting password.")
+        # set this to simplify login flow for user
+        config.cognito_client.admin_set_user_password(
+            UserPoolId=config.cognito_staff_user_pool_id,
+            Username=email,
+            Password=TEST_STAFF_USER_PASSWORD,
+            Permanent=True
+        )
+        logger.info(f"Set password for staff user, '{email}' in Cognito. New user data: {user_data}")
+        return get_sub_from_attributes(user_data['User']['Attributes'])
+
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'UsernameExistsException':
+            logger.info(f"Staff user, '{email}', already exists in Cognito. Getting user data.")
+            user_data = config.cognito_client.admin_get_user(UserPoolId=config.cognito_staff_user_pool_id,
+                                                             Username=email)
+            return get_sub_from_attributes(user_data['UserAttributes'])
+
+        raise e
+
+def delete_test_staff_user(email, user_sub: str, compact: str):
+    """
+    Deletes a test staff user from Cognito.
+    """
+    try:
+        logger.info(f"Deleting staff user from cognito, '{email}'")
+        config.cognito_client.admin_delete_user(
+            UserPoolId=config.cognito_staff_user_pool_id,
+            Username=email
+        )
+        # now clean up the user record in DynamoDB
+        pk = f'USER#{user_sub}'
+        sk = f'COMPACT#{compact}'
+        logger.info(f"Deleting staff user record from DynamoDB, PK: '{pk}', SK: '{sk}'")
+        config.staff_users_dynamodb_table.delete_item(Key={'pk': pk, 'sk': sk})
+        logger.info(f"Deleted staff user, '{email}', from Cognito and DynamoDB")
+    except ClientError as e:
+        logger.error(f"Failed to delete staff user data, '{email}': {str(e)}")
+        raise e
+
+
+def create_test_staff_user(*, email: str, compact: str, jurisdiction: str, permissions: dict):
+    """
+    Creates a test staff user in Cognito, stores their data in DynamoDB, and returns their user sub id.
+    """
+    logger.info(f"Creating staff user, '{email}', in {compact}/{jurisdiction}")
+    user_attributes = {'email': email, 'familyName': 'Dokes', 'givenName': 'Joe'}
+    sub = _create_staff_user_in_cognito(email=email)
+    schema = UserRecordSchema()
+    config.staff_users_dynamodb_table.put_item(
+        Item=schema.dump(
+            {
+                'type': 'user',
+                'userId': sub,
+                'compact': compact,
+                'attributes': user_attributes,
+                'permissions': permissions,
+            },
+        ),
+    )
+    logger.info(f"Created staff user record in DynamoDB. User data: {user_attributes}")
+
+    return sub
+
+def get_user_tokens(email, password=TEST_STAFF_USER_PASSWORD, is_staff=False):
+    """
+    Gets Cognito tokens for a user.
+    {
+        'IdToken': 'string',
+        'AccessToken': 'string',
+        'RefreshToken': 'string',
+        'ExpiresIn': 123,
+        'TokenType': 'string',
+        'NewDeviceMetadata': {
+            'DeviceKey': 'string',
+            'DeviceGroupKey': 'string'
+        }
+    }
+    """
+    try:
+        logger.info("Getting tokens for user: " + email + " user type: " + ("staff" if is_staff else "provider"))
+        response = config.cognito_client.admin_initiate_auth(
+            UserPoolId=config.cognito_staff_user_pool_id if is_staff else config.cognito_provider_user_pool_id,
+            ClientId=config.cognito_staff_user_client_id if is_staff else config.cognito_provider_user_client_id,
+            AuthFlow='ADMIN_USER_PASSWORD_AUTH',
+            AuthParameters={
+                'USERNAME': email,
+                'PASSWORD': password
+            }
+        )
+
+        return response['AuthenticationResult']
+
+    except ClientError as e:
+        logger.info(f"Failed to get tokens for user {email}: {str(e)}")
+        raise e
+
+
+
 def get_provider_user_auth_headers():
+    provider_token = os.environ.get('TEST_PROVIDER_USER_ID_TOKEN')
+    if not provider_token:
+        tokens = get_user_tokens(config.test_provider_user_username, config.test_provider_user_password, is_staff=False)
+        os.environ['TEST_PROVIDER_USER_ID_TOKEN'] = tokens['IdToken']
+
     return {
         'Authorization': 'Bearer ' + os.environ['TEST_PROVIDER_USER_ID_TOKEN'],
     }
 
 
-def get_staff_user_auth_headers():
+def get_staff_user_auth_headers(username: str, password: str = TEST_STAFF_USER_PASSWORD):
+    tokens = get_user_tokens(username, password, is_staff=True)
     return {
-        'Authorization': 'Bearer ' + os.environ['TEST_STAFF_USER_ACCESS_TOKEN'],
+        'Authorization': 'Bearer ' + tokens['AccessToken'],
     }
 
 
@@ -47,7 +192,7 @@ def load_smoke_test_env():
 def call_provider_users_me_endpoint():
     # Get the provider data from the GET '/v1/provider-users/me' endpoint.
     get_provider_data_response = requests.get(
-        url=get_api_base_url() + '/v1/provider-users/me', headers=get_provider_user_auth_headers(), timeout=10
+        url=config.api_base_url + '/v1/provider-users/me', headers=get_provider_user_auth_headers(), timeout=10
     )
     if get_provider_data_response.status_code != 200:
         raise SmokeTestFailureException(f'Failed to GET provider data. Response: {get_provider_data_response.json()}')

--- a/backend/compact-connect/tests/smoke/smoke_tests_env_example.json
+++ b/backend/compact-connect/tests/smoke/smoke_tests_env_example.json
@@ -2,6 +2,11 @@
   "CC_TEST_API_BASE_URL": "https://api.test.compactconnect.org",
   "CC_TEST_PROVIDER_DYNAMO_TABLE_NAME": "Sandbox-PersistentStack-ProviderTable12345",
   "CC_TEST_DATA_EVENT_DYNAMO_TABLE_NAME": "Sandbox-PersistentStack-DataEventTable1234",
-  "TEST_PROVIDER_USER_ID_TOKEN": "This can be fetched by logging in as a licensee into the Compact Connect UI of your test environment and copying the value of 'id_token_licensee' from the browser's local storage.",
-  "TEST_STAFF_USER_ACCESS_TOKEN": "This can be fetched by logging in as a staff user into the Compact Connect UI of your test environment and copying the value of 'auth_token_staff' from the browser's local storage."
+  "CC_TEST_STAFF_USER_DYNAMO_TABLE_NAME": "Sandbox-PersistentStack-StaffUserTable1234",
+  "CC_TEST_COGNITO_STAFF_USER_POOL_ID": "us-east-1_12345",
+  "CC_TEST_COGNITO_STAFF_USER_POOL_CLIENT_ID": "72612345",
+  "CC_TEST_COGNITO_PROVIDER_USER_POOL_ID": "us-east-1_12345",
+  "CC_TEST_COGNITO_PROVIDER_USER_POOL_CLIENT_ID": "72612345",
+  "CC_TEST_PROVIDER_USER_USERNAME": "example@example.com",
+  "CC_TEST_PROVIDER_USER_PASSWORD": "examplePassword"
 }


### PR DESCRIPTION
We need to support specific read access for our staff users when searching for providers in their respective 
compacts/jurisdictions. This makes the following updates to our permissions model

- The former '{compact}/read' scope has been replaced with a '{compact}/readGeneral' scope, which is granted implicitly to all staff users in the system, and allows them to call the query and GET provider endpoints to get generally available (aka not private) data from the system.
- A new action has been added at the compact and jurisdiction levels, 'readPrivate' which must be explicitly granted to a user and allows a user to view the PII for a provider record within their respective compact/jurisdiction that they have permissions for.

With the former read permission split out into 'readGeneral' and 'readPrivate', this allows us to support the following requested access patterns:
- state administrators can view all the data for those that have a license or privilege in their state (this includes a license that is not the "home state" license)
- state administrators can see public information for those that are in their state. This includes license and discipline,  address, and phone/email (Only SSN and DOB are excluded)
- compact administrators can view all data for all their profession

### Requirements List
- Note that the authorizer scope change will cause all active JWTs at the time of deployment to become invalid. Any users logged into the system at time of deployment will need to log out and log back in again.

### Description List
- see above

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- Code review

Closes #207 
