### PR TITLE
Add aria-label to mobile nav logo

### DIFF
--- a/webroot/src/components/Page/PageHeader/PageHeader.vue
+++ b/webroot/src/components/Page/PageHeader/PageHeader.vue
@@ -16,6 +16,7 @@
                 @keyup.enter="logoClick"
                 role="button"
                 tabindex="0"
+                :aria-label="$t('common.appName')"
             />
         </div>
         <div v-if="$matches.phone.only" class="nav-toggle-container">


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Add aria-label to mobile nav logo

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review

Sprint PR hotfix.
