### PR TITLE
Feat/weekly reports

### DIFF
--- a/backend/compact-connect/bin/generate_mock_license_csv_upload_file.py
+++ b/backend/compact-connect/bin/generate_mock_license_csv_upload_file.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-# Quick script to generate some mock data for test environments
+# Quick script to generate some mock data in a csv file for test environments
+# The csv file must then be uploaded into the system using the bulk upload process.
 #
 # Run from 'backend/compact-connect' like:
-# bin/generate_mock_data.py --count 100 --compact octp --jurisdiction ne
+# bin/generate_mock_license_csv_upload_file.py --count 100 --compact octp --jurisdiction ne
 import json
 import os
 import sys

--- a/backend/compact-connect/bin/generate_mock_transactions.py
+++ b/backend/compact-connect/bin/generate_mock_transactions.py
@@ -1,0 +1,186 @@
+# ruff: noqa: T201 we use print statements for local scripts
+#!/usr/bin/env python3
+# Script to generate mock transaction data for test environments
+# it spreads the transactions across a range of dates and providers to simulate real-world data.
+#
+# Run from 'backend/compact-connect' like:
+# bin/generate_mock_transactions.py --compact aslp --start_date 01/01/2024 --end_date 03/01/2024 --count 100
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import sys
+from datetime import UTC, datetime
+
+import boto3
+from botocore.config import Config
+
+# Add the provider data lambda runtime to our pythonpath
+provider_data_path = os.path.join('lambdas', 'python', 'common')
+sys.path.append(provider_data_path)
+
+with open('cdk.json') as context_file:
+    _context = json.load(context_file)['context']
+COMPACTS = _context['compacts']
+
+
+def parse_date(date_str: str) -> datetime:
+    """Parse date string in mm/dd/yyyy format to datetime object."""
+    return datetime.strptime(date_str, '%m/%d/%Y').replace(tzinfo=UTC)
+
+
+def get_random_timestamp(start_date: datetime, end_date: datetime) -> datetime:
+    """Generate a random timestamp between start and end dates."""
+    time_diff = end_date.timestamp() - start_date.timestamp()
+    random_time = start_date.timestamp() + random.random() * time_diff
+    return datetime.fromtimestamp(random_time, tz=UTC)
+
+
+def get_table_by_pattern(tables: list[dict], pattern: str) -> str:
+    """Find table name that contains the given pattern."""
+    matching_tables = [t['TableName'] for t in tables if pattern in t['TableName']]
+    if not matching_tables:
+        raise ValueError(f'No table found containing pattern: {pattern}')
+    return matching_tables[0]
+
+
+async def get_provider_ids(provider_table, compact: str) -> set:
+    """Get all provider IDs for the given compact."""
+    provider_ids = set()
+    scan_kwargs = {'FilterExpression': boto3.dynamodb.conditions.Key('sk').eq(f'{compact}#PROVIDER')}
+
+    done = False
+    start_key = None
+    while not done:
+        if start_key:
+            scan_kwargs['ExclusiveStartKey'] = start_key
+        response = provider_table.scan(**scan_kwargs)
+        for item in response.get('Items', []):
+            if 'providerId' in item:
+                provider_ids.add(item['providerId'])
+        start_key = response.get('LastEvaluatedKey', None)
+        done = start_key is None
+
+    print(f'Found {len(provider_ids)} providers for compact {compact}')
+    return provider_ids
+
+
+def generate_transaction(compact: str, start_date: datetime, end_date: datetime, provider_id: str) -> dict:
+    """Generate a single mock transaction."""
+    settlement_time = get_random_timestamp(start_date, end_date)
+    submit_time = get_random_timestamp(start_date, settlement_time)
+    transaction_id = str(random.randint(100000000000, 999999999999))
+    batch_id = '15867123'
+    epoch_timestamp = int(settlement_time.timestamp())
+    month_key = settlement_time.strftime('%Y-%m')
+
+    return {
+        'pk': f'COMPACT#{compact}#TRANSACTIONS#MONTH#{month_key}',
+        'sk': f'COMPACT#{compact}#TIME#{epoch_timestamp}#BATCH#{batch_id}#TX#{transaction_id}',
+        'batch': {
+            'batchId': batch_id,
+            'settlementState': 'settledSuccessfully',
+            'settlementTimeLocal': settlement_time.strftime('%Y-%m-%dT%H:%M:%S'),
+            'settlementTimeUTC': settlement_time.strftime('%Y-%m-%dT%H:%M:%S.000Z'),
+        },
+        'compact': compact,
+        'licenseeId': provider_id,
+        'lineItems': [
+            {
+                'description': 'Compact Privilege for Ohio',
+                'itemId': f'{compact}-oh',
+                'name': 'Ohio Compact Privilege',
+                'quantity': '1.0',
+                'taxable': 'False',
+                'unitPrice': '75.0',
+            },
+            {
+                'description': 'Compact fee applied for each privilege purchased',
+                'itemId': f'{compact}-compact-fee',
+                'name': f'{compact.upper()} Compact Fee',
+                'quantity': '1.0',
+                'taxable': 'False',
+                'unitPrice': '10.0',
+            },
+        ],
+        'responseCode': '1',
+        'settleAmount': '85.0',
+        'submitTimeUTC': submit_time.strftime('%Y-%m-%dT%H:%M:%S.000Z'),
+        'transactionId': transaction_id,
+        'transactionProcessor': 'authorize.net',
+        'transactionStatus': 'settledSuccessfully',
+        'transactionType': 'authCaptureTransaction',
+    }
+
+
+async def write_transactions_batch(transaction_table, batch: list[dict]):
+    """Write a batch of transactions to DynamoDB."""
+    try:
+        with transaction_table.batch_writer() as batch_writer:
+            for transaction in batch:
+                batch_writer.put_item(Item=transaction)
+                # Give other tasks a chance to run
+                await asyncio.sleep(0)
+    except Exception as e:
+        print(f'Error writing batch: {str(e)}')
+        raise
+
+
+async def main():
+    parser = argparse.ArgumentParser(description='Generate mock transaction data')
+    parser.add_argument('--compact', required=True, choices=COMPACTS, help='The compact to generate transactions for')
+    parser.add_argument('--start_date', required=True, help='Start date in mm/dd/yyyy format')
+    parser.add_argument('--end_date', required=True, help='End date in mm/dd/yyyy format')
+    parser.add_argument('--count', type=int, required=True, help='Number of transactions to generate')
+
+    args = parser.parse_args()
+
+    # Parse dates
+    start_date = parse_date(args.start_date)
+    end_date = parse_date(args.end_date)
+
+    # Initialize DynamoDB resource
+    config = Config(retries=dict(max_attempts=10))
+    dynamodb = boto3.resource('dynamodb', config=config)
+
+    # Get list of tables
+    client = boto3.client('dynamodb')
+    tables = client.list_tables()['TableNames']
+    tables = [{'TableName': t} for t in tables]
+
+    # Get table resources
+    provider_table = dynamodb.Table(get_table_by_pattern(tables, 'ProviderTable'))
+    transaction_table = dynamodb.Table(get_table_by_pattern(tables, 'TransactionHistoryTable'))
+
+    # Get provider IDs
+    provider_ids = await get_provider_ids(provider_table, args.compact)
+    if not provider_ids:
+        raise ValueError(f'No providers found for compact {args.compact}')
+
+    # Convert provider_ids to list for random selection
+    provider_ids = list(provider_ids)
+
+    # Generate transactions
+    transactions = []
+    for _ in range(args.count):
+        provider_id = provider_ids[_ % len(provider_ids)]
+        transaction = generate_transaction(args.compact, start_date, end_date, provider_id)
+        transactions.append(transaction)
+
+    # Split transactions into batches for parallel processing
+    batch_size = 25  # DynamoDB batch_writer handles up to 25 items
+    transaction_batches = [transactions[i : i + batch_size] for i in range(0, len(transactions), batch_size)]
+
+    # Create tasks for parallel batch writing
+    tasks = [write_transactions_batch(transaction_table, batch) for batch in transaction_batches]
+
+    # Execute all batch writes concurrently
+    await asyncio.gather(*tasks)
+
+    print(f'Successfully wrote {len(transactions)} transactions to the database')
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
+++ b/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
@@ -52,7 +52,7 @@ export class Lambda implements LambdaInterface {
      */
     @logger.injectLambdaContext({ resetKeys: true })
     public async handler(event: EmailNotificationEvent, context: Context): Promise<EmailNotificationResponse> {
-        logger.info('Processing event', { event: event });
+        logger.info('Processing event', { template: event.template, compact: event.compact, jurisdiction: event.jurisdiction });
 
         // Check if FROM_ADDRESS is configured
         if (environmentVariables.getFromAddress() === 'NONE') {

--- a/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
+++ b/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
@@ -63,6 +63,16 @@ export class Lambda implements LambdaInterface {
                 event.specificEmails
             );
             break;
+        case 'CompactTransactionReporting':
+            if (!event.templateVariables?.compactFinancialSummaryReportCSV || !event.templateVariables?.compactTransactionReportCSV) {
+                throw new Error('Missing required template variables for CompactTransactionReporting template');
+            }
+            await this.emailService.sendCompactTransactionReportEmail(
+                event.compact,
+                event.templateVariables.compactFinancialSummaryReportCSV,
+                event.templateVariables.compactTransactionReportCSV
+            );
+            break;
         default:
             logger.info('Unsupported email template provided', { template: event.template });
             throw new Error(`Unsupported email template: ${event.template}`);

--- a/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
+++ b/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
@@ -71,7 +71,8 @@ export class Lambda implements LambdaInterface {
             );
             break;
         case 'CompactTransactionReporting':
-            if (!event.templateVariables?.compactFinancialSummaryReportCSV || !event.templateVariables?.compactTransactionReportCSV) {
+            if (!event.templateVariables?.compactFinancialSummaryReportCSV ||
+                !event.templateVariables?.compactTransactionReportCSV) {
                 throw new Error('Missing required template variables for CompactTransactionReporting template');
             }
             await this.emailService.sendCompactTransactionReportEmail(

--- a/backend/compact-connect/lambdas/nodejs/ingest-event-reporter/lambda.ts
+++ b/backend/compact-connect/lambdas/nodejs/ingest-event-reporter/lambda.ts
@@ -47,6 +47,7 @@ export class Lambda implements LambdaInterface {
             logger: logger,
             sesClient: props.sesClient,
             compactConfigurationClient: compactConfigurationClient,
+            jurisdictionClient: this.jurisdictionClient
         });
     }
 

--- a/backend/compact-connect/lambdas/nodejs/lib/email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email-service.ts
@@ -257,6 +257,7 @@ export class EmailService {
         recipientType: RecipientType,
         specificEmails?: string[]
     ): Promise<void> {
+        this.logger.info('Sending transaction batch settlement failure email', { compact: compact });
         const recipients = await this.getRecipients(compact, recipientType, specificEmails);
 
         if (recipients.length === 0) {
@@ -864,6 +865,7 @@ export class EmailService {
         compactFinancialSummaryReportCSV: string,
         compactTransactionReportCSV: string
     ): Promise<void> {
+        this.logger.info('Sending compact transaction report email', { compact: compact });
         const recipients = await this.getRecipients(compact, 'COMPACT_SUMMARY_REPORT');
         
         if (recipients.length === 0) {
@@ -907,6 +909,7 @@ export class EmailService {
         jurisdictionPostalAbbreviation: string,
         jurisdictionTransactionReportCSV: string
     ): Promise<void> {
+        this.logger.info('Sending jurisdiction transaction report email', { compact: compact, jurisdiction: jurisdictionPostalAbbreviation });
         // Get jurisdiction configuration to get the jurisdiction name and recipients
         const jurisdiction = await this.jurisdictionClient.getJurisdictionConfiguration(
             compact, jurisdictionPostalAbbreviation);
@@ -924,9 +927,8 @@ export class EmailService {
 
         const report = JSON.parse(JSON.stringify(this.emailTemplate));
         const subject = `${jurisdictionName} Weekly Report for Compact ${compactName}`;
-        const bodyText = 'Please find attached the weekly transaction report for your jurisdiction.\n\n' +
-            `This report contains all transactions that purchased a privilege within ${jurisdictionName} ` +
-            'during the previous week.';
+        const bodyText = `Please find attached the weekly transaction report for your jurisdiction.\n\n` +
+            `This report contains all transactions that purchased a privilege within ${jurisdictionName} during the previous week.`;
 
         this.insertHeader(report, subject);
         this.insertBody(report, bodyText);

--- a/backend/compact-connect/lambdas/nodejs/lib/email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email-service.ts
@@ -106,7 +106,7 @@ export class EmailService {
         try {
             // Create a nodemailer transport that generates raw MIME messages
             const transport = nodemailer.createTransport({
-                SES: { ses: this.sesClient, aws: { SendRawEmailCommand } }
+                SES: { ses: this.sesClient, aws: { SendRawEmailCommand }}
             });
 
             // Create the email message
@@ -115,7 +115,7 @@ export class EmailService {
                 to: recipients,
                 subject: subject,
                 html: htmlContent,
-                attachments: attachments.map(attachment => ({
+                attachments: attachments.map((attachment) => ({
                     filename: attachment.filename,
                     content: attachment.content,
                     contentType: attachment.contentType
@@ -124,6 +124,7 @@ export class EmailService {
 
             // Send the email
             const result = await transport.sendMail(message);
+
             return result.messageId;
         } catch (error) {
             this.logger.error(errorMessage, { error: error });
@@ -907,9 +908,11 @@ export class EmailService {
         jurisdictionTransactionReportCSV: string
     ): Promise<void> {
         // Get jurisdiction configuration to get the jurisdiction name and recipients
-        const jurisdiction = await this.jurisdictionClient.getJurisdictionConfiguration(compact, jurisdictionPostalAbbreviation);
+        const jurisdiction = await this.jurisdictionClient.getJurisdictionConfiguration(
+            compact, jurisdictionPostalAbbreviation);
 
         const recipients = jurisdiction.jurisdictionSummaryReportNotificationEmails;
+
         if (recipients.length === 0) {
             throw new Error(`No recipients found for jurisdiction ${jurisdictionPostalAbbreviation} in compact ${compact}`);
         }
@@ -921,8 +924,9 @@ export class EmailService {
 
         const report = JSON.parse(JSON.stringify(this.emailTemplate));
         const subject = `${jurisdictionName} Weekly Report for Compact ${compactName}`;
-        const bodyText = `Please find attached the weekly transaction report for your jurisdiction.\n\n` +
-            `This report contains all transactions that purchased a privilege within ${jurisdictionName} during the previous week.`;
+        const bodyText = 'Please find attached the weekly transaction report for your jurisdiction.\n\n' +
+            `This report contains all transactions that purchased a privilege within ${jurisdictionName} ` +
+            'during the previous week.';
 
         this.insertHeader(report, subject);
         this.insertBody(report, bodyText);

--- a/backend/compact-connect/lambdas/nodejs/lib/jurisdiction-client.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/jurisdiction-client.ts
@@ -3,25 +3,27 @@
  * DynamoDB table.
  */
 import { Logger } from '@aws-lambda-powertools/logger';
-import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, QueryCommand, GetItemCommand } from '@aws-sdk/client-dynamodb';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { EnvironmentVariablesService } from './environment-variables-service';
 import { IJurisdiction } from './models';
 
 const environmentVariables = new EnvironmentVariablesService();
 
-
 interface JurisdictionClientProps {
     logger: Logger;
     dynamoDBClient: DynamoDBClient;
 }
 
-
 export class JurisdictionClient {
+    private readonly logger: Logger;
     private readonly dynamoDBClient: DynamoDBClient;
+    private readonly tableName: string;
 
     public constructor(props: JurisdictionClientProps) {
+        this.logger = props.logger;
         this.dynamoDBClient = props.dynamoDBClient;
+        this.tableName = environmentVariables.getCompactConfigurationTableName();
     }
 
     /*
@@ -31,7 +33,7 @@ export class JurisdictionClient {
         compactAbbr: string
     ): Promise<IJurisdiction[]> {
         const resp = await this.dynamoDBClient.send(new QueryCommand({
-            TableName: environmentVariables.getCompactConfigurationTableName(),
+            TableName: this.tableName,
             Select: 'ALL_ATTRIBUTES',
             KeyConditionExpression: 'pk = :pk and begins_with (sk, :sk)',
             ExpressionAttributeValues: {
@@ -41,5 +43,34 @@ export class JurisdictionClient {
         }));
 
         return resp.Items?.map((item) => unmarshall(item) as IJurisdiction) || [];
+    }
+
+    /**
+     * Get a specific jurisdiction configuration
+     * 
+     * @param compact - The compact abbreviation
+     * @param jurisdiction - The jurisdiction postal abbreviation
+     * @returns The jurisdiction configuration
+     * @throws CCNotFoundException if the jurisdiction configuration is not found
+     */
+    public async getJurisdictionConfiguration(compact: string, jurisdiction: string): Promise<IJurisdiction> {
+        this.logger.info('Getting jurisdiction configuration', { compact, jurisdiction });
+
+        const response = await this.dynamoDBClient.send(
+            new GetItemCommand({
+                TableName: this.tableName,
+                Key: {
+                    'pk': { S: `${compact}#CONFIGURATION` },
+                    'sk': { S: `${compact}#JURISDICTION#${jurisdiction.toLowerCase()}` }
+                }
+            })
+        );
+
+        if (!response.Item) {
+            throw new Error(`Jurisdiction configuration not found for ${jurisdiction}`);
+        }
+
+        return unmarshall(response.Item) as IJurisdiction;
+
     }
 }

--- a/backend/compact-connect/lambdas/nodejs/package.json
+++ b/backend/compact-connect/lambdas/nodejs/package.json
@@ -22,6 +22,7 @@
     "@types/aws-lambda": "8.10.145",
     "@types/jest": "^29.5.12",
     "@types/node": "22.5.4",
+    "@types/nodemailer": "^6.4.14",
     "@types/react": "^18.3.12",
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",
@@ -55,6 +56,7 @@
     "@aws-sdk/util-dynamodb": "^3.682.0",
     "@usewaypoint/email-builder": "^0.0.6",
     "aws-lambda": "1.0.7",
+    "nodemailer": "^6.9.12",
     "zod": "^3.23.8"
   }
 }

--- a/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
@@ -69,6 +69,7 @@ describe('EmailNotificationServiceLambda', () => {
         // Set up default successful responses
         mockDynamoDBClient.on(GetItemCommand).callsFake((input) => {
             const key = input.Key;
+
             if (key.sk.S === 'aslp#CONFIGURATION') {
                 return Promise.resolve({
                     Item: SAMPLE_COMPACT_CONFIGURATION
@@ -200,8 +201,10 @@ describe('EmailNotificationServiceLambda', () => {
 
             // Get the raw email data and verify it contains the attachments
             const rawEmailData = mockSESClient.commandCalls(SendRawEmailCommand)[0].args[0].input.RawMessage?.Data;
+
             expect(rawEmailData).toBeDefined();
             const rawEmailString = rawEmailData?.toString();
+
             expect(rawEmailString).toContain('Content-Type: text/csv');
             expect(rawEmailString).toContain('Content-Disposition: attachment; filename=financial-summary-report.csv');
             expect(rawEmailString).toContain('Content-Disposition: attachment; filename=transaction-detail-report.csv');
@@ -215,7 +218,7 @@ describe('EmailNotificationServiceLambda', () => {
             mockDynamoDBClient.on(GetItemCommand).resolves({
                 Item: {
                     ...SAMPLE_COMPACT_CONFIGURATION,
-                    compactSummaryReportNotificationEmails: { L: [] }
+                    compactSummaryReportNotificationEmails: { L: []}
                 }
             });
 
@@ -274,8 +277,10 @@ describe('EmailNotificationServiceLambda', () => {
 
             // Get the raw email data and verify it contains the attachments
             const rawEmailData = mockSESClient.commandCalls(SendRawEmailCommand)[0].args[0].input.RawMessage?.Data;
+
             expect(rawEmailData).toBeDefined();
             const rawEmailString = rawEmailData?.toString();
+
             expect(rawEmailString).toContain('Content-Type: text/csv');
             expect(rawEmailString).toContain('Content-Disposition: attachment; filename=oh-transaction-report.csv');
             expect(rawEmailString).toContain('Subject: Ohio Weekly Report for Compact ASLP');
@@ -287,7 +292,7 @@ describe('EmailNotificationServiceLambda', () => {
             mockDynamoDBClient.on(GetItemCommand).resolves({
                 Item: {
                     ...SAMPLE_JURISDICTION_CONFIGURATION,
-                    jurisdictionSummaryReportNotificationEmails: { L: [] }
+                    jurisdictionSummaryReportNotificationEmails: { L: []}
                 }
             });
 

--- a/backend/compact-connect/lambdas/nodejs/tests/email-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-service.test.ts
@@ -5,6 +5,7 @@ import { SendEmailCommand, SendRawEmailCommand, SESClient } from '@aws-sdk/clien
 import * as nodemailer from 'nodemailer';
 import { EmailService } from '../lib/email-service';
 import { CompactConfigurationClient } from '../lib/compact-configuration-client';
+import { JurisdictionClient } from '../lib/jurisdiction-client';
 import {
     SAMPLE_SORTABLE_VALIDATION_ERROR_RECORDS,
     SAMPLE_UNMARSHALLED_INGEST_FAILURE_ERROR_RECORD,
@@ -28,6 +29,17 @@ const SAMPLE_COMPACT_CONFIG = {
     type: 'compact'
 };
 
+const SAMPLE_JURISDICTION_CONFIG = {
+    pk: 'aslp#CONFIGURATION',
+    sk: 'aslp#JURISDICTION#OH',
+    jurisdictionName: 'Ohio',
+    postalAbbreviation: 'OH',
+    compact: 'aslp',
+    jurisdictionOperationsTeamEmails: ['oh-ops@example.com'],
+    jurisdictionAdverseActionsNotificationEmails: ['oh-adverse@example.com'],
+    jurisdictionSummaryReportNotificationEmails: ['oh-summary@example.com']
+};
+
 /*
  * Double casting to allow us to pass a mock in for the real thing
  */
@@ -38,11 +50,7 @@ describe('Email Service', () => {
     let emailService: EmailService;
     let mockSESClient: ReturnType<typeof mockClient>;
     let mockCompactConfigurationClient: jest.Mocked<CompactConfigurationClient>;
-    beforeAll(async () => {
-        process.env.DEBUG = 'true';
-        process.env.FROM_ADDRESS = 'noreply@example.org';
-        process.env.UI_BASE_PATH_URL = 'https://app.test.compactconnect.org';
-    });
+    let mockJurisdictionClient: jest.Mocked<JurisdictionClient>;
     const MOCK_TRANSPORT = {
         sendMail: jest.fn().mockResolvedValue({ messageId: 'test-message-id' })
     };
@@ -51,9 +59,16 @@ describe('Email Service', () => {
         jest.clearAllMocks();
         mockSESClient = mockClient(SESClient);
         mockCompactConfigurationClient = {
-            getCompactConfiguration: jest.fn(),
-        } as unknown as jest.Mocked<CompactConfigurationClient>;
+            getCompactConfiguration: jest.fn()
+        } as any;
+        mockJurisdictionClient = {
+            getJurisdictionConfigurations: jest.fn(),
+            getJurisdictionConfiguration: jest.fn()
+        } as any;
 
+        // Reset environment variables
+        process.env.FROM_ADDRESS = 'noreply@example.org';
+        process.env.UI_BASE_PATH_URL = 'https://app.test.compactconnect.org';
 
         // Set up default successful responses
         mockSESClient.on(SendEmailCommand).resolves({
@@ -67,9 +82,10 @@ describe('Email Service', () => {
         (nodemailer.createTransport as jest.Mock).mockReturnValue(MOCK_TRANSPORT);
 
         emailService = new EmailService({
-            logger: new Logger(),
+            logger: new Logger({ serviceName: 'test' }),
             sesClient: asSESClient(mockSESClient),
-            compactConfigurationClient: mockCompactConfigurationClient
+            compactConfigurationClient: mockCompactConfigurationClient,
+            jurisdictionClient: mockJurisdictionClient
         });
     });
 
@@ -380,6 +396,62 @@ describe('Email Service', () => {
                 SAMPLE_SUMMARY_CSV,
                 SAMPLE_DETAIL_CSV
             )).rejects.toThrow('No recipients found for compact aslp with recipient type COMPACT_SUMMARY_REPORT');
+
+            // Verify no email was sent
+            expect(MOCK_TRANSPORT.sendMail).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Jurisdiction Transaction Report', () => {
+        const SAMPLE_TRANSACTION_CSV = 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,Compact Fee,Transaction Id\n';
+
+        beforeEach(() => {
+            mockCompactConfigurationClient.getCompactConfiguration.mockResolvedValue(SAMPLE_COMPACT_CONFIG);
+            mockJurisdictionClient.getJurisdictionConfiguration.mockResolvedValue(SAMPLE_JURISDICTION_CONFIG);
+        });
+
+        it('should send email with CSV attachment', async () => {
+            await emailService.sendJurisdictionTransactionReportEmail(
+                'aslp',
+                'oh',
+                SAMPLE_TRANSACTION_CSV
+            );
+
+            // Verify nodemailer transport was created with correct SES config
+            expect(nodemailer.createTransport).toHaveBeenCalledWith({
+                SES: { 
+                    ses: expect.any(Object), 
+                    aws: { SendRawEmailCommand } 
+                }
+            });
+
+            // Verify email was sent with correct parameters
+            expect(MOCK_TRANSPORT.sendMail).toHaveBeenCalledWith({
+                from: 'Compact Connect <noreply@example.org>',
+                to: ['oh-summary@example.com'],
+                subject: 'Ohio Weekly Report for Compact ASLP',
+                html: expect.stringContaining('Please find attached the weekly transaction report for your jurisdiction'),
+                attachments: [
+                    {
+                        filename: 'oh-transaction-report.csv',
+                        content: SAMPLE_TRANSACTION_CSV,
+                        contentType: 'text/csv'
+                    }
+                ]
+            });
+        });
+
+        it('should throw error when no recipients found', async () => {
+            mockJurisdictionClient.getJurisdictionConfiguration.mockResolvedValue({
+                ...SAMPLE_JURISDICTION_CONFIG,
+                jurisdictionSummaryReportNotificationEmails: []
+            });
+
+            await expect(emailService.sendJurisdictionTransactionReportEmail(
+                'aslp',
+                'oh',
+                SAMPLE_TRANSACTION_CSV
+            )).rejects.toThrow('No recipients found for jurisdiction oh in compact aslp');
 
             // Verify no email was sent
             expect(MOCK_TRANSPORT.sendMail).not.toHaveBeenCalled();

--- a/backend/compact-connect/lambdas/nodejs/yarn.lock
+++ b/backend/compact-connect/lambdas/nodejs/yarn.lock
@@ -2302,6 +2302,13 @@
   dependencies:
     undici-types "~6.19.2"
 
+"@types/nodemailer@^6.4.14":
+  version "6.4.17"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.17.tgz#5c82a42aee16a3dd6ea31446a1bd6a447f1ac1a4"
+  integrity sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==
+  dependencies:
+    "@types/node" "*"
+
 "@types/prop-types@*":
   version "15.7.14"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.14.tgz#1433419d73b2a7ebfc6918dcefd2ec0d5cd698f2"
@@ -5074,6 +5081,11 @@ node-releases@^2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
+
+nodemailer@^6.9.12:
+  version "6.9.16"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.16.tgz#3ebdf6c6f477c571c0facb0727b33892635e0b8b"
+  integrity sha512-psAuZdTIRN08HKVd/E8ObdV6NO7NTBY3KsC30F7M4H1OnmLCUNaS56FpYxyb26zWLSyYF9Ozch9KYHhHegsiOQ==
 
 nopt@~3.0.6:
   version "3.0.6"

--- a/backend/compact-connect/lambdas/python/common/cc_common/config.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/config.py
@@ -193,5 +193,13 @@ class _Config:
     def transaction_history_table(self):
         return boto3.resource('dynamodb').Table(self.transaction_history_table_name)
 
+    @cached_property
+    def lambda_client(self):
+        return boto3.client('lambda')
+
+    @property
+    def email_notification_service_lambda_name(self):
+        return os.environ['EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME']
+
 
 config = _Config()

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/data_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/data_client.py
@@ -561,7 +561,7 @@ class DataClient:
     def batch_get_providers_by_id(self, compact: str, provider_ids: list[str]) -> list[dict]:
         """
         Get provider records by their IDs in batches.
-        
+
         :param compact: The compact name
         :param provider_ids: List of provider IDs to fetch
         :return: List of provider records
@@ -569,31 +569,26 @@ class DataClient:
         providers = []
         # DynamoDB batch_get_item has a limit of 100 items per request
         batch_size = 100
-        
+
         # Process provider IDs in batches
         for i in range(0, len(provider_ids), batch_size):
-            batch_ids = provider_ids[i:i + batch_size]
+            batch_ids = provider_ids[i : i + batch_size]
             request_items = {
                 self.config.provider_table.table_name: {
                     'Keys': [
-                        {
-                            'pk': f'{compact}#PROVIDER#{provider_id}',
-                            'sk': f'{compact}#PROVIDER'
-                        }
+                        {'pk': f'{compact}#PROVIDER#{provider_id}', 'sk': f'{compact}#PROVIDER'}
                         for provider_id in batch_ids
                     ],
-                    'ConsistentRead': True
+                    'ConsistentRead': True,
                 }
             }
-            
-            response = self.config.provider_table.meta.client.batch_get_item(
-                RequestItems=request_items
-            )
-            
+
+            response = self.config.provider_table.meta.client.batch_get_item(RequestItems=request_items)
+
             # Add the returned items to our results
             if response['Responses']:
                 providers.extend(response['Responses'][self.config.provider_table.table_name])
-            
+
             # Handle any unprocessed keys by retrying
             while response.get('UnprocessedKeys'):
                 response = self.config.provider_table.meta.client.batch_get_item(
@@ -601,5 +596,5 @@ class DataClient:
                 )
                 if response['Responses']:
                     providers.extend(response['Responses'][self.config.provider_table.table_name])
-        
+
         return providers

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/common.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/common.py
@@ -98,8 +98,6 @@ class ChangeHashMixin:
         if 'removedValues' in in_data:
             hash_data['removedValues'] = sorted(in_data['removedValues'])
 
-        change_hash.update(
-            json.dumps(hash_data, sort_keys=True).encode('utf-8')
-        )
+        change_hash.update(json.dumps(hash_data, sort_keys=True).encode('utf-8'))
 
         return change_hash.hexdigest()

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
@@ -39,3 +39,94 @@ class TransactionClient:
                     batch.put_item(Item=item)
                 else:
                     raise ValueError(f'Unsupported transaction processor: {transaction_processor}')
+
+    def get_transactions_in_range(self, compact: str, start_epoch: int, end_epoch: int) -> dict:
+        """
+        Get all transactions for a compact within a given epoch timestamp range.
+
+        :param compact: The compact name
+        :param start_epoch: Start epoch timestamp (inclusive)
+        :param end_epoch: End epoch timestamp (inclusive)
+        :return: Dict containing transactions
+        """
+        # Calculate the month keys we need to query based on the epoch timestamps
+        start_date = datetime.fromtimestamp(start_epoch)
+        end_date = datetime.fromtimestamp(end_epoch)
+        
+        start_month = start_date.strftime('%Y-%m')
+        end_month = end_date.strftime('%Y-%m')
+
+        # Build query parameters
+        query_params = {
+            'Limit': 500,  # Max items per page
+            'ScanIndexForward': True,  # Sort by time ascending
+        }
+
+        all_items = []
+        
+        # Query start month
+        start_month_items = self._query_transactions_for_month(
+            compact=compact,
+            month=start_month,
+            start_epoch=start_epoch,
+            end_epoch=end_epoch,
+            query_params=query_params
+        )
+        all_items.extend(start_month_items)
+
+        # If end month is different, query that month as well
+        if end_month != start_month:
+            end_month_items = self._query_transactions_for_month(
+                compact=compact,
+                month=end_month,
+                start_epoch=start_epoch,
+                end_epoch=end_epoch,
+                query_params=query_params
+            )
+            all_items.extend(end_month_items)
+
+        return all_items
+
+    def _query_transactions_for_month(
+        self,
+        compact: str,
+        month: str,
+        start_epoch: int,
+        end_epoch: int,
+        query_params: dict,
+    ) -> None:
+        """
+        Query transactions for a specific month with pagination.
+
+        :param compact: The compact name
+        :param month: Month to query in YYYY-MM format
+        :param start_epoch: Start epoch timestamp
+        :param end_epoch: End epoch timestamp
+        :param query_params: Query parameters dict
+        :param all_items: List to append results to
+        """
+        all_matching_transactions = []
+        last_evaluated_key = None
+        while True:
+            if last_evaluated_key:
+                query_params['ExclusiveStartKey'] = last_evaluated_key
+
+            response = self.config.transaction_history_table.query(
+                KeyConditionExpression=(
+                    'pk = :pk AND sk BETWEEN :start_sk AND :end_sk'
+                ),
+                ExpressionAttributeValues={
+                    ':pk': f'COMPACT#{compact}#TRANSACTIONS#MONTH#{month}',
+                    ':start_sk': f'COMPACT#{compact}#TIME#{start_epoch}',
+                    ':end_sk': f'COMPACT#{compact}#TIME#{end_epoch}'
+                },
+                **query_params
+            )
+            
+            all_matching_transactions.extend(response.get('Items', []))
+            
+            last_evaluated_key = response.get('LastEvaluatedKey')
+            if not last_evaluated_key:
+                break
+
+        return all_matching_transactions

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 
 from boto3.dynamodb.conditions import Key
+
 from cc_common.config import _Config
 
 AUTHORIZE_DOT_NET_CLIENT_TYPE = 'authorize.net'

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
@@ -60,7 +60,7 @@ class TransactionClient:
         }
 
         all_items = []
-        
+
         # Generate list of months to query
         current_date = start_date.replace(day=1)
         months_to_query = []
@@ -75,11 +75,7 @@ class TransactionClient:
         # Query each month in the range
         for month in months_to_query:
             month_items = self._query_transactions_for_month(
-                compact=compact,
-                month=month,
-                start_epoch=start_epoch,
-                end_epoch=end_epoch,
-                query_params=query_params
+                compact=compact, month=month, start_epoch=start_epoch, end_epoch=end_epoch, query_params=query_params
             )
             all_items.extend(month_items)
 
@@ -110,15 +106,13 @@ class TransactionClient:
                 query_params['ExclusiveStartKey'] = last_evaluated_key
 
             response = self.config.transaction_history_table.query(
-                KeyConditionExpression=(
-                    'pk = :pk AND sk BETWEEN :start_sk AND :end_sk'
-                ),
+                KeyConditionExpression=('pk = :pk AND sk BETWEEN :start_sk AND :end_sk'),
                 ExpressionAttributeValues={
                     ':pk': f'COMPACT#{compact}#TRANSACTIONS#MONTH#{month}',
                     ':start_sk': f'COMPACT#{compact}#TIME#{start_epoch}',
-                    ':end_sk': f'COMPACT#{compact}#TIME#{end_epoch}'
+                    ':end_sk': f'COMPACT#{compact}#TIME#{end_epoch}',
                 },
-                **query_params
+                **query_params,
             )
 
             all_matching_transactions.extend(response.get('Items', []))

--- a/backend/compact-connect/lambdas/python/common/tests/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/tests/__init__.py
@@ -18,6 +18,7 @@ class TstLambdas(TestCase):
                 'EVENT_BUS_NAME': 'license-data-events',
                 'PROVIDER_TABLE_NAME': 'provider-table',
                 'COMPACT_CONFIGURATION_TABLE_NAME': 'compact-configuration-table',
+                'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': 'email-notification-service',
                 'ENVIRONMENT_NAME': 'test',
                 'PROV_FAM_GIV_MID_INDEX_NAME': 'providerFamGivMid',
                 'FAM_GIV_INDEX_NAME': 'famGiv',

--- a/backend/compact-connect/lambdas/python/common/tests/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/tests/__init__.py
@@ -19,6 +19,7 @@ class TstLambdas(TestCase):
                 'PROVIDER_TABLE_NAME': 'provider-table',
                 'COMPACT_CONFIGURATION_TABLE_NAME': 'compact-configuration-table',
                 'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': 'email-notification-service',
+                'TRANSACTION_HISTORY_TABLE_NAME': 'transaction-history-table',
                 'ENVIRONMENT_NAME': 'test',
                 'PROV_FAM_GIV_MID_INDEX_NAME': 'providerFamGivMid',
                 'FAM_GIV_INDEX_NAME': 'famGiv',

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_ingest.py
@@ -608,7 +608,7 @@ class TestIngest(TstFunction):
                     },
                     'updatedValues': {
                         'emailAddress': 'björk@example.com',
-                    }
+                    },
                 }
             ]
 

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -205,7 +205,7 @@ def _generate_compact_summary_report(
 def _generate_compact_transaction_report(transactions: list[dict], providers: dict) -> str:
     """Generate the compact transaction report CSV."""
     output = StringIO()
-    writer = csv.writer(output, lineterminator='\n')
+    writer = csv.writer(output, lineterminator='\n', dialect='excel')
     writer.writerow(
         [
             'Licensee First Name',
@@ -275,7 +275,7 @@ def _generate_jurisdiction_reports(
     for jurisdiction, trans_items in jurisdiction_transactions.items():
         logger.info('Generating report for jurisdiction', jurisdiction=jurisdiction)
         output = StringIO()
-        writer = csv.writer(output, lineterminator='\n')
+        writer = csv.writer(output, lineterminator='\n', dialect='excel')
         writer.writerow(
             [
                 'First Name',

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -1,0 +1,270 @@
+import csv
+from datetime import datetime, timedelta
+from io import StringIO
+from typing import Dict, List, Tuple
+import json
+
+from cc_common.data_model.schema.compact import COMPACT_TYPE, Compact
+from cc_common.data_model.schema.jurisdiction import JURISDICTION_TYPE, Jurisdiction
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from cc_common.config import config, logger
+from cc_common.exceptions import CCNotFoundException
+
+
+def generate_transaction_reports(event: dict, context: LambdaContext) -> dict:  # noqa: ARG001 unused-argument
+    """
+    Generate weekly transaction reports for a compact and its jurisdictions.
+    
+    :param event: Event containing the compact name
+    :param context: Lambda context
+    :return: Success message
+    """
+    compact = event['compact']
+    logger.info('Generating transaction reports', compact=compact)
+    
+    # Initialize clients
+    data_client = config.data_client
+    transaction_client = config.transaction_client
+    
+    # Calculate time range for the past week
+    # Use 11:59 PM UTC for end time to ensure we capture full day
+    end_time = config.current_standard_datetime.replace(hour=23, minute=59, second=59, microsecond=0)
+    start_time = end_time - timedelta(days=7)
+    start_epoch = int(start_time.timestamp())
+    end_epoch = int(end_time.timestamp())
+    
+    # Get all transactions for the past week
+    transactions = transaction_client.get_transactions_in_range(
+            compact=compact,
+            start_epoch=start_epoch,
+            end_epoch=end_epoch
+        )
+
+    # Get compact configuration and jurisdictions
+    compact_configuration_options = data_client.get_privilege_purchase_options(compact=compact)
+
+    compact_configuration = next((Compact(item) for item in compact_configuration_options['items'] if item['type'] == COMPACT_TYPE), None)
+    if not compact_configuration:
+        message = f"Compact configuration not found for the specified compact: {compact}"
+        logger.error(message)
+        raise CCNotFoundException(message)
+
+    jurisdiction_configurations = [item for item in compact_configuration_options['items'] if item['type'] == JURISDICTION_TYPE]
+
+    # Get unique provider IDs from transactions and their details
+    provider_ids = {t['licenseeId'] for t in transactions}
+    providers = {}
+    if provider_ids:
+        providers = {
+            p['providerId']: p 
+            for p in data_client.batch_get_providers_by_id(compact, list(provider_ids))
+        }
+    
+    # Generate reports
+    compact_summary_csv = generate_compact_summary_report(transactions, compact_configuration, jurisdiction_configurations)
+    compact_transaction_csv = generate_compact_transaction_report(transactions, providers)
+    jurisdiction_reports = generate_jurisdiction_reports(transactions, providers, jurisdiction_configurations)
+    
+    # Send compact summary report
+    config.lambda_client.invoke(
+        FunctionName=config.email_notification_service_lambda_name,
+        InvocationType='RequestResponse',
+        Payload=json.dumps({
+            'compact': compact,
+            'template': 'CompactTransactionReporting',
+            'recipientType': 'COMPACT_SUMMARY_REPORT',
+            'templateVariables': {
+                'compactFinancialSummaryReportCSV': compact_summary_csv,
+                'compactTransactionReportCSV': compact_transaction_csv
+            }
+        })
+    )
+    
+    # Send jurisdiction reports
+    for jurisdiction, report in jurisdiction_reports.items():
+        config.lambda_client.invoke(
+            FunctionName=config.email_notification_service_lambda_name,
+            InvocationType='RequestResponse',
+            Payload=json.dumps({
+                'compact': compact,
+                'jurisdiction': jurisdiction,
+                'template': 'JurisdictionTransactionReporting',
+                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                'templateVariables': {
+                    'jurisdictionTransactionReportCSV': report
+                }
+            })
+        )
+    
+    return {'message': 'reports sent successfully'}
+
+
+def generate_compact_summary_report(transactions: List[dict], compact_config: Compact, jurisdiction_configs: List[dict]) -> str:
+    """Generate the compact financial summary report CSV."""
+    total_transactions = len(transactions)
+    compact_fees = sum(
+        float(item['unitPrice']) * float(item['quantity'])
+        for t in transactions
+        for item in t['lineItems']
+        if item['itemId'].endswith('-compact fee')
+    ) if transactions else 0
+    
+    # Calculate state fees per jurisdiction
+    jurisdiction_fees = {}
+    for jurisdiction in jurisdiction_configs:
+        jurisdiction_postal = jurisdiction['postalAbbreviation'].lower()
+        jurisdiction_fees[jurisdiction_postal] = sum(
+            float(item['unitPrice']) * float(item['quantity'])
+            for t in transactions
+            for item in t['lineItems']
+            if item['itemId'].endswith(f'-{jurisdiction_postal}')
+        )
+    
+    # Generate CSV
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(['Total Transactions', total_transactions])
+    writer.writerow(['Total Compact Fees', f'${compact_fees:.2f}'])
+    
+    for jurisdiction in jurisdiction_configs:
+        postal = jurisdiction['postalAbbreviation'].lower()
+        fee_value = jurisdiction_fees.get(postal, 0)
+        writer.writerow([
+            f'State Fees ({jurisdiction["jurisdictionName"].capitalize()})',
+            f'${fee_value:.2f}'
+        ])
+    
+    return output.getvalue()
+
+
+def generate_compact_transaction_report(transactions: List[dict], providers: Dict[str, dict]) -> str:
+    """Generate the compact transaction report CSV."""
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow([
+        'Licensee First Name',
+        'Licensee Last Name',
+        'Licensee Id',
+        'Transaction Date',
+        'State',
+        'State Fee',
+        'Compact Fee',
+        'Transaction Id'
+    ])
+    
+    if not transactions:
+        writer.writerow(['No transactions for this period'] + [''] * 7)
+        return output.getvalue()
+    
+    for transaction in transactions:
+        provider = providers.get(transaction['licenseeId'], {})
+        transaction_date = datetime.fromisoformat(transaction['batch']['settlementTimeUTC']).strftime('%m-%d-%Y')
+        compact_fee_item = next(
+            item for item in transaction['lineItems'] 
+            if item['itemId'].endswith('-compact fee')
+        )
+        
+        # Write a row for each state privilege in the transaction
+        for item in transaction['lineItems']:
+            if item['itemId'].endswith('-compact fee'):
+                continue
+                
+            # Extract state from itemId (format: compact-state)
+            state = item['itemId'].split('-')[1].upper()
+            
+            writer.writerow([
+                provider.get('givenName', ''),
+                provider.get('familyName', ''),
+                transaction['licenseeId'],
+                transaction_date,
+                state,
+                item['unitPrice'],
+                compact_fee_item['unitPrice'],
+                transaction['transactionId']
+            ])
+    
+    return output.getvalue()
+
+
+def generate_jurisdiction_reports(
+    transactions: List[dict],
+    providers: Dict[str, dict],
+    jurisdiction_configurations: List[dict]
+
+) -> Dict[str, str]:
+    """Generate transaction reports for each jurisdiction."""
+    jurisdiction_transactions: Dict[str, List[Tuple[dict, dict]]] = {
+        j['postalAbbreviation'].lower(): []
+        for j in jurisdiction_configurations
+    }
+    
+    # Group transactions by jurisdiction
+    for transaction in transactions:
+        for item in transaction['lineItems']:
+            if item['itemId'].endswith('-compact fee'):
+                continue
+                
+            state = item['itemId'].split('-')[1]
+            if state in jurisdiction_transactions:
+                jurisdiction_transactions[state].append((transaction, item))
+    
+    # Generate report for each jurisdiction
+    reports = {}
+    for jurisdiction, trans_items in jurisdiction_transactions.items():
+        output = StringIO()
+        writer = csv.writer(output)
+        writer.writerow([
+            'First Name',
+            'Last Name',
+            'Licensee Id',
+            'Transaction Date',
+            'State Fee',
+            'State',
+            'Compact Fee',
+            'Transaction Id'
+        ])
+        
+        if not trans_items:
+            writer.writerow(['No transactions for this period'] + [''] * 7)
+            writer.writerow([''] * 8)
+            writer.writerow(['Privileges Purchased', 'Total State Amount'] + [''] * 6)
+            writer.writerow(['0', '$0.00'] + [''] * 6)
+            reports[jurisdiction] = output.getvalue()
+            continue
+            
+        total_privileges = 0
+        total_amount = 0
+        
+        for transaction, item in trans_items:
+            provider = providers.get(transaction['licenseeId'], {})
+            transaction_date = datetime.fromisoformat(
+                transaction['batch']['settlementTimeUTC']
+            ).strftime('%m-%d-%Y')
+            
+            compact_fee_item = next(
+                i for i in transaction['lineItems']
+                if i['itemId'].endswith('-compact fee')
+            )
+            
+            writer.writerow([
+                provider.get('givenName', ''),
+                provider.get('familyName', ''),
+                transaction['licenseeId'],
+                transaction_date,
+                item['unitPrice'],
+                jurisdiction.upper(),
+                compact_fee_item['unitPrice'],
+                transaction['transactionId']
+            ])
+            
+            total_privileges += float(item['quantity'])
+            total_amount += float(item['unitPrice']) * float(item['quantity'])
+        
+        # Add summary rows
+        writer.writerow([''] * 8)
+        writer.writerow(['Privileges Purchased', 'Total State Amount'] + [''] * 6)
+        writer.writerow([int(total_privileges), f'${total_amount:.2f}'] + [''] * 6)
+        
+        reports[jurisdiction] = output.getvalue()
+    
+    return reports

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -58,6 +58,16 @@ def generate_transaction_reports(event: dict, context: LambdaContext) -> dict:  
     if provider_ids:
         providers = {p['providerId']: p for p in data_client.batch_get_providers_by_id(compact, list(provider_ids))}
 
+        # the batch_get_item api call will silently omit any records that are not found, so we need to check for it here
+        # This should not happen, but if it does, we log it
+        missing_providers = provider_ids - set(providers.keys())
+        if missing_providers:
+            logger.warning(
+                'Some providers were not found in the database',
+                missing_provider_ids=list(missing_providers),
+                compact=compact,
+            )
+
     # Generate reports
     compact_summary_csv = generate_compact_summary_report(
         transactions, compact_configuration, jurisdiction_configurations

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -134,7 +134,9 @@ def generate_transaction_reports(event: dict, context: LambdaContext) -> dict:  
             lambda_error_messages.append(jurisdiction_response.get('FunctionError'))
 
     if lambda_error_messages:
-        raise CCInternalException(f'Failed to send one or more reports. Errors: {lambda_error_messages}')
+        raise CCInternalException(
+            f'One or more errors occurred while generating reports. ' f'Errors: {lambda_error_messages}'
+        )
 
     return {'message': 'reports sent successfully'}
 

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -1,7 +1,7 @@
 import csv
-from decimal import Decimal
 import json
 from datetime import datetime, timedelta
+from decimal import Decimal
 from io import StringIO
 
 from aws_lambda_powertools.utilities.typing import LambdaContext

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -1,109 +1,114 @@
 import csv
+import json
 from datetime import datetime, timedelta
 from io import StringIO
-from typing import Dict, List, Tuple
-import json
 
-from cc_common.data_model.schema.compact import COMPACT_TYPE, Compact
-from cc_common.data_model.schema.jurisdiction import JURISDICTION_TYPE
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from cc_common.config import config, logger
+from cc_common.data_model.schema.compact import COMPACT_TYPE, Compact
+from cc_common.data_model.schema.jurisdiction import JURISDICTION_TYPE
 from cc_common.exceptions import CCNotFoundException
 
 
 def generate_transaction_reports(event: dict, context: LambdaContext) -> dict:  # noqa: ARG001 unused-argument
     """
     Generate weekly transaction reports for a compact and its jurisdictions.
-    
+
     :param event: Event containing the compact name
     :param context: Lambda context
     :return: Success message
     """
     compact = event['compact']
     logger.info('Generating transaction reports', compact=compact)
-    
+
     # Initialize clients
     data_client = config.data_client
     transaction_client = config.transaction_client
-    
+
     # Calculate time range for the past week
     # Use 11:59 PM UTC for end time to ensure we capture full day
     end_time = config.current_standard_datetime.replace(hour=23, minute=59, second=59, microsecond=0)
     start_time = end_time - timedelta(days=7)
     start_epoch = int(start_time.timestamp())
     end_epoch = int(end_time.timestamp())
-    
+
     # Get all transactions for the past week
     transactions = transaction_client.get_transactions_in_range(
-            compact=compact,
-            start_epoch=start_epoch,
-            end_epoch=end_epoch
-        )
+        compact=compact, start_epoch=start_epoch, end_epoch=end_epoch
+    )
 
     # Get compact configuration and jurisdictions
     compact_configuration_options = data_client.get_privilege_purchase_options(compact=compact)
 
-    compact_configuration = next((Compact(item) for item in compact_configuration_options['items'] if item['type'] == COMPACT_TYPE), None)
+    compact_configuration = next(
+        (Compact(item) for item in compact_configuration_options['items'] if item['type'] == COMPACT_TYPE), None
+    )
     if not compact_configuration:
-        message = f"Compact configuration not found for the specified compact: {compact}"
+        message = f'Compact configuration not found for the specified compact: {compact}'
         logger.error(message)
         raise CCNotFoundException(message)
 
-    jurisdiction_configurations = [item for item in compact_configuration_options['items'] if item['type'] == JURISDICTION_TYPE]
+    jurisdiction_configurations = [
+        item for item in compact_configuration_options['items'] if item['type'] == JURISDICTION_TYPE
+    ]
 
     # Get unique provider IDs from transactions and their details
     provider_ids = {t['licenseeId'] for t in transactions}
     providers = {}
     if provider_ids:
-        providers = {
-            p['providerId']: p 
-            for p in data_client.batch_get_providers_by_id(compact, list(provider_ids))
-        }
-    
+        providers = {p['providerId']: p for p in data_client.batch_get_providers_by_id(compact, list(provider_ids))}
+
     # Generate reports
-    compact_summary_csv = generate_compact_summary_report(transactions, compact_configuration, jurisdiction_configurations)
+    compact_summary_csv = generate_compact_summary_report(
+        transactions, compact_configuration, jurisdiction_configurations
+    )
     compact_transaction_csv = generate_compact_transaction_report(transactions, providers)
     jurisdiction_reports = generate_jurisdiction_reports(transactions, providers, jurisdiction_configurations)
-    
+
     # Send compact summary report
     config.lambda_client.invoke(
         FunctionName=config.email_notification_service_lambda_name,
         InvocationType='RequestResponse',
-        Payload=json.dumps({
-            'compact': compact,
-            'template': 'CompactTransactionReporting',
-            'recipientType': 'COMPACT_SUMMARY_REPORT',
-            'templateVariables': {
-                'compactFinancialSummaryReportCSV': compact_summary_csv,
-                'compactTransactionReportCSV': compact_transaction_csv
+        Payload=json.dumps(
+            {
+                'compact': compact,
+                'template': 'CompactTransactionReporting',
+                'recipientType': 'COMPACT_SUMMARY_REPORT',
+                'templateVariables': {
+                    'compactFinancialSummaryReportCSV': compact_summary_csv,
+                    'compactTransactionReportCSV': compact_transaction_csv,
+                },
             }
-        })
+        ),
     )
-    
+
     # Send jurisdiction reports
     for jurisdiction, report in jurisdiction_reports.items():
         config.lambda_client.invoke(
             FunctionName=config.email_notification_service_lambda_name,
             InvocationType='RequestResponse',
-            Payload=json.dumps({
-                'compact': compact,
-                'jurisdiction': jurisdiction,
-                'template': 'JurisdictionTransactionReporting',
-                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
-                'templateVariables': {
-                    'jurisdictionTransactionReportCSV': report
+            Payload=json.dumps(
+                {
+                    'compact': compact,
+                    'jurisdiction': jurisdiction,
+                    'template': 'JurisdictionTransactionReporting',
+                    'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                    'templateVariables': {'jurisdictionTransactionReportCSV': report},
                 }
-            })
+            ),
         )
-    
+
     return {'message': 'reports sent successfully'}
 
-def _get_jurisdiction_postal_abbreviations(jurisdiction_configs: List[dict]) -> set[str]:
+
+def _get_jurisdiction_postal_abbreviations(jurisdiction_configs: list[dict]) -> set[str]:
     """Get the postal abbreviations for all jurisdictions."""
     return {j['postalAbbreviation'].lower() for j in jurisdiction_configs}
 
 
-def generate_compact_summary_report(transactions: List[dict], compact_config: Compact, jurisdiction_configs: List[dict]) -> str:
+def generate_compact_summary_report(
+    transactions: list[dict], compact_config: Compact, jurisdiction_configs: list[dict]
+) -> str:
     """Generate the compact financial summary report CSV."""
     # Initialize variables
     compact_fees = 0
@@ -115,7 +120,7 @@ def generate_compact_summary_report(transactions: List[dict], compact_config: Co
     for transaction in transactions:
         for item in transaction['lineItems']:
             fee = float(item['unitPrice']) * float(item['quantity'])
-            
+
             if item['itemId'].endswith('-compact-fee'):
                 compact_fees += fee
             else:
@@ -133,117 +138,111 @@ def generate_compact_summary_report(transactions: List[dict], compact_config: Co
         logger.error(
             'Unknown jurisdictions found in transactions.',
             jurisdictions=list(unknown_jurisdictions),
-            compact=compact_config.compact_name
+            compact=compact_config.compact_name,
         )
-    
+
     # Generate CSV
     output = StringIO()
     writer = csv.writer(output, lineterminator='\n')
     writer.writerow(['Total Transactions', len(transactions)])
     writer.writerow(['Total Compact Fees', f'${compact_fees:.2f}'])
-    
+
     for jurisdiction in jurisdiction_configs:
         postal = jurisdiction['postalAbbreviation'].lower()
         fee_value = jurisdiction_fees.get(postal, 0)
-        writer.writerow([
-            f'State Fees ({jurisdiction["jurisdictionName"].capitalize()})',
-            f'${fee_value:.2f}'
-        ])
+        writer.writerow([f'State Fees ({jurisdiction["jurisdictionName"].capitalize()})', f'${fee_value:.2f}'])
     for jurisdiction in unknown_jurisdictions:
-        writer.writerow([
-            f'State Fees (UNKNOWN ({jurisdiction}))',
-            f'${jurisdiction_fees[jurisdiction]:.2f}'
-        ])
-    
+        writer.writerow([f'State Fees (UNKNOWN ({jurisdiction}))', f'${jurisdiction_fees[jurisdiction]:.2f}'])
+
     return output.getvalue()
 
 
-def generate_compact_transaction_report(transactions: List[dict], providers: Dict[str, dict]) -> str:
+def generate_compact_transaction_report(transactions: list[dict], providers: list[str, dict]) -> str:
     """Generate the compact transaction report CSV."""
     output = StringIO()
     writer = csv.writer(output, lineterminator='\n')
-    writer.writerow([
-        'Licensee First Name',
-        'Licensee Last Name',
-        'Licensee Id',
-        'Transaction Date',
-        'State',
-        'State Fee',
-        'Compact Fee',
-        'Transaction Id'
-    ])
-    
+    writer.writerow(
+        [
+            'Licensee First Name',
+            'Licensee Last Name',
+            'Licensee Id',
+            'Transaction Date',
+            'State',
+            'State Fee',
+            'Compact Fee',
+            'Transaction Id',
+        ]
+    )
+
     if not transactions:
         writer.writerow(['No transactions for this period'] + [''] * 7)
         return output.getvalue()
-    
+
     for transaction in transactions:
         provider = providers.get(transaction['licenseeId'], {})
         transaction_date = datetime.fromisoformat(transaction['batch']['settlementTimeUTC']).strftime('%m-%d-%Y')
-        compact_fee_item = next(
-            item for item in transaction['lineItems'] 
-            if item['itemId'].endswith('-compact-fee')
-        )
-        
+        compact_fee_item = next(item for item in transaction['lineItems'] if item['itemId'].endswith('-compact-fee'))
+
         # Write a row for each state privilege in the transaction
         for item in transaction['lineItems']:
             if item['itemId'].endswith('-compact-fee'):
                 continue
-                
+
             # Extract state from itemId (format: compact-state)
             state = item['itemId'].split('-')[1].upper()
-            
-            writer.writerow([
-                provider.get('givenName', 'UNKNOWN'),
-                provider.get('familyName', 'UNKNOWN'),
-                transaction['licenseeId'],
-                transaction_date,
-                state,
-                item['unitPrice'],
-                compact_fee_item['unitPrice'],
-                transaction['transactionId']
-            ])
-    
+
+            writer.writerow(
+                [
+                    provider.get('givenName', 'UNKNOWN'),
+                    provider.get('familyName', 'UNKNOWN'),
+                    transaction['licenseeId'],
+                    transaction_date,
+                    state,
+                    item['unitPrice'],
+                    compact_fee_item['unitPrice'],
+                    transaction['transactionId'],
+                ]
+            )
+
     return output.getvalue()
 
 
 def generate_jurisdiction_reports(
-    transactions: List[dict],
-    providers: Dict[str, dict],
-    jurisdiction_configurations: List[dict]
-) -> Dict[str, str]:
+    transactions: list[dict], providers: dict[str, dict], jurisdiction_configurations: list[dict]
+) -> dict[str, str]:
     """Generate transaction reports for each jurisdiction."""
-    jurisdiction_transactions: Dict[str, List[Tuple[dict, dict]]] = {
-        j['postalAbbreviation'].lower(): []
-        for j in jurisdiction_configurations
+    jurisdiction_transactions: dict[str, list[tuple[dict, dict]]] = {
+        j['postalAbbreviation'].lower(): [] for j in jurisdiction_configurations
     }
-    
+
     # Group transactions by jurisdiction
     for transaction in transactions:
         for item in transaction['lineItems']:
             if item['itemId'].endswith('-compact-fee'):
                 continue
-                
+
             state = item['itemId'].split('-')[1]
             if state in jurisdiction_transactions:
                 jurisdiction_transactions[state].append((transaction, item))
-    
+
     # Generate report for each jurisdiction
     reports = {}
     for jurisdiction, trans_items in jurisdiction_transactions.items():
         output = StringIO()
         writer = csv.writer(output, lineterminator='\n')
-        writer.writerow([
-            'First Name',
-            'Last Name',
-            'Licensee Id',
-            'Transaction Date',
-            'State Fee',
-            'State',
-            'Compact Fee',
-            'Transaction Id'
-        ])
-        
+        writer.writerow(
+            [
+                'First Name',
+                'Last Name',
+                'Licensee Id',
+                'Transaction Date',
+                'State Fee',
+                'State',
+                'Compact Fee',
+                'Transaction Id',
+            ]
+        )
+
         if not trans_items:
             writer.writerow(['No transactions for this period'] + [''] * 7)
             writer.writerow([''] * 8)
@@ -251,40 +250,37 @@ def generate_jurisdiction_reports(
             writer.writerow(['0', '$0.00'] + [''] * 6)
             reports[jurisdiction] = output.getvalue()
             continue
-            
+
         total_privileges = 0
         total_amount = 0
-        
+
         for transaction, item in trans_items:
             provider = providers.get(transaction['licenseeId'], {})
-            transaction_date = datetime.fromisoformat(
-                transaction['batch']['settlementTimeUTC']
-            ).strftime('%m-%d-%Y')
-            
-            compact_fee_item = next(
-                i for i in transaction['lineItems']
-                if i['itemId'].endswith('-compact-fee')
+            transaction_date = datetime.fromisoformat(transaction['batch']['settlementTimeUTC']).strftime('%m-%d-%Y')
+
+            compact_fee_item = next(i for i in transaction['lineItems'] if i['itemId'].endswith('-compact-fee'))
+
+            writer.writerow(
+                [
+                    provider.get('givenName', 'UNKNOWN'),
+                    provider.get('familyName', 'UNKNOWN'),
+                    transaction['licenseeId'],
+                    transaction_date,
+                    item['unitPrice'],
+                    jurisdiction.upper(),
+                    compact_fee_item['unitPrice'],
+                    transaction['transactionId'],
+                ]
             )
-            
-            writer.writerow([
-                provider.get('givenName', 'UNKNOWN'),
-                provider.get('familyName', 'UNKNOWN'),
-                transaction['licenseeId'],
-                transaction_date,
-                item['unitPrice'],
-                jurisdiction.upper(),
-                compact_fee_item['unitPrice'],
-                transaction['transactionId']
-            ])
-            
+
             total_privileges += float(item['quantity'])
             total_amount += float(item['unitPrice']) * float(item['quantity'])
-        
+
         # Add summary rows
         writer.writerow([''] * 8)
         writer.writerow(['Privileges Purchased', 'Total State Amount'] + [''] * 6)
         writer.writerow([int(total_privileges), f'${total_amount:.2f}'] + [''] * 6)
-        
+
         reports[jurisdiction] = output.getvalue()
-    
+
     return reports

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -72,8 +72,9 @@ def generate_transaction_reports(event: dict, context: LambdaContext) -> dict:  
                 compact=compact,
             )
             # append the error so we can raise an exception after sending the reports
-            lambda_error_messages.append(f'Some providers were not found in the database. Providers not found: {missing_providers}')
-
+            lambda_error_messages.append(
+                f'Some providers were not found in the database. Providers not found: {missing_providers}'
+            )
 
     # Generate reports
     compact_summary_csv = _generate_compact_summary_report(
@@ -143,7 +144,10 @@ def _get_jurisdiction_postal_abbreviations(jurisdiction_configs: list[dict]) -> 
 
 
 def _generate_compact_summary_report(
-    transactions: list[dict], compact_config: Compact, jurisdiction_configs: list[dict], lambda_error_messages: list[str]
+    transactions: list[dict],
+    compact_config: Compact,
+    jurisdiction_configs: list[dict],
+    lambda_error_messages: list[str],
 ) -> str:
     """Generate the compact financial summary report CSV."""
     # Initialize variables
@@ -177,8 +181,9 @@ def _generate_compact_summary_report(
             compact=compact_config.compact_name,
         )
         # we can still generate the reports, but we need to add this so an exception is thrown after sending the reports
-        lambda_error_messages.append(f'Unknown jurisdictions found in transactions. Jurisdictions: {unknown_jurisdictions}')
-
+        lambda_error_messages.append(
+            f'Unknown jurisdictions found in transactions. Jurisdictions: {unknown_jurisdictions}'
+        )
 
     # Generate CSV
     output = StringIO()

--- a/backend/compact-connect/lambdas/python/purchases/tests/__init__.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/__init__.py
@@ -16,6 +16,7 @@ class TstLambdas(TestCase):
                 'AWS_DEFAULT_REGION': 'us-east-1',
                 'COMPACT_CONFIGURATION_TABLE_NAME': 'compact-configuration-table',
                 'TRANSACTION_HISTORY_TABLE_NAME': 'transaction-history-table',
+                'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': 'email-notification-service',
                 'COMPACTS': '["aslp", "octp", "coun"]',
                 'JURISDICTIONS': '["ne", "oh", "ky"]',
                 'ENVIRONMENT_NAME': 'test',

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -1,10 +1,11 @@
+# ruff: noqa: E501  line-too-long The lines displaying the csv file contents are long, but they are necessary for the test.
 import json
+from datetime import datetime, timedelta
 from decimal import Decimal
 from unittest.mock import patch
-from datetime import datetime, timedelta
 
-from moto import mock_aws
 from cc_common.exceptions import CCNotFoundException
+from moto import mock_aws
 
 from .. import TstFunction
 
@@ -21,26 +22,14 @@ MOCK_COMPACT_FEE = '10.50'
 MOCK_JURISDICTION_FEE = '100'
 
 # these are used to generate jurisdiction data in the DB
-OHIO_JURISDICTION = {
-    'postalAbbreviation': 'oh',
-    'jurisdictionName': 'ohio',
-    'sk': 'aslp#JURISDICTION#oh'
-}
-KENTUCKY_JURISDICTION = {
-    'postalAbbreviation': 'ky',
-    'jurisdictionName': 'kentucky',
-    'sk': 'aslp#JURISDICTION#ky'
-}
-NEBRASKA_JURISDICTION = {
-    'postalAbbreviation': 'ne',
-    'jurisdictionName': 'nebraska',
-    'sk': 'aslp#JURISDICTION#ne'
-}
+OHIO_JURISDICTION = {'postalAbbreviation': 'oh', 'jurisdictionName': 'ohio', 'sk': 'aslp#JURISDICTION#oh'}
+KENTUCKY_JURISDICTION = {'postalAbbreviation': 'ky', 'jurisdictionName': 'kentucky', 'sk': 'aslp#JURISDICTION#ky'}
+NEBRASKA_JURISDICTION = {'postalAbbreviation': 'ne', 'jurisdictionName': 'nebraska', 'sk': 'aslp#JURISDICTION#ne'}
+
 
 def generate_mock_event():
-    return {
-        'compact': TEST_COMPACT
-    }
+    return {'compact': TEST_COMPACT}
+
 
 def _generate_mock_transaction(
     jurisdictions: list[str],
@@ -52,7 +41,7 @@ def _generate_mock_transaction(
 ) -> dict:
     """
     Generate a mock transaction with privileges for the specified jurisdictions.
-    
+
     :param jurisdictions: List of jurisdiction postal codes (e.g. ['oh', 'ky'])
     :param licensee_id: The licensee ID
     :param month_iso_string: Month in YYYY-MM format
@@ -73,17 +62,19 @@ def _generate_mock_transaction(
         }
         for jurisdiction in jurisdictions
     ]
-    
+
     # Add compact fee (one per privilege)
-    line_items.append({
-        "description": "Compact fee applied for each privilege purchased",
-        "itemId": f"{TEST_COMPACT}-compact-fee",
-        "name": "ASLP Compact Fee",
-        "quantity": str(len(jurisdictions)),  # One fee per privilege
-        "taxable": "False",
-        "unitPrice": MOCK_COMPACT_FEE
-    })
-    
+    line_items.append(
+        {
+            'description': 'Compact fee applied for each privilege purchased',
+            'itemId': f'{TEST_COMPACT}-compact-fee',
+            'name': 'ASLP Compact Fee',
+            'quantity': str(len(jurisdictions)),  # One fee per privilege
+            'taxable': 'False',
+            'unitPrice': MOCK_COMPACT_FEE,
+        }
+    )
+
     return {
         'batch': {
             'batchId': batch_id,
@@ -96,7 +87,9 @@ def _generate_mock_transaction(
         'lineItems': line_items,
         'pk': f'COMPACT#{TEST_COMPACT}#TRANSACTIONS#MONTH#{month_iso_string}',
         'responseCode': '1',
-        'settleAmount': str(float(MOCK_JURISDICTION_FEE) * len(jurisdictions) + float(MOCK_COMPACT_FEE) * len(jurisdictions)),
+        'settleAmount': str(
+            float(MOCK_JURISDICTION_FEE) * len(jurisdictions) + float(MOCK_COMPACT_FEE) * len(jurisdictions)
+        ),
         'sk': f'COMPACT#{TEST_COMPACT}#TIME#{int(transaction_settlement_time_utc.timestamp())}#BATCH#{batch_id}#'
         f'TX#{transaction_id}',
         'submitTimeUTC': MOCK_SUBMIT_TIME_UTC,
@@ -112,22 +105,20 @@ class TestGenerateTransactionReports(TstFunction):
     """Test the process_settled_transactions Lambda function."""
 
     def add_mock_provider_to_db(self, licensee_id, first_name, last_name) -> dict:
-        test_resources = ['../common/tests/resources/dynamo/provider.json']
-
         def privilege_jurisdictions_to_set(obj: dict):
             if obj.get('type') == 'provider' and 'privilegeJurisdictions' in obj:
                 obj['privilegeJurisdictions'] = set(obj['privilegeJurisdictions'])
             return obj
 
-        for resource in test_resources:
-            with open(resource) as f:
-                record = json.load(f, object_hook=privilege_jurisdictions_to_set, parse_float=Decimal)
-                record['providerId'] = licensee_id
-                record['pk'] = f"{TEST_COMPACT}#PROVIDER#{licensee_id}"
-                record['givenName'] = first_name
-                record['familyName'] = last_name
-                self._provider_table.put_item(Item=record)
-                return record
+        with open('../common/tests/resources/dynamo/provider.json') as f:
+            record = json.load(f, object_hook=privilege_jurisdictions_to_set, parse_float=Decimal)
+            record['providerId'] = licensee_id
+            record['pk'] = f'{TEST_COMPACT}#PROVIDER#{licensee_id}'
+            record['givenName'] = first_name
+            record['familyName'] = last_name
+            self._provider_table.put_item(Item=record)
+
+        return record
 
     def add_mock_transaction_to_db(
         self,
@@ -140,7 +131,7 @@ class TestGenerateTransactionReports(TstFunction):
     ) -> dict:
         """
         Add a mock transaction to the DB with privileges for the specified jurisdictions.
-        
+
         :param jurisdictions: List of jurisdiction postal codes (e.g. ['oh', 'ky'])
         :param licensee_id: The licensee ID
         :param month_iso_string: Month in YYYY-MM format
@@ -183,6 +174,7 @@ class TestGenerateTransactionReports(TstFunction):
     def test_generate_transaction_reports_sends_csv_with_zero_values_when_no_transactions(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
         from handlers.transaction_reporting import generate_transaction_reports
+
         self._add_compact_configuration_data()
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
@@ -192,34 +184,41 @@ class TestGenerateTransactionReports(TstFunction):
         compact_call = call_args[0][1]
         self.assertEqual(self.config.email_notification_service_lambda_name, compact_call['FunctionName'])
         self.assertEqual('RequestResponse', compact_call['InvocationType'])
-        self.assertEqual({
-            'compact': TEST_COMPACT,
-            'recipientType': 'COMPACT_SUMMARY_REPORT',
-            'template': 'CompactTransactionReporting',
-            'templateVariables': {
-                'compactFinancialSummaryReportCSV': 'Total Transactions,0\nTotal Compact Fees,$0.00\nState Fees (Ohio),$0.00\n',
-                'compactTransactionReportCSV': 'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\nNo transactions for this period,,,,,,,\n',
+        self.assertEqual(
+            {
+                'compact': TEST_COMPACT,
+                'recipientType': 'COMPACT_SUMMARY_REPORT',
+                'template': 'CompactTransactionReporting',
+                'templateVariables': {
+                    'compactFinancialSummaryReportCSV': 'Total Transactions,0\nTotal Compact Fees,$0.00\nState Fees (Ohio),$0.00\n',
+                    'compactTransactionReportCSV': 'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\nNo transactions for this period,,,,,,,\n',
+                },
             },
-        }, json.loads(compact_call['Payload']))
+            json.loads(compact_call['Payload']),
+        )
 
         ohio_call = call_args[1][1]
         self.assertEqual(self.config.email_notification_service_lambda_name, ohio_call['FunctionName'])
         self.assertEqual('RequestResponse', ohio_call['InvocationType'])
-        self.assertEqual({
-            'compact': TEST_COMPACT,
-            'jurisdiction': 'oh',
-            'recipientType': 'JURISDICTION_SUMMARY_REPORT',
-            'template': 'JurisdictionTransactionReporting',
-            'templateVariables': {
-                'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\nNo transactions for this period,,,,,,,\n,,,,,,,\nPrivileges Purchased,Total State Amount,,,,,,\n0,$0.00,,,,,,\n'
+        self.assertEqual(
+            {
+                'compact': TEST_COMPACT,
+                'jurisdiction': 'oh',
+                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                'template': 'JurisdictionTransactionReporting',
+                'templateVariables': {
+                    'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\nNo transactions for this period,,,,,,,\n,,,,,,,\nPrivileges Purchased,Total State Amount,,,,,,\n0,$0.00,,,,,,\n'
+                },
             },
-        }, json.loads(ohio_call['Payload']))
+            json.loads(ohio_call['Payload']),
+        )
 
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_collects_transactions_across_two_months(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
         from handlers.transaction_reporting import generate_transaction_reports
+
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
         # Add a transaction that will be in the previous month
         mock_user_1 = self.add_mock_provider_to_db('12345', 'John', 'Doe')
@@ -230,13 +229,13 @@ class TestGenerateTransactionReports(TstFunction):
             jurisdictions=['oh'],
             licensee_id=mock_user_1['providerId'],
             month_iso_string='2025-03',
-            transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00')
+            transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00'),
         )
         self.add_mock_transaction_to_db(
             jurisdictions=['ky'],
             licensee_id=mock_user_2['providerId'],
             month_iso_string='2025-04',
-            transaction_settlement_time_utc=datetime.fromisoformat('2025-04-01T12:00:00+00:00')
+            transaction_settlement_time_utc=datetime.fromisoformat('2025-04-01T12:00:00+00:00'),
         )
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
@@ -244,71 +243,84 @@ class TestGenerateTransactionReports(TstFunction):
         # assert that the email_notification_service_lambda_name was called with the correct payload
         calls_args = mock_lambda_client.invoke.call_args_list
         compact_call_payload = json.loads(calls_args[0][1]['Payload'])
-        self.assertEqual({
-            'compact': 'aslp',
-            'recipientType': 'COMPACT_SUMMARY_REPORT',
-            'template': 'CompactTransactionReporting',
-            'templateVariables': {
-            'compactFinancialSummaryReportCSV':
-                 'Total Transactions,2\n'
-                 'Total Compact Fees,$21.00\n'
-                 'State Fees (Kentucky),$100.00\n'
-                 'State Fees (Ohio),$100.00\n',
-             'compactTransactionReportCSV':
-             f'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\n'
-             f'{mock_user_1['givenName']},{mock_user_1['familyName']},{mock_user_1['providerId']},03-30-2025,OH,100,10.50,{MOCK_TRANSACTION_ID}\n'
-             f'{mock_user_2['givenName']},{mock_user_2['familyName']},{mock_user_2['providerId']},04-01-2025,KY,100,10.50,{MOCK_TRANSACTION_ID}\n'
-                                }}, compact_call_payload)
+        self.assertEqual(
+            {
+                'compact': 'aslp',
+                'recipientType': 'COMPACT_SUMMARY_REPORT',
+                'template': 'CompactTransactionReporting',
+                'templateVariables': {
+                    'compactFinancialSummaryReportCSV': 'Total Transactions,2\n'
+                    'Total Compact Fees,$21.00\n'
+                    'State Fees (Kentucky),$100.00\n'
+                    'State Fees (Ohio),$100.00\n',
+                    'compactTransactionReportCSV': f'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\n'
+                    f'{mock_user_1['givenName']},{mock_user_1['familyName']},{mock_user_1['providerId']},03-30-2025,OH,100,10.50,{MOCK_TRANSACTION_ID}\n'
+                    f'{mock_user_2['givenName']},{mock_user_2['familyName']},{mock_user_2['providerId']},04-01-2025,KY,100,10.50,{MOCK_TRANSACTION_ID}\n',
+                },
+            },
+            compact_call_payload,
+        )
 
         kentucky_call_payload = json.loads(calls_args[1][1]['Payload'])
-        self.assertEqual({'compact': 'aslp',
-                                'jurisdiction': 'ky',
-                                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
-                                'template': 'JurisdictionTransactionReporting',
-                                'templateVariables': {
-                                    'jurisdictionTransactionReportCSV':
-                                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
-                                        f'{mock_user_2['givenName']},{mock_user_2['familyName']},{mock_user_2['providerId']},04-01-2025,100,KY,10.50,{MOCK_TRANSACTION_ID}\n'
-                                        ',,,,,,,\n'
-                                        'Privileges Purchased,Total State Amount,,,,,,\n'
-                                        '1,$100.00,,,,,,\n'
-                                    }}, kentucky_call_payload)
+        self.assertEqual(
+            {
+                'compact': 'aslp',
+                'jurisdiction': 'ky',
+                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                'template': 'JurisdictionTransactionReporting',
+                'templateVariables': {
+                    'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                    f'{mock_user_2['givenName']},{mock_user_2['familyName']},{mock_user_2['providerId']},04-01-2025,100,KY,10.50,{MOCK_TRANSACTION_ID}\n'
+                    ',,,,,,,\n'
+                    'Privileges Purchased,Total State Amount,,,,,,\n'
+                    '1,$100.00,,,,,,\n'
+                },
+            },
+            kentucky_call_payload,
+        )
 
         ohio_call_payload = json.loads(calls_args[2][1]['Payload'])
-        self.assertEqual({'compact': 'aslp',
-                                'jurisdiction': 'oh',
-                                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
-                                'template': 'JurisdictionTransactionReporting',
-                                'templateVariables': {
-                                    'jurisdictionTransactionReportCSV':
-                                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
-                                        f'{mock_user_1['givenName']},{mock_user_1['familyName']},{mock_user_1['providerId']},03-30-2025,100,OH,10.50,{MOCK_TRANSACTION_ID}\n'
-                                        ',,,,,,,\n'
-                                        'Privileges Purchased,Total State Amount,,,,,,\n'
-                                        '1,$100.00,,,,,,\n'
-                                    }}, ohio_call_payload)
+        self.assertEqual(
+            {
+                'compact': 'aslp',
+                'jurisdiction': 'oh',
+                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                'template': 'JurisdictionTransactionReporting',
+                'templateVariables': {
+                    'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                    f'{mock_user_1['givenName']},{mock_user_1['familyName']},{mock_user_1['providerId']},03-30-2025,100,OH,10.50,{MOCK_TRANSACTION_ID}\n'
+                    ',,,,,,,\n'
+                    'Privileges Purchased,Total State Amount,,,,,,\n'
+                    '1,$100.00,,,,,,\n'
+                },
+            },
+            ohio_call_payload,
+        )
 
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_with_multiple_privileges_in_single_transaction(self, mock_lambda_client):
         """Test processing of transactions with multiple privileges in a single transaction."""
         from handlers.transaction_reporting import generate_transaction_reports
-        self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION])
-        
+
+        self._add_compact_configuration_data(
+            jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION]
+        )
+
         mock_user = self.add_mock_provider_to_db('12345', 'John', 'Doe')
         # Create a transaction with privileges for multiple jurisdictions
         self.add_mock_transaction_to_db(
             jurisdictions=['oh', 'ky', 'ne'],
             licensee_id=mock_user['providerId'],
             month_iso_string='2025-03',
-            transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00')
+            transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00'),
         )
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
 
         calls_args = mock_lambda_client.invoke.call_args_list
         compact_call_payload = json.loads(calls_args[0][1]['Payload'])
-        
+
         # Verify compact summary shows correct totals
         self.assertEqual(
             'Total Transactions,1\n'
@@ -316,19 +328,18 @@ class TestGenerateTransactionReports(TstFunction):
             'State Fees (Kentucky),$100.00\n'
             'State Fees (Nebraska),$100.00\n'
             'State Fees (Ohio),$100.00\n',
-            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV']
+            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV'],
         )
 
         # Verify each jurisdiction report shows the correct privilege
         for jurisdiction in ['ky', 'ne', 'oh']:
             jurisdiction_call = next(
-                call for call in calls_args[1:]
-                if json.loads(call[1]['Payload'])['jurisdiction'] == jurisdiction
+                call for call in calls_args[1:] if json.loads(call[1]['Payload'])['jurisdiction'] == jurisdiction
             )
             jurisdiction_payload = json.loads(jurisdiction_call[1]['Payload'])
             self.assertIn(
                 f'{mock_user['givenName']},{mock_user['familyName']},{mock_user['providerId']},03-30-2025,100,{jurisdiction.upper()},10.50,{MOCK_TRANSACTION_ID}',
-                jurisdiction_payload['templateVariables']['jurisdictionTransactionReportCSV']
+                jurisdiction_payload['templateVariables']['jurisdictionTransactionReportCSV'],
             )
 
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
@@ -336,18 +347,15 @@ class TestGenerateTransactionReports(TstFunction):
     def test_generate_report_with_large_number_of_transactions_and_providers(self, mock_lambda_client):
         """Test processing of a large number of transactions (>500) and providers (>100)."""
         from handlers.transaction_reporting import generate_transaction_reports
+
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
-        
+
         # Create 700 providers
         providers = []
         for i in range(700):
-            provider = self.add_mock_provider_to_db(
-                f'user_{i}',
-                f'First{i}',
-                f'Last{i}'
-            )
+            provider = self.add_mock_provider_to_db(f'user_{i}', f'First{i}', f'Last{i}')
             providers.append(provider)
-        
+
         # Create 600 transactions (300 per jurisdiction)
         base_time = datetime.fromisoformat('2025-03-30T12:00:00+00:00')
         for i in range(600):
@@ -358,40 +366,36 @@ class TestGenerateTransactionReports(TstFunction):
                 licensee_id=provider['providerId'],
                 month_iso_string='2025-03',
                 transaction_settlement_time_utc=base_time + timedelta(minutes=i),
-                transaction_id=f'tx_{i}'
+                transaction_id=f'tx_{i}',
             )
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
 
         calls_args = mock_lambda_client.invoke.call_args_list
         compact_call_payload = json.loads(calls_args[0][1]['Payload'])
-        
+
         # Verify summary totals
         self.assertEqual(
             'Total Transactions,600\n'
             'Total Compact Fees,$6300.00\n'  # $10.50 x 600
             'State Fees (Kentucky),$30000.00\n'  # $100 x 300
             'State Fees (Ohio),$30000.00\n',  # $100 x 300
-            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV']
+            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV'],
         )
 
         # Verify transaction reports
         ohio_transactions_in_report = [
-            line for line in compact_call_payload['templateVariables']['compactTransactionReportCSV'].split('\n')
+            line
+            for line in compact_call_payload['templateVariables']['compactTransactionReportCSV'].split('\n')
             if 'OH' in line
         ]
         kentucky_transactions_in_report = [
-            line for line in compact_call_payload['templateVariables']['compactTransactionReportCSV'].split('\n')
+            line
+            for line in compact_call_payload['templateVariables']['compactTransactionReportCSV'].split('\n')
             if 'KY' in line
         ]
-        self.assertEqual(
-            300,
-            len(ohio_transactions_in_report)
-        )
-        self.assertEqual(
-            300,
-            len(kentucky_transactions_in_report)
-        )
+        self.assertEqual(300, len(ohio_transactions_in_report))
+        self.assertEqual(300, len(kentucky_transactions_in_report))
         # make sure all expected user ids in report
         for i in range(300):
             self.assertIn(f'user_{i}', ohio_transactions_in_report[i])
@@ -400,8 +404,7 @@ class TestGenerateTransactionReports(TstFunction):
         # Verify jurisdiction reports
         for jurisdiction in ['oh', 'ky']:
             jurisdiction_call = next(
-                call for call in calls_args[1:]
-                if json.loads(call[1]['Payload'])['jurisdiction'] == jurisdiction
+                call for call in calls_args[1:] if json.loads(call[1]['Payload'])['jurisdiction'] == jurisdiction
             )
             jurisdiction_payload = json.loads(jurisdiction_call[1]['Payload'])
             report_csv = jurisdiction_payload['templateVariables']['jurisdictionTransactionReportCSV']
@@ -432,22 +435,23 @@ class TestGenerateTransactionReports(TstFunction):
         This is unlikely to happen in practice, but we should handle it gracefully.
         """
         from handlers.transaction_reporting import generate_transaction_reports
+
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
-        
+
         mock_user = self.add_mock_provider_to_db('12345', 'John', 'Doe')
         # Create a transaction with a jurisdiction not in the configuration
         self.add_mock_transaction_to_db(
             jurisdictions=['oh', 'ky', 'xx'],  # 'xx' is not a configured jurisdiction
             licensee_id=mock_user['providerId'],
             month_iso_string='2025-03',
-            transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00')
+            transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00'),
         )
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
 
         calls_args = mock_lambda_client.invoke.call_args_list
         compact_call_payload = json.loads(calls_args[0][1]['Payload'])
-        
+
         # Verify compact summary includes unknown jurisdiction
         self.assertEqual(
             'Total Transactions,1\n'
@@ -455,16 +459,17 @@ class TestGenerateTransactionReports(TstFunction):
             'State Fees (Kentucky),$100.00\n'
             'State Fees (Ohio),$100.00\n'
             'State Fees (UNKNOWN (xx)),$100.00\n',
-            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV']
+            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV'],
         )
 
         # Verify we only sent reports for known jurisdictions
         jurisdiction_calls = [
-            call for call in calls_args[1:]
+            call
+            for call in calls_args[1:]
             if json.loads(call[1]['Payload'])['template'] == 'JurisdictionTransactionReporting'
         ]
         self.assertEqual(2, len(jurisdiction_calls))  # Only OH and KY should get reports
-        
+
         jurisdiction_report_payloads = [json.loads(call[1]['Payload']) for call in jurisdiction_calls]
         reported_jurisdictions = {payload['jurisdiction'] for payload in jurisdiction_report_payloads}
         self.assertEqual({'oh', 'ky'}, reported_jurisdictions)  # Verify only OH and KY got reports

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -1,0 +1,95 @@
+import json
+from decimal import Decimal
+from unittest.mock import call, patch
+
+from moto import mock_aws
+
+from .. import TstFunction
+
+TEST_COMPACT = 'aslp'
+
+def generate_mock_event():
+    return {
+        'compact': TEST_COMPACT
+    }
+
+def _load_compact_configuration_data(self,
+                                     jurisdictions={"postalAbbreviation": "oh", "jurisdictionName": "ohio"}):
+
+    with open('../common/tests/resources/dynamo/compact.json') as f:
+        record = json.load(f, parse_float=Decimal)
+        self._compact_configuration_table.put_item(Item=record)
+
+    with open('../common/tests/resources/dynamo/jurisdiction.json') as f:
+        record = json.load(f, parse_float=Decimal)
+        for jurisdiction in jurisdictions:
+            record.update(jurisdiction)
+            self._compact_configuration_table.put_item(Item=record)
+
+
+@mock_aws
+class TestGenerateTransactionReports(TstFunction):
+    """Test the process_settled_transactions Lambda function."""
+
+    def _load_compact_configuration_data(self,
+                                         jurisdictions=None):
+        """
+        Use the canned test resources to load compact and jurisdiction information into the DB.
+
+        If jurisdictions is None, it will default to only include Ohio.
+        """
+        if jurisdictions is None:
+            jurisdictions = [{"postalAbbreviation": "oh", "jurisdictionName": "ohio"}]
+
+        with open('../common/tests/resources/dynamo/compact.json') as f:
+            record = json.load(f, parse_float=Decimal)
+            self._compact_configuration_table.put_item(Item=record)
+
+        with open('../common/tests/resources/dynamo/jurisdiction.json') as f:
+            record = json.load(f, parse_float=Decimal)
+            for jurisdiction in jurisdictions:
+                record.update(jurisdiction)
+                self._compact_configuration_table.put_item(Item=record)
+
+    def _when_testing_week_with_no_transactions(
+        self,
+    ):
+        self._load_compact_configuration_data()
+
+
+    @patch('handlers.transaction_reporting.config.lambda_client')
+    def test_generate_transaction_reports_sends_csv_with_zero_values_when_no_transactions(self, mock_lambda_client):
+        """Test successful processing of settled transactions."""
+        from handlers.transaction_reporting import generate_transaction_reports
+        self._when_testing_week_with_no_transactions()
+
+        generate_transaction_reports(generate_mock_event(), self.mock_context)
+
+        # assert that the email_notification_service_lambda_name was called with the correct payload
+        expected_calls = [
+            call(FunctionName=self.config.email_notification_service_lambda_name,
+                 InvocationType='RequestResponse',
+                 Payload=json.dumps({
+                     'compact': TEST_COMPACT,
+                     'template': 'CompactTransactionReporting',
+                     'recipientType': 'COMPACT_SUMMARY_REPORT',
+                     'templateVariables': {
+                         'compactFinancialSummaryReportCSV': 'Total Transactions,0\r\nTotal Compact Fees,$0.00\r\nState Fees (Ohio),$0.00\r\n',
+                         'compactTransactionReportCSV': 'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\r\nNo transactions for this period,,,,,,,\r\n',
+                     },
+                 })),
+            call(FunctionName=self.config.email_notification_service_lambda_name,
+                 InvocationType='RequestResponse',
+                 Payload=json.dumps({
+                     'compact': TEST_COMPACT,
+                     'jurisdiction': 'oh',
+                     'template': 'JurisdictionTransactionReporting',
+                     'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                     'templateVariables': {
+                         'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\r\nNo transactions for this period,,,,,,,\r\n,,,,,,,\r\nPrivileges Purchased,Total State Amount,,,,,,\r\n0,$0.00,,,,,,\r\n'
+                     },
+                 })),
+        ]
+
+
+        mock_lambda_client.invoke.assert_has_calls(expected_calls)

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -1,45 +1,173 @@
 import json
 from decimal import Decimal
-from unittest.mock import call, patch
+from unittest.mock import patch
+from datetime import datetime, timedelta
 
 from moto import mock_aws
+from cc_common.exceptions import CCNotFoundException
 
 from .. import TstFunction
 
 TEST_COMPACT = 'aslp'
+# Test transaction data
+MOCK_TRANSACTION_ID = 'mockTransactionIdPlaceholder'
+MOCK_BATCH_ID = '67890'
+MOCK_SUBMIT_TIME_UTC = '2024-01-01T12:00:00.000Z'
+MOCK_SETTLEMENT_TIME_UTC = '2024-01-01T13:00:00.000Z'
+MOCK_SETTLEMENT_TIME_LOCAL = '2024-01-01T09:00:00'
+
+# Mock compact config values
+MOCK_COMPACT_FEE = '10.50'
+MOCK_JURISDICTION_FEE = '100'
+
+# these are used to generate jurisdiction data in the DB
+OHIO_JURISDICTION = {
+    'postalAbbreviation': 'oh',
+    'jurisdictionName': 'ohio',
+    'sk': 'aslp#JURISDICTION#oh'
+}
+KENTUCKY_JURISDICTION = {
+    'postalAbbreviation': 'ky',
+    'jurisdictionName': 'kentucky',
+    'sk': 'aslp#JURISDICTION#ky'
+}
+NEBRASKA_JURISDICTION = {
+    'postalAbbreviation': 'ne',
+    'jurisdictionName': 'nebraska',
+    'sk': 'aslp#JURISDICTION#ne'
+}
 
 def generate_mock_event():
     return {
         'compact': TEST_COMPACT
     }
 
-def _load_compact_configuration_data(self,
-                                     jurisdictions={"postalAbbreviation": "oh", "jurisdictionName": "ohio"}):
-
-    with open('../common/tests/resources/dynamo/compact.json') as f:
-        record = json.load(f, parse_float=Decimal)
-        self._compact_configuration_table.put_item(Item=record)
-
-    with open('../common/tests/resources/dynamo/jurisdiction.json') as f:
-        record = json.load(f, parse_float=Decimal)
-        for jurisdiction in jurisdictions:
-            record.update(jurisdiction)
-            self._compact_configuration_table.put_item(Item=record)
+def _generate_mock_transaction(
+    jurisdictions: list[str],
+    licensee_id: str,
+    month_iso_string: str,
+    transaction_settlement_time_utc: datetime,
+    transaction_id: str = MOCK_TRANSACTION_ID,
+    batch_id: str = MOCK_BATCH_ID,
+) -> dict:
+    """
+    Generate a mock transaction with privileges for the specified jurisdictions.
+    
+    :param jurisdictions: List of jurisdiction postal codes (e.g. ['oh', 'ky'])
+    :param licensee_id: The licensee ID
+    :param month_iso_string: Month in YYYY-MM format
+    :param transaction_settlement_time_utc: Settlement time in UTC
+    :param transaction_id: Optional transaction ID
+    :param batch_id: Optional batch ID
+    :return: Mock transaction record
+    """
+    # Create line items for each jurisdiction
+    line_items = [
+        {
+            'description': f'Compact Privilege for {jurisdiction.upper()}',
+            'itemId': f'{TEST_COMPACT}-{jurisdiction}',
+            'name': f'{jurisdiction.upper()} Compact Privilege',
+            'quantity': '1',
+            'taxable': False,
+            'unitPrice': MOCK_JURISDICTION_FEE,
+        }
+        for jurisdiction in jurisdictions
+    ]
+    
+    # Add compact fee (one per privilege)
+    line_items.append({
+        "description": "Compact fee applied for each privilege purchased",
+        "itemId": f"{TEST_COMPACT}-compact-fee",
+        "name": "ASLP Compact Fee",
+        "quantity": str(len(jurisdictions)),  # One fee per privilege
+        "taxable": "False",
+        "unitPrice": MOCK_COMPACT_FEE
+    })
+    
+    return {
+        'batch': {
+            'batchId': batch_id,
+            'settlementState': 'settledSuccessfully',
+            'settlementTimeLocal': '2024-01-01T09:00:00',
+            'settlementTimeUTC': transaction_settlement_time_utc.isoformat(),
+        },
+        'compact': TEST_COMPACT,
+        'licenseeId': licensee_id,
+        'lineItems': line_items,
+        'pk': f'COMPACT#{TEST_COMPACT}#TRANSACTIONS#MONTH#{month_iso_string}',
+        'responseCode': '1',
+        'settleAmount': str(float(MOCK_JURISDICTION_FEE) * len(jurisdictions) + float(MOCK_COMPACT_FEE) * len(jurisdictions)),
+        'sk': f'COMPACT#{TEST_COMPACT}#TIME#{int(transaction_settlement_time_utc.timestamp())}#BATCH#{batch_id}#'
+        f'TX#{transaction_id}',
+        'submitTimeUTC': MOCK_SUBMIT_TIME_UTC,
+        'transactionId': transaction_id,
+        'transactionStatus': 'settledSuccessfully',
+        'transactionType': 'authCaptureTransaction',
+        'transactionProcessor': 'authorize.net',
+    }
 
 
 @mock_aws
 class TestGenerateTransactionReports(TstFunction):
     """Test the process_settled_transactions Lambda function."""
 
-    def _load_compact_configuration_data(self,
-                                         jurisdictions=None):
+    def add_mock_provider_to_db(self, licensee_id, first_name, last_name) -> dict:
+        test_resources = ['../common/tests/resources/dynamo/provider.json']
+
+        def privilege_jurisdictions_to_set(obj: dict):
+            if obj.get('type') == 'provider' and 'privilegeJurisdictions' in obj:
+                obj['privilegeJurisdictions'] = set(obj['privilegeJurisdictions'])
+            return obj
+
+        for resource in test_resources:
+            with open(resource) as f:
+                record = json.load(f, object_hook=privilege_jurisdictions_to_set, parse_float=Decimal)
+                record['providerId'] = licensee_id
+                record['pk'] = f"{TEST_COMPACT}#PROVIDER#{licensee_id}"
+                record['givenName'] = first_name
+                record['familyName'] = last_name
+                self._provider_table.put_item(Item=record)
+                return record
+
+    def add_mock_transaction_to_db(
+        self,
+        jurisdictions: list[str],
+        licensee_id: str,
+        month_iso_string: str,
+        transaction_settlement_time_utc: datetime,
+        transaction_id: str = MOCK_TRANSACTION_ID,
+        batch_id: str = MOCK_BATCH_ID,
+    ) -> dict:
+        """
+        Add a mock transaction to the DB with privileges for the specified jurisdictions.
+        
+        :param jurisdictions: List of jurisdiction postal codes (e.g. ['oh', 'ky'])
+        :param licensee_id: The licensee ID
+        :param month_iso_string: Month in YYYY-MM format
+        :param transaction_settlement_time_utc: Settlement time in UTC
+        :param transaction_id: Optional transaction ID
+        :param batch_id: Optional batch ID
+        :return: The created transaction record
+        """
+        transaction = _generate_mock_transaction(
+            jurisdictions,
+            licensee_id,
+            month_iso_string,
+            transaction_settlement_time_utc,
+            transaction_id,
+            batch_id,
+        )
+        self._transaction_history_table.put_item(Item=transaction)
+        return transaction
+
+    def _add_compact_configuration_data(self, jurisdictions=None):
         """
         Use the canned test resources to load compact and jurisdiction information into the DB.
 
         If jurisdictions is None, it will default to only include Ohio.
         """
         if jurisdictions is None:
-            jurisdictions = [{"postalAbbreviation": "oh", "jurisdictionName": "ohio"}]
+            jurisdictions = [OHIO_JURISDICTION]
 
         with open('../common/tests/resources/dynamo/compact.json') as f:
             record = json.load(f, parse_float=Decimal)
@@ -51,45 +179,248 @@ class TestGenerateTransactionReports(TstFunction):
                 record.update(jurisdiction)
                 self._compact_configuration_table.put_item(Item=record)
 
-    def _when_testing_week_with_no_transactions(
-        self,
-    ):
-        self._load_compact_configuration_data()
-
-
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_transaction_reports_sends_csv_with_zero_values_when_no_transactions(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
         from handlers.transaction_reporting import generate_transaction_reports
-        self._when_testing_week_with_no_transactions()
+        self._add_compact_configuration_data()
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
 
         # assert that the email_notification_service_lambda_name was called with the correct payload
-        expected_calls = [
-            call(FunctionName=self.config.email_notification_service_lambda_name,
-                 InvocationType='RequestResponse',
-                 Payload=json.dumps({
-                     'compact': TEST_COMPACT,
-                     'template': 'CompactTransactionReporting',
-                     'recipientType': 'COMPACT_SUMMARY_REPORT',
-                     'templateVariables': {
-                         'compactFinancialSummaryReportCSV': 'Total Transactions,0\r\nTotal Compact Fees,$0.00\r\nState Fees (Ohio),$0.00\r\n',
-                         'compactTransactionReportCSV': 'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\r\nNo transactions for this period,,,,,,,\r\n',
-                     },
-                 })),
-            call(FunctionName=self.config.email_notification_service_lambda_name,
-                 InvocationType='RequestResponse',
-                 Payload=json.dumps({
-                     'compact': TEST_COMPACT,
-                     'jurisdiction': 'oh',
-                     'template': 'JurisdictionTransactionReporting',
-                     'recipientType': 'JURISDICTION_SUMMARY_REPORT',
-                     'templateVariables': {
-                         'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\r\nNo transactions for this period,,,,,,,\r\n,,,,,,,\r\nPrivileges Purchased,Total State Amount,,,,,,\r\n0,$0.00,,,,,,\r\n'
-                     },
-                 })),
+        call_args = mock_lambda_client.invoke.call_args_list
+        compact_call = call_args[0][1]
+        self.assertEqual(self.config.email_notification_service_lambda_name, compact_call['FunctionName'])
+        self.assertEqual('RequestResponse', compact_call['InvocationType'])
+        self.assertEqual({
+            'compact': TEST_COMPACT,
+            'recipientType': 'COMPACT_SUMMARY_REPORT',
+            'template': 'CompactTransactionReporting',
+            'templateVariables': {
+                'compactFinancialSummaryReportCSV': 'Total Transactions,0\nTotal Compact Fees,$0.00\nState Fees (Ohio),$0.00\n',
+                'compactTransactionReportCSV': 'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\nNo transactions for this period,,,,,,,\n',
+            },
+        }, json.loads(compact_call['Payload']))
+
+        ohio_call = call_args[1][1]
+        self.assertEqual(self.config.email_notification_service_lambda_name, ohio_call['FunctionName'])
+        self.assertEqual('RequestResponse', ohio_call['InvocationType'])
+        self.assertEqual({
+            'compact': TEST_COMPACT,
+            'jurisdiction': 'oh',
+            'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+            'template': 'JurisdictionTransactionReporting',
+            'templateVariables': {
+                'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\nNo transactions for this period,,,,,,,\n,,,,,,,\nPrivileges Purchased,Total State Amount,,,,,,\n0,$0.00,,,,,,\n'
+            },
+        }, json.loads(ohio_call['Payload']))
+
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    @patch('handlers.transaction_reporting.config.lambda_client')
+    def test_generate_report_collects_transactions_across_two_months(self, mock_lambda_client):
+        """Test successful processing of settled transactions."""
+        from handlers.transaction_reporting import generate_transaction_reports
+        self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
+        # Add a transaction that will be in the previous month
+        mock_user_1 = self.add_mock_provider_to_db('12345', 'John', 'Doe')
+        mock_user_2 = self.add_mock_provider_to_db('5678', 'Jane', 'Johnson')
+        # in this case, there will be two transactions, one in march and the other in April
+        # the lambda should pick up both transactions
+        self.add_mock_transaction_to_db(
+            jurisdictions=['oh'],
+            licensee_id=mock_user_1['providerId'],
+            month_iso_string='2025-03',
+            transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00')
+        )
+        self.add_mock_transaction_to_db(
+            jurisdictions=['ky'],
+            licensee_id=mock_user_2['providerId'],
+            month_iso_string='2025-04',
+            transaction_settlement_time_utc=datetime.fromisoformat('2025-04-01T12:00:00+00:00')
+        )
+
+        generate_transaction_reports(generate_mock_event(), self.mock_context)
+
+        # assert that the email_notification_service_lambda_name was called with the correct payload
+        calls_args = mock_lambda_client.invoke.call_args_list
+        compact_call_payload = json.loads(calls_args[0][1]['Payload'])
+        self.assertEqual({
+            'compact': 'aslp',
+            'recipientType': 'COMPACT_SUMMARY_REPORT',
+            'template': 'CompactTransactionReporting',
+            'templateVariables': {
+            'compactFinancialSummaryReportCSV':
+                 'Total Transactions,2\n'
+                 'Total Compact Fees,$21.00\n'
+                 'State Fees (Kentucky),$100.00\n'
+                 'State Fees (Ohio),$100.00\n',
+             'compactTransactionReportCSV':
+             f'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\n'
+             f'{mock_user_1['givenName']},{mock_user_1['familyName']},{mock_user_1['providerId']},03-30-2025,OH,100,10.50,{MOCK_TRANSACTION_ID}\n'
+             f'{mock_user_2['givenName']},{mock_user_2['familyName']},{mock_user_2['providerId']},04-01-2025,KY,100,10.50,{MOCK_TRANSACTION_ID}\n'
+                                }}, compact_call_payload)
+
+        kentucky_call_payload = json.loads(calls_args[1][1]['Payload'])
+        self.assertEqual({'compact': 'aslp',
+                                'jurisdiction': 'ky',
+                                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                                'template': 'JurisdictionTransactionReporting',
+                                'templateVariables': {
+                                    'jurisdictionTransactionReportCSV':
+                                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                                        f'{mock_user_2['givenName']},{mock_user_2['familyName']},{mock_user_2['providerId']},04-01-2025,100,KY,10.50,{MOCK_TRANSACTION_ID}\n'
+                                        ',,,,,,,\n'
+                                        'Privileges Purchased,Total State Amount,,,,,,\n'
+                                        '1,$100.00,,,,,,\n'
+                                    }}, kentucky_call_payload)
+
+        ohio_call_payload = json.loads(calls_args[2][1]['Payload'])
+        self.assertEqual({'compact': 'aslp',
+                                'jurisdiction': 'oh',
+                                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                                'template': 'JurisdictionTransactionReporting',
+                                'templateVariables': {
+                                    'jurisdictionTransactionReportCSV':
+                                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                                        f'{mock_user_1['givenName']},{mock_user_1['familyName']},{mock_user_1['providerId']},03-30-2025,100,OH,10.50,{MOCK_TRANSACTION_ID}\n'
+                                        ',,,,,,,\n'
+                                        'Privileges Purchased,Total State Amount,,,,,,\n'
+                                        '1,$100.00,,,,,,\n'
+                                    }}, ohio_call_payload)
+
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    @patch('handlers.transaction_reporting.config.lambda_client')
+    def test_generate_report_with_multiple_privileges_in_single_transaction(self, mock_lambda_client):
+        """Test processing of transactions with multiple privileges in a single transaction."""
+        from handlers.transaction_reporting import generate_transaction_reports
+        self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION])
+        
+        mock_user = self.add_mock_provider_to_db('12345', 'John', 'Doe')
+        # Create a transaction with privileges for multiple jurisdictions
+        self.add_mock_transaction_to_db(
+            jurisdictions=['oh', 'ky', 'ne'],
+            licensee_id=mock_user['providerId'],
+            month_iso_string='2025-03',
+            transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00')
+        )
+
+        generate_transaction_reports(generate_mock_event(), self.mock_context)
+
+        calls_args = mock_lambda_client.invoke.call_args_list
+        compact_call_payload = json.loads(calls_args[0][1]['Payload'])
+        
+        # Verify compact summary shows correct totals
+        self.assertEqual(
+            'Total Transactions,1\n'
+            'Total Compact Fees,$31.50\n'  # $10.50 x 3 privileges
+            'State Fees (Kentucky),$100.00\n'
+            'State Fees (Nebraska),$100.00\n'
+            'State Fees (Ohio),$100.00\n',
+            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV']
+        )
+
+        # Verify each jurisdiction report shows the correct privilege
+        for jurisdiction in ['ky', 'ne', 'oh']:
+            jurisdiction_call = next(
+                call for call in calls_args[1:]
+                if json.loads(call[1]['Payload'])['jurisdiction'] == jurisdiction
+            )
+            jurisdiction_payload = json.loads(jurisdiction_call[1]['Payload'])
+            self.assertIn(
+                f'{mock_user['givenName']},{mock_user['familyName']},{mock_user['providerId']},03-30-2025,100,{jurisdiction.upper()},10.50,{MOCK_TRANSACTION_ID}',
+                jurisdiction_payload['templateVariables']['jurisdictionTransactionReportCSV']
+            )
+
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    @patch('handlers.transaction_reporting.config.lambda_client')
+    def test_generate_report_with_large_number_of_transactions_and_providers(self, mock_lambda_client):
+        """Test processing of a large number of transactions (>500) and providers (>100)."""
+        from handlers.transaction_reporting import generate_transaction_reports
+        self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
+        
+        # Create 700 providers
+        providers = []
+        for i in range(700):
+            provider = self.add_mock_provider_to_db(
+                f'user_{i}',
+                f'First{i}',
+                f'Last{i}'
+            )
+            providers.append(provider)
+        
+        # Create 600 transactions (300 per jurisdiction)
+        base_time = datetime.fromisoformat('2025-03-30T12:00:00+00:00')
+        for i in range(600):
+            provider = providers[i]
+            jurisdiction = 'oh' if i < 300 else 'ky'
+            self.add_mock_transaction_to_db(
+                jurisdictions=[jurisdiction],
+                licensee_id=provider['providerId'],
+                month_iso_string='2025-03',
+                transaction_settlement_time_utc=base_time + timedelta(minutes=i),
+                transaction_id=f'tx_{i}'
+            )
+
+        generate_transaction_reports(generate_mock_event(), self.mock_context)
+
+        calls_args = mock_lambda_client.invoke.call_args_list
+        compact_call_payload = json.loads(calls_args[0][1]['Payload'])
+        
+        # Verify summary totals
+        self.assertEqual(
+            'Total Transactions,600\n'
+            'Total Compact Fees,$6300.00\n'  # $10.50 x 600
+            'State Fees (Kentucky),$30000.00\n'  # $100 x 300
+            'State Fees (Ohio),$30000.00\n',  # $100 x 300
+            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV']
+        )
+
+        # Verify transaction reports
+        ohio_transactions_in_report = [
+            line for line in compact_call_payload['templateVariables']['compactTransactionReportCSV'].split('\n')
+            if 'OH' in line
         ]
+        kentucky_transactions_in_report = [
+            line for line in compact_call_payload['templateVariables']['compactTransactionReportCSV'].split('\n')
+            if 'KY' in line
+        ]
+        self.assertEqual(
+            300,
+            len(ohio_transactions_in_report)
+        )
+        self.assertEqual(
+            300,
+            len(kentucky_transactions_in_report)
+        )
+        # make sure all expected user ids in report
+        for i in range(300):
+            self.assertIn(f'user_{i}', ohio_transactions_in_report[i])
+            self.assertIn(f'user_{i+300}', kentucky_transactions_in_report[i])
 
+        # Verify jurisdiction reports
+        for jurisdiction in ['oh', 'ky']:
+            jurisdiction_call = next(
+                call for call in calls_args[1:]
+                if json.loads(call[1]['Payload'])['jurisdiction'] == jurisdiction
+            )
+            jurisdiction_payload = json.loads(jurisdiction_call[1]['Payload'])
+            report_csv = jurisdiction_payload['templateVariables']['jurisdictionTransactionReportCSV']
 
-        mock_lambda_client.invoke.assert_has_calls(expected_calls)
+            # 300 transactions + 5 extra lines for the header, spacing, summary headers, summary values, and line at EOF
+            expected_csv_line_count = 305
+            self.assertEqual(expected_csv_line_count, len(report_csv.split('\n')))
+            # Verify the summary totals are correct
+            self.assertIn('Privileges Purchased,Total State Amount,,,,,,', report_csv)
+            self.assertIn('300,$30000.00,,,,,,', report_csv)
+
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    def test_generate_report_raises_error_when_compact_not_found(self):
+        """Test error handling when compact configuration is not found."""
+        from handlers.transaction_reporting import generate_transaction_reports
+
+        # Don't add any compact configuration data
+        with self.assertRaises(CCNotFoundException) as exc_info:
+            generate_transaction_reports(generate_mock_event(), self.mock_context)
+
+        self.assertIn('Compact configuration not found', str(exc_info.exception.message))
+

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from unittest.mock import patch
 
-from cc_common.exceptions import CCNotFoundException, CCInternalException
+from cc_common.exceptions import CCInternalException, CCNotFoundException
 from moto import mock_aws
 
 from .. import TstFunction
@@ -99,14 +99,15 @@ def _generate_mock_transaction(
         'transactionProcessor': 'authorize.net',
     }
 
+
 def _set_default_lambda_client_behavior(mock_lambda_client):
     """Set the default behavior for the mock lambda client."""
     mock_lambda_client.invoke.return_value = {
-    'StatusCode': 200,
-    'LogResult': 'string',
-    'Payload': "{\"message\": \"Email message sent\"}",
-    'ExecutedVersion': '1'
-}
+        'StatusCode': 200,
+        'LogResult': 'string',
+        'Payload': '{"message": "Email message sent"}',
+        'ExecutedVersion': '1',
+    }
 
 
 @mock_aws
@@ -183,6 +184,7 @@ class TestGenerateTransactionReports(TstFunction):
     def test_generate_transaction_reports_sends_csv_with_zero_values_when_no_transactions(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
         from handlers.transaction_reporting import generate_transaction_reports
+
         _set_default_lambda_client_behavior(mock_lambda_client)
 
         self._add_compact_configuration_data()
@@ -228,6 +230,7 @@ class TestGenerateTransactionReports(TstFunction):
     def test_generate_report_collects_transactions_across_two_months(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
         from handlers.transaction_reporting import generate_transaction_reports
+
         _set_default_lambda_client_behavior(mock_lambda_client)
 
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
@@ -313,6 +316,7 @@ class TestGenerateTransactionReports(TstFunction):
     def test_generate_report_with_multiple_privileges_in_single_transaction(self, mock_lambda_client):
         """Test processing of transactions with multiple privileges in a single transaction."""
         from handlers.transaction_reporting import generate_transaction_reports
+
         _set_default_lambda_client_behavior(mock_lambda_client)
 
         self._add_compact_configuration_data(
@@ -359,6 +363,7 @@ class TestGenerateTransactionReports(TstFunction):
     def test_generate_report_with_large_number_of_transactions_and_providers(self, mock_lambda_client):
         """Test processing of a large number of transactions (>500) and providers (>100)."""
         from handlers.transaction_reporting import generate_transaction_reports
+
         _set_default_lambda_client_behavior(mock_lambda_client)
 
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
@@ -445,6 +450,7 @@ class TestGenerateTransactionReports(TstFunction):
     def test_generate_report_raises_error_when_lambda_returns_function_error(self, mock_lambda_client):
         """Test error handling when compact configuration is not found."""
         from handlers.transaction_reporting import generate_transaction_reports
+
         mock_lambda_client.invoke.return_value = {'FunctionError': 'Something went wrong'}
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
 
@@ -461,6 +467,7 @@ class TestGenerateTransactionReports(TstFunction):
         This is unlikely to happen in practice, but we should handle it gracefully.
         """
         from handlers.transaction_reporting import generate_transaction_reports
+
         _set_default_lambda_client_behavior(mock_lambda_client)
 
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -476,7 +476,7 @@ class ApiModel:
             description='Post purchase privileges request model',
             schema=JsonSchema(
                 type=JsonSchemaType.OBJECT,
-                required=['selectedJurisdictions', 'orderInformation', 'attestations'],
+                required=['selectedJurisdictions', 'orderInformation'],
                 properties={
                     'selectedJurisdictions': JsonSchema(
                         type=JsonSchemaType.ARRAY,

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -124,11 +124,11 @@ class ReportingStack(AppStack):
     def _add_transaction_reporting_chain(self, persistent_stack: ps.PersistentStack):
         """Add the transaction reporting lambda and event rules.
 
-            Based on our initial load testing, we determined that this lambda can process up to 70,000 transactions
-            in a single invocation. The limit is set by the size of the payload we can send to the
-            email-notification-service lambda (6MB) which is a hard limit. If we need to process more transactions than
-            this, we will need to update the system to use an S3 bucket to store the transaction data and have the
-            email-notification-service lambda read from the bucket.
+        Based on our initial load testing, we determined that this lambda can process up to 70,000 transactions
+        in a single invocation. The limit is set by the size of the payload we can send to the
+        email-notification-service lambda (6MB) which is a hard limit. If we need to process more transactions than
+        this, we will need to update the system to use an S3 bucket to store the transaction data and have the
+        email-notification-service lambda read from the bucket.
         """
         self.transaction_reporter = PythonFunction(
             self,

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -171,7 +171,7 @@ class ReportingStack(AppStack):
                 targets=[
                     LambdaFunction(
                         handler=self.transaction_reporter,
-                        event=RuleTargetInput.from_object({'compact': compact.lower()})
+                        event=RuleTargetInput.from_object({'compact': compact.lower()}),
                     )
                 ],
             )

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -137,7 +137,7 @@ class ReportingStack(AppStack):
                 'TRANSACTION_HISTORY_TABLE_NAME': persistent_stack.transaction_history_table.table_name,
                 'PROVIDER_TABLE_NAME': persistent_stack.provider_table.table_name,
                 'COMPACT_CONFIGURATION_TABLE_NAME': persistent_stack.compact_configuration_table.table_name,
-                'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': persistent_stack.email_notification_service_lambda.function_name, # noqa: E501 line-too-long
+                'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': persistent_stack.email_notification_service_lambda.function_name,  # noqa: E501 line-too-long
                 **self.common_env_vars,
             },
         )

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import os
+
 from aws_cdk import Duration
 from aws_cdk.aws_cloudwatch import Alarm, ComparisonOperator, Stats, TreatMissingData
 from aws_cdk.aws_cloudwatch_actions import SnsAction
@@ -8,6 +11,7 @@ from aws_cdk.aws_events_targets import LambdaFunction
 from aws_cdk.aws_logs import QueryDefinition, QueryString
 from cdk_nag import NagSuppressions
 from common_constructs.nodejs_function import NodejsFunction
+from common_constructs.python_function import PythonFunction
 from common_constructs.stack import AppStack
 from constructs import Construct
 
@@ -18,6 +22,7 @@ class ReportingStack(AppStack):
     def __init__(self, scope: Construct, construct_id: str, *, persistent_stack: ps.PersistentStack, **kwargs):
         super().__init__(scope, construct_id, **kwargs)
         self._add_ingest_event_reporting_chain(persistent_stack)
+        self._add_transaction_reporting_chain(persistent_stack)
 
     def _add_ingest_event_reporting_chain(self, persistent_stack: ps.PersistentStack):
         from_address = f'noreply@{persistent_stack.user_email_notifications.email_identity.email_identity_name}'
@@ -114,6 +119,99 @@ class ReportingStack(AppStack):
                 sort='@timestamp desc',
             ),
             log_groups=[event_collector.log_group],
+        )
+
+    def _add_transaction_reporting_chain(self, persistent_stack: ps.PersistentStack):
+        """Add the transaction reporting lambda and event rules."""
+        self.transaction_reporter = PythonFunction(
+            self,
+            'TransactionReporter',
+            description='Transaction report generator',
+            handler='generate_transaction_reports',
+            lambda_dir='purchases',
+            index=os.path.join('handlers', 'transaction_reporting.py'),
+            timeout=Duration.minutes(15),
+            # required as this lambda is bundled with the authorize.net SDK which is large
+            memory_size=512,
+            environment={
+                'TRANSACTION_HISTORY_TABLE_NAME': persistent_stack.transaction_history_table.table_name,
+                'PROVIDER_TABLE_NAME': persistent_stack.provider_table.table_name,
+                'COMPACT_CONFIGURATION_TABLE_NAME': persistent_stack.compact_configuration_table.table_name,
+                'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': persistent_stack.email_notification_service_lambda.function_name,
+                **self.common_env_vars,
+            },
+        )
+
+        # Grant necessary permissions
+        persistent_stack.transaction_history_table.grant_read_data(self.transaction_reporter)
+        persistent_stack.provider_table.grant_read_data(self.transaction_reporter)
+        persistent_stack.compact_configuration_table.grant_read_data(self.transaction_reporter)
+        persistent_stack.email_notification_service_lambda.grant_invoke(self.transaction_reporter)
+
+        NagSuppressions.add_resource_suppressions_by_path(
+            self,
+            f'{self.transaction_reporter.node.path}/ServiceRole/DefaultPolicy/Resource',
+            suppressions=[
+                {
+                    'id': 'AwsSolutions-IAM5',
+                    'reason': """
+                            This policy contains wild-carded actions and resources but they are scoped to the
+                            specific actions, KMS key, and Tables that this lambda specifically needs access to.
+                            """,
+                },
+            ],
+        )
+
+        # Create event rules for each compact
+        for compact in json.loads(self.common_env_vars['COMPACTS']):
+            Rule(
+                self,
+                f'{compact.capitalize()}-WeeklyTransactionReportRule',
+                schedule=Schedule.cron(week_day='7', hour='1', minute='0', month='*', year='*'),
+                targets=[
+                    LambdaFunction(
+                        handler=self.transaction_reporter,
+                        event=RuleTargetInput.from_object({'compact': compact.lower()})
+                    )
+                ],
+            )
+
+        # Add alarms
+        Alarm(
+            self,
+            'TransactionReporterFailure',
+            metric=self.transaction_reporter.metric_errors(statistic=Stats.SUM),
+            evaluation_periods=1,
+            threshold=1,
+            actions_enabled=True,
+            alarm_description=f'{self.transaction_reporter.node.path} failed to process an event',
+            comparison_operator=ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(SnsAction(persistent_stack.alarm_topic))
+
+        # If the max function execution time is approaching its max timeout
+        Alarm(
+            self,
+            'TransactionReporterDurationAlarm',
+            metric=self.transaction_reporter.metric_duration(statistic=Stats.MAXIMUM, period=Duration.days(1)),
+            evaluation_periods=1,
+            threshold=600_000,  # 10 minutes
+            actions_enabled=True,
+            alarm_description=f'{self.transaction_reporter.node.path} Lambda Duration',
+            comparison_operator=ComparisonOperator.GREATER_THAN_THRESHOLD,
+            treat_missing_data=TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(SnsAction(persistent_stack.alarm_topic))
+
+        QueryDefinition(
+            self,
+            'TransactionReporterQuery',
+            query_definition_name=f'{self.node.id}/TransactionReporter',
+            query_string=QueryString(
+                fields=['@timestamp', '@log', 'level', 'message', 'compact', '@message'],
+                filter_statements=['level in ["INFO", "WARNING", "ERROR"]'],
+                sort='@timestamp desc',
+            ),
+            log_groups=[self.transaction_reporter.log_group],
         )
 
     def _get_ui_base_path_url(self) -> str:

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -137,7 +137,7 @@ class ReportingStack(AppStack):
                 'TRANSACTION_HISTORY_TABLE_NAME': persistent_stack.transaction_history_table.table_name,
                 'PROVIDER_TABLE_NAME': persistent_stack.provider_table.table_name,
                 'COMPACT_CONFIGURATION_TABLE_NAME': persistent_stack.compact_configuration_table.table_name,
-                'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': persistent_stack.email_notification_service_lambda.function_name,
+                'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': persistent_stack.email_notification_service_lambda.function_name, # noqa: E501 line-too-long
                 **self.common_env_vars,
             },
         )

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -131,8 +131,8 @@ class ReportingStack(AppStack):
             lambda_dir='purchases',
             index=os.path.join('handlers', 'transaction_reporting.py'),
             timeout=Duration.minutes(15),
-            # required as this lambda is bundled with the authorize.net SDK which is large
-            memory_size=512,
+            # This lambda can process many transactions at once
+            memory_size=3008,
             environment={
                 'TRANSACTION_HISTORY_TABLE_NAME': persistent_stack.transaction_history_table.table_name,
                 'PROVIDER_TABLE_NAME': persistent_stack.provider_table.table_name,

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
@@ -174,8 +174,7 @@
   },
   "required": [
     "selectedJurisdictions",
-    "orderInformation",
-    "attestations"
+    "orderInformation"
   ],
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#"


### PR DESCRIPTION
compact commission admins and state admins will want to know how many compact privileges were purchased in a week, who purchased them, which states they were purchased for, and the cost totals so that they can track payments and new practitioners in their state.

This adds the needed infrastructure/logic to get the list of transactions for the previous week and generate reports for both compacts and all jurisdictions within those compacts.

### Requirements List
- If any compact or jurisdiction in the environment does not have any email addresses listed in their respective reporting list, the transaction reporting lambda will raise an exception, which will fire an alert once a week. This is by design as support teams will need to be notified if reports are not being sent to any recipients.

### Description List
- Added transaction reporting system which will send out transaction reports to all jurisdictions as well as the compact
- Updated email notification service lambda to handle file attachments

### Testing List
- Added tests for python and lambda logic
- Verified functionality in sandbox account
- Code review

Closes #316 
