### PR TITLE
Simplify password constraints to match server

### DIFF
--- a/webroot/src/components/ChangePassword/ChangePassword.ts
+++ b/webroot/src/components/ChangePassword/ChangePassword.ts
@@ -11,7 +11,6 @@ import { authStorage, AuthTypes, tokens } from '@/app.config';
 import MixinForm from '@components/Forms/_mixins/form.mixin';
 import InputPassword from '@components/Forms/InputPassword/InputPassword.vue';
 import InputSubmit from '@components/Forms/InputSubmit/InputSubmit.vue';
-import { User } from '@models/User/User.model';
 import { FormInput } from '@models/FormInput/FormInput.model';
 import { dataApi } from '@network/data.api';
 import Joi from 'joi';
@@ -42,10 +41,6 @@ class ChangePassword extends mixins(MixinForm) {
         return this.$store.state;
     }
 
-    get userStore() {
-        return this.$store.state.user;
-    }
-
     get authType(): AuthTypes {
         return this.globalStore.authType;
     }
@@ -68,10 +63,6 @@ class ChangePassword extends mixins(MixinForm) {
         }
 
         return token;
-    }
-
-    get user(): User {
-        return this.userStore.model || new User();
     }
 
     get submitLabel(): string {
@@ -100,9 +91,6 @@ class ChangePassword extends mixins(MixinForm) {
                 validation: joiPassword
                     .string()
                     .min(12)
-                    .doesNotInclude([
-                        this.user.email,
-                    ])
                     .messages({
                         ...this.joiMessages.string,
                         ...this.joiMessages.password,

--- a/webroot/src/components/UserAccount/UserAccount.less
+++ b/webroot/src/components/UserAccount/UserAccount.less
@@ -6,6 +6,12 @@
 //
 
 .account-area-container {
+    width: 95%;
+
+    @media @tabletWidth {
+        width: 50rem;
+    }
+
     .card-title {
         margin-bottom: 3.2rem;
     }


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Joi password plugin was not string matching all cases as expected, so we just removed that constraint since it wasn't server enforced anyway.

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- New password should now just enforce character length only, which aligns exactly with the backend currently.

Hotfix for sprint merge.
