### PR TITLE
fix/make file extension matching case-insensitive

### DIFF
--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/provider_users.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/provider_users.py
@@ -81,7 +81,7 @@ def _post_provider_military_affiliation(event, context):  # noqa: ARG001 unused-
     # verify all files use supported file extensions
     for file_name in file_names:
         file_name_without_extension, file_extension = file_name.rsplit('.', 1)
-        if file_extension not in SUPPORTED_MILITARY_AFFILIATION_FILE_EXTENSIONS:
+        if file_extension.lower() not in [ext.lower() for ext in SUPPORTED_MILITARY_AFFILIATION_FILE_EXTENSIONS]:
             raise CCInvalidRequestException(
                 f'Invalid file type "{file_extension}" The following file types '
                 f'are supported: {SUPPORTED_MILITARY_AFFILIATION_FILE_EXTENSIONS}'
@@ -89,7 +89,7 @@ def _post_provider_military_affiliation(event, context):  # noqa: ARG001 unused-
 
         # generate a UUID for the document key, which includes a random UUID followed by the filename
         # and the file extension
-        document_uuid = f'{uuid.uuid4()}#{file_name_without_extension}.{file_extension}'
+        document_uuid = f'{uuid.uuid4()}#{file_name_without_extension}.{file_extension.lower()}'
         document_key = s3_document_prefix + document_uuid
         document_keys.append(document_key)
 

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_provider_users.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_provider_users.py
@@ -148,6 +148,24 @@ class TestPostProviderMilitaryAffiliation(TstFunction):
             military_affiliation_data,
         )
 
+    @patch('handlers.provider_users.uuid')
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-12-04T08:08:08+00:00'))
+    def test_post_provider_military_affiliation_handles_file_with_uppercase_extension(self, mock_uuid):
+        from handlers.provider_users import provider_user_me_military_affiliation
+
+        mock_uuid.uuid4.return_value = '1234'
+
+        event = self._when_testing_post_provider_user_military_affiliation_event_with_custom_claims()
+        event['body'] = json.dumps(
+            {
+                'fileNames': [MOCK_MILITARY_AFFILIATION_FILE_NAME.upper()],
+                'affiliationType': 'militaryMember',
+            }
+        )
+
+        resp = provider_user_me_military_affiliation(event, self.mock_context)
+        self.assertEqual(200, resp['statusCode'])
+
     def test_post_provider_military_affiliation_sets_previous_record_status_to_inactive(self):
         from handlers.provider_users import provider_user_me_military_affiliation
 


### PR DESCRIPTION
File extension matching should not fail if extension is a valid type by uses different casing


