### PR TITLE
Feat/delete staff user

### DIFF
--- a/backend/compact-connect/README.md
+++ b/backend/compact-connect/README.md
@@ -105,8 +105,7 @@ Keeping documentation current is an important part of feature development in thi
 1) Export a fresh api specification (OAS 3.0) is exported from API Gateway and used to update [the Open API Specification JSON file](./docs/api-specification/latest-oas30.json).
 2) Run `bin/trim_oas30.py` to organize and trim the API to include only supported API endpoints (and update the script itself, if needed).
 3) If you exported the api specification from somewhere other than the CSG Test environment, be sure to set the `servers[0].url` entry back to the correct base URL for the CSG Test environment.
-4) Update the change summary at the bottom of the [Technical User Docs](./docs/README.md).
-5) Update the [Postman Collection and Environment](./docs/postman) as appropriate.
+4) Update the [Postman Collection and Environment](./docs/postman) as appropriate.
 
 ## Deployment
 [Back to top](#compact-connect---backend-developer-documentation)

--- a/backend/compact-connect/bin/trim_oas30.py
+++ b/backend/compact-connect/bin/trim_oas30.py
@@ -15,11 +15,26 @@ def strip_sort_paths(oas30: dict) -> dict:
     return oas30
 
 
+def strip_options_endpoints(oas30: dict) -> dict:
+    """
+    The OPTIONS endpoints add a lot of noise to the spec and are not important to developers, so we'll omit them.
+    """
+    for path_key, path_value in oas30['paths'].items():
+        oas30['paths'][path_key] = {
+            method_key: method_value for method_key, method_value in path_value.items()
+            if method_key != 'options'
+        }
+    # Remove now empty paths
+    oas30['paths'] = {path_key: path_value for path_key, path_value in oas30['paths'].items() if path_value}
+    return oas30
+
+
 if __name__ == '__main__':
     with open('docs/api-specification/latest-oas30.json') as f:
         original_spec = json.load(f)
 
     new_spec = strip_sort_paths(original_spec)
+    new_spec = strip_options_endpoints(new_spec)
 
     with open('docs/api-specification/latest-oas30.json', 'w') as f:
         json.dump(new_spec, f, indent=2)

--- a/backend/compact-connect/docs/README.md
+++ b/backend/compact-connect/docs/README.md
@@ -56,7 +56,3 @@ For your convenience, use of this feature is included in the [Postman Collection
 We will maintain the latest api specification here, in [latest-oas30.json](api-specification/latest-oas30.json). You can
 use [Swagger.io](https://editor.swagger.io/) to render the json directly or, if you happen to use an IDE that supports
 the feature, you can open a Swagger UI view of it by opening up the accompanying [swagger.html](api-specification/swagger.html) in your browser.
-
-### Change summary:
-- 2024-08-21: First API version release
-- 2024-09-03: Proposed addition of staff-user API

--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -2,11 +2,11 @@
   "openapi": "3.0.1",
   "info": {
     "title": "LicenseApi",
-    "version": "2025-01-15T17:49:42Z"
+    "version": "2025-01-22T18:15:37Z"
   },
   "servers": [
     {
-      "url": "https://api.test.compactconnect.org"
+      "url": "https://api.justin.jcc.iaapi.io"
     }
   ],
   "paths": {
@@ -973,6 +973,16 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                }
+              }
+            }
+          },
           "200": {
             "description": "200 response",
             "headers": {
@@ -986,6 +996,57 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SandboxAPIStackLicenseApiStaffPoolsAuthorizerD744D6FB": [
+              "aslp/admin",
+              "octp/admin",
+              "coun/admin"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "parameters": [
+          {
+            "name": "compact",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
                 }
               }
             }
@@ -1074,6 +1135,16 @@
           "required": true
         },
         "responses": {
+          "404": {
+            "description": "404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                }
+              }
+            }
+          },
           "200": {
             "description": "200 response",
             "headers": {
@@ -1470,6 +1541,16 @@
     "/v1/staff-users/me": {
       "get": {
         "responses": {
+          "404": {
+            "description": "404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                }
+              }
+            }
+          },
           "200": {
             "description": "200 response",
             "headers": {
@@ -1533,6 +1614,16 @@
           "required": true
         },
         "responses": {
+          "404": {
+            "description": "404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                }
+              }
+            }
+          },
           "200": {
             "description": "200 response",
             "headers": {
@@ -3149,6 +3240,13 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "removedValues": {
+                        "type": "array",
+                        "description": "List of field names that were present in the previous record but removed in the update",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
                       "compact": {
                         "type": "string",
                         "enum": [
@@ -3760,6 +3858,13 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "removedValues": {
+                        "type": "array",
+                        "description": "List of field names that were present in the previous record but removed in the update",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
                       "compact": {
                         "type": "string",
                         "enum": [

--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -6,111 +6,10 @@
   },
   "servers": [
     {
-      "url": "https://api.justin.jcc.iaapi.io"
+      "url": "https://api.test.compactconnect.org"
     }
   ],
   "paths": {
-    "/v1/compacts": {
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
-    "/v1/compacts/{compact}": {
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
-    "/v1/compacts/{compact}/attestations": {
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
     "/v1/compacts/{compact}/attestations/{attestationId}": {
       "get": {
         "parameters": [
@@ -156,86 +55,6 @@
             "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
           }
         ]
-      },
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "attestationId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
-    "/v1/compacts/{compact}/credentials": {
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/compacts/{compact}/credentials/payment-processor": {
@@ -289,123 +108,6 @@
             ]
           }
         ]
-      },
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
-    "/v1/compacts/{compact}/jurisdictions": {
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
-    "/v1/compacts/{compact}/jurisdictions/{jurisdiction}": {
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "jurisdiction",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/compacts/{compact}/jurisdictions/{jurisdiction}/licenses": {
@@ -467,49 +169,6 @@
             ]
           }
         ]
-      },
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "jurisdiction",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/compacts/{compact}/jurisdictions/{jurisdiction}/licenses/bulk-upload": {
@@ -561,86 +220,6 @@
             ]
           }
         ]
-      },
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "jurisdiction",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
-    "/v1/compacts/{compact}/providers": {
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/compacts/{compact}/providers/query": {
@@ -694,41 +273,6 @@
             ]
           }
         ]
-      },
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/compacts/{compact}/providers/{providerId}": {
@@ -780,49 +324,6 @@
             ]
           }
         ]
-      },
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "providerId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/compacts/{compact}/staff-users": {
@@ -915,41 +416,6 @@
             ]
           }
         ]
-      },
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/compacts/{compact}/staff-users/{userId}": {
@@ -1062,49 +528,6 @@
           }
         ]
       },
-      "options": {
-        "parameters": [
-          {
-            "name": "compact",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      },
       "patch": {
         "parameters": [
           {
@@ -1174,33 +597,6 @@
         ]
       }
     },
-    "/v1/provider-users": {
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
     "/v1/provider-users/me": {
       "get": {
         "parameters": [
@@ -1230,31 +626,6 @@
             "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
           }
         ]
-      },
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/provider-users/me/military-affiliation": {
@@ -1297,31 +668,6 @@
           }
         ]
       },
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      },
       "patch": {
         "parameters": [
           {
@@ -1360,33 +706,6 @@
             "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
           }
         ]
-      }
-    },
-    "/v1/purchases": {
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/purchases/privileges": {
@@ -1428,31 +747,6 @@
             "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
           }
         ]
-      },
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/purchases/privileges/options": {
@@ -1484,58 +778,6 @@
             "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA": []
           }
         ]
-      },
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
-      }
-    },
-    "/v1/staff-users": {
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       }
     },
     "/v1/staff-users/me": {
@@ -1576,31 +818,6 @@
             ]
           }
         ]
-      },
-      "options": {
-        "responses": {
-          "204": {
-            "description": "204 response",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        }
       },
       "patch": {
         "requestBody": {

--- a/backend/compact-connect/docs/postman/postman-collection.json
+++ b/backend/compact-connect/docs/postman/postman-collection.json
@@ -44,9 +44,9 @@
 							}
 						],
 						"url": {
-							"raw": "{{boardUserPoolUrl}}/oauth2/token?grant_type=client_credentials&client_id={{clientId}}&client_secret={{clientSecret}}&scope={{compact}}/{{jurisdiction}}",
+							"raw": "{{staffUserPoolUrl}}/oauth2/token?grant_type=client_credentials&client_id={{clientId}}&client_secret={{clientSecret}}&scope={{compact}}/{{jurisdiction}}",
 							"host": [
-								"{{boardUserPoolUrl}}"
+								"{{staffUserPoolUrl}}"
 							],
 							"path": [
 								"oauth2",
@@ -123,9 +123,9 @@
 							}
 						],
 						"url": {
-							"raw": "{{boardUserPoolUrl}}/oauth2/token?grant_type=authorization_code&code=f50f8482-d18f-49e1-82d2-078b84aba11c&client_id={{clientId}}&scope=openid&redirect_uri=http://localhost:3018/auth/callback",
+							"raw": "{{staffUserPoolUrl}}/oauth2/token?grant_type=authorization_code&code=f23723c3-1d21-40e1-89ec-64807d2d658d&client_id={{clientId}}&scope=openid&redirect_uri=http://localhost:3018/auth/callback",
 							"host": [
-								"{{boardUserPoolUrl}}"
+								"{{staffUserPoolUrl}}"
 							],
 							"path": [
 								"oauth2",
@@ -138,7 +138,7 @@
 								},
 								{
 									"key": "code",
-									"value": "f50f8482-d18f-49e1-82d2-078b84aba11c"
+									"value": "f23723c3-1d21-40e1-89ec-64807d2d658d"
 								},
 								{
 									"key": "client_id",
@@ -151,6 +151,158 @@
 								{
 									"key": "redirect_uri",
 									"value": "http://localhost:3018/auth/callback"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "authorization-code-authorize",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Access token returned', () => {",
+									"    var access_token = pm.response.json().access_token;",
+									"    pm.expect(access_token).not.to.be.empty;",
+									"    pm.environment.set(\"accessToken\", access_token);",
+									"    console.log('Access token: ' + access_token);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"followRedirects": false
+					},
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded",
+								"disabled": true
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{staffUserPoolUrl}}/oauth2/authorize?response_type=code&client_id={{clientId}}&redirect_uri=http://localhost:3018/auth/callback&scope=openid",
+							"host": [
+								"{{staffUserPoolUrl}}"
+							],
+							"path": [
+								"oauth2",
+								"authorize"
+							],
+							"query": [
+								{
+									"key": "response_type",
+									"value": "code"
+								},
+								{
+									"key": "client_id",
+									"value": "{{clientId}}"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "http://localhost:3018/auth/callback"
+								},
+								{
+									"key": "scope",
+									"value": "openid"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "authorization-code-login",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Access token returned', () => {",
+									"    var access_token = pm.response.json().access_token;",
+									"    pm.expect(access_token).not.to.be.empty;",
+									"    pm.environment.set(\"accessToken\", access_token);",
+									"    console.log('Access token: ' + access_token);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"followRedirects": false
+					},
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{staffUserPoolUrl}}/oauth2/authorize?scope=openid&response_type=code&client_id={{clientId}}&redirect_uri=http://localhost:3018/auth/callback&identity_provider=COGNITO",
+							"host": [
+								"{{staffUserPoolUrl}}"
+							],
+							"path": [
+								"oauth2",
+								"authorize"
+							],
+							"query": [
+								{
+									"key": "scope",
+									"value": "openid"
+								},
+								{
+									"key": "response_type",
+									"value": "code"
+								},
+								{
+									"key": "client_id",
+									"value": "{{clientId}}"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "http://localhost:3018/auth/callback"
+								},
+								{
+									"key": "identity_provider",
+									"value": "COGNITO"
 								}
 							]
 						}
@@ -197,9 +349,9 @@
 							}
 						],
 						"url": {
-							"raw": "{{boardUserPoolUrl}}/oauth2/token?grant_type=refresh_token&client_id={{clientId}}&refresh_token={{refreshToken}}",
+							"raw": "{{staffUserPoolUrl}}/oauth2/token?grant_type=refresh_token&client_id={{clientId}}&refresh_token={{refreshToken}}",
 							"host": [
-								"{{boardUserPoolUrl}}"
+								"{{staffUserPoolUrl}}"
 							],
 							"path": [
 								"oauth2",
@@ -235,6 +387,262 @@
 							"name": "{compact}",
 							"item": [
 								{
+									"name": "attestations",
+									"item": [
+										{
+											"name": "{attestationId}",
+											"item": [
+												{
+													"name": "/v1/compacts/:compact/attestations/:attestationId",
+													"request": {
+														"auth": {
+															"type": "apikey",
+															"apikey": [
+																{
+																	"key": "key",
+																	"value": "Authorization",
+																	"type": "string"
+																},
+																{
+																	"key": "value",
+																	"value": "{{apiKey}}",
+																	"type": "string"
+																},
+																{
+																	"key": "in",
+																	"value": "header",
+																	"type": "string"
+																}
+															]
+														},
+														"method": "GET",
+														"header": [
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/v1/compacts/:compact/attestations/:attestationId",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"v1",
+																"compacts",
+																":compact",
+																"attestations",
+																":attestationId"
+															],
+															"variable": [
+																{
+																	"key": "compact",
+																	"value": "<string>",
+																	"description": "(Required) "
+																},
+																{
+																	"key": "attestationId",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "200 response",
+															"originalRequest": {
+																"method": "GET",
+																"header": [
+																	{
+																		"key": "Accept",
+																		"value": "application/json"
+																	},
+																	{
+																		"key": "Authorization",
+																		"value": "<API Key>",
+																		"description": "Added as a part of security scheme: apikey"
+																	}
+																],
+																"url": {
+																	"raw": "{{baseUrl}}/v1/compacts/:compact/attestations/:attestationId",
+																	"host": [
+																		"{{baseUrl}}"
+																	],
+																	"path": [
+																		"v1",
+																		"compacts",
+																		":compact",
+																		"attestations",
+																		":attestationId"
+																	],
+																	"variable": [
+																		{
+																			"key": "compact"
+																		},
+																		{
+																			"key": "attestationId"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n  \"dateCreated\": \"<dateTime>\",\n  \"compact\": \"coun\",\n  \"attestationType\": \"<string>\",\n  \"text\": \"<string>\",\n  \"type\": \"attestation\",\n  \"version\": \"<string>\",\n  \"required\": \"<boolean>\"\n}"
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "credentials",
+									"item": [
+										{
+											"name": "payment-processor",
+											"item": [
+												{
+													"name": "/v1/compacts/:compact/credentials/payment-processor",
+													"request": {
+														"auth": {
+															"type": "apikey",
+															"apikey": [
+																{
+																	"key": "key",
+																	"value": "Authorization",
+																	"type": "string"
+																},
+																{
+																	"key": "value",
+																	"value": "{{apiKey}}",
+																	"type": "string"
+																},
+																{
+																	"key": "in",
+																	"value": "header",
+																	"type": "string"
+																}
+															]
+														},
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n  \"apiLoginId\": \"<string>\",\n  \"processor\": \"authorize.net\",\n  \"transactionKey\": \"<string>\"\n}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/v1/compacts/:compact/credentials/payment-processor",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"v1",
+																"compacts",
+																":compact",
+																"credentials",
+																"payment-processor"
+															],
+															"variable": [
+																{
+																	"key": "compact",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "200 response",
+															"originalRequest": {
+																"method": "POST",
+																"header": [
+																	{
+																		"key": "Content-Type",
+																		"value": "application/json"
+																	},
+																	{
+																		"key": "Accept",
+																		"value": "application/json"
+																	},
+																	{
+																		"key": "Authorization",
+																		"value": "<API Key>",
+																		"description": "Added as a part of security scheme: apikey"
+																	}
+																],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n  \"apiLoginId\": \"<string>\",\n  \"processor\": \"authorize.net\",\n  \"transactionKey\": \"<string>\"\n}",
+																	"options": {
+																		"raw": {
+																			"headerFamily": "json",
+																			"language": "json"
+																		}
+																	}
+																},
+																"url": {
+																	"raw": "{{baseUrl}}/v1/compacts/:compact/credentials/payment-processor",
+																	"host": [
+																		"{{baseUrl}}"
+																	],
+																	"path": [
+																		"v1",
+																		"compacts",
+																		":compact",
+																		"credentials",
+																		"payment-processor"
+																	],
+																	"variable": [
+																		{
+																			"key": "compact"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n  \"message\": \"<string>\"\n}"
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
 									"name": "jurisdictions",
 									"item": [
 										{
@@ -248,39 +656,27 @@
 															"item": [
 																{
 																	"name": "/v1/compacts/:compact/jurisdictions/:jurisdiction/licenses/bulk-upload",
-																	"event": [
-																		{
-																			"listen": "test",
-																			"script": {
-																				"exec": [
-																					"pm.test(\"Response status code is 200\", function () {",
-																					"    pm.expect(pm.response.code).to.equal(200);",
-																					"});",
-																					"",
-																					"pm.test(\"URL must exist in the response\", function () {",
-																					"    const responseData = pm.response.json();",
-																					"    ",
-																					"    pm.expect(responseData.upload.url).to.exist;",
-																					"    pm.environment.set('docUrl', responseData.upload.url);",
-																					"});",
-																					"",
-																					"",
-																					"pm.test(\"Fields must be in response\", function () {",
-																					"    const responseData = pm.response.json();",
-																					"    ",
-																					"    pm.expect(responseData.upload.fields).to.exist;",
-																					"    for (const [key, value] of Object.entries(responseData.upload.fields)) {",
-																					"        pm.environment.set(key, value);",
-																					"    }",
-																					"});",
-																					""
-																				],
-																				"type": "text/javascript",
-																				"packages": {}
-																			}
-																		}
-																	],
 																	"request": {
+																		"auth": {
+																			"type": "apikey",
+																			"apikey": [
+																				{
+																					"key": "key",
+																					"value": "Authorization",
+																					"type": "string"
+																				},
+																				{
+																					"key": "value",
+																					"value": "{{apiKey}}",
+																					"type": "string"
+																				},
+																				{
+																					"key": "in",
+																					"value": "header",
+																					"type": "string"
+																				}
+																			]
+																		},
 																		"method": "GET",
 																		"header": [
 																			{
@@ -305,12 +701,12 @@
 																			"variable": [
 																				{
 																					"key": "compact",
-																					"value": "aslp",
+																					"value": "<string>",
 																					"description": "(Required) "
 																				},
 																				{
 																					"key": "jurisdiction",
-																					"value": "oh",
+																					"value": "<string>",
 																					"description": "(Required) "
 																				}
 																			]
@@ -366,7 +762,7 @@
 																				}
 																			],
 																			"cookie": [],
-																			"body": "{\n  \"fields\": {\n    \"sint_5f\": \"<string>\",\n    \"sit2\": \"<string>\",\n    \"laborec_1\": \"<string>\",\n    \"Ut_32b\": \"<string>\"\n  },\n  \"url\": \"<string>\"\n}"
+																			"body": "{\n  \"fields\": {\n    \"deseruntd_\": \"<string>\"\n  },\n  \"url\": \"<string>\"\n}"
 																		}
 																	]
 																}
@@ -375,6 +771,26 @@
 														{
 															"name": "/v1/compacts/:compact/jurisdictions/:jurisdiction/licenses",
 															"request": {
+																"auth": {
+																	"type": "apikey",
+																	"apikey": [
+																		{
+																			"key": "key",
+																			"value": "Authorization",
+																			"type": "string"
+																		},
+																		{
+																			"key": "value",
+																			"value": "{{apiKey}}",
+																			"type": "string"
+																		},
+																		{
+																			"key": "in",
+																			"value": "header",
+																			"type": "string"
+																		}
+																	]
+																},
 																"method": "POST",
 																"header": [
 																	{
@@ -388,7 +804,7 @@
 																],
 																"body": {
 																	"mode": "raw",
-																	"raw": "[\n  {\n    \"dateOfBirth\": \"1963-07-30\",\n    \"dateOfExpiration\": \"2025-08-11\",\n    \"dateOfIssuance\": \"2020-12-30\",\n    \"dateOfRenewal\": \"2022-12-31\",\n    \"familyName\": \"Guðmundsdóttir\",\n    \"givenName\": \"Björk\",\n    \"homeAddressCity\": \"Birmingham\",\n    \"homeAddressState\": \"oh\",\n    \"homeAddressPostalCode\": \"35004\",\n    \"homeAddressStreet1\": \"123 A St.\",\n    \"status\": \"inactive\",\n    \"licenseType\": \"audiologist\",\n    \"ssn\": \"337-66-6786\",\n    \"npi\": \"5045836020\",\n    \"middleName\": \"Gunnar\"\n  }\n]",
+																	"raw": "[\n  {\n    \"dateOfBirth\": \"2512-05-24\",\n    \"dateOfExpiration\": \"1625-00-06\",\n    \"dateOfIssuance\": \"1576-07-02\",\n    \"dateOfRenewal\": \"1374-07-38\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\",\n    \"homeAddressCity\": \"<string>\",\n    \"homeAddressPostalCode\": \"<string>\",\n    \"homeAddressState\": \"<string>\",\n    \"homeAddressStreet1\": \"<string>\",\n    \"licenseType\": \"occupational therapy assistant\",\n    \"ssn\": \"557-23-0406\",\n    \"status\": \"active\",\n    \"homeAddressStreet2\": \"<string>\",\n    \"npi\": \"7500286789\",\n    \"militaryWaiver\": \"<boolean>\",\n    \"middleName\": \"<string>\"\n  },\n  {\n    \"dateOfBirth\": \"1744-05-16\",\n    \"dateOfExpiration\": \"2921-05-28\",\n    \"dateOfIssuance\": \"2278-02-34\",\n    \"dateOfRenewal\": \"2366-04-32\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\",\n    \"homeAddressCity\": \"<string>\",\n    \"homeAddressPostalCode\": \"<string>\",\n    \"homeAddressState\": \"<string>\",\n    \"homeAddressStreet1\": \"<string>\",\n    \"licenseType\": \"licensed clinical mental health counselor\",\n    \"ssn\": \"946-99-8502\",\n    \"status\": \"active\",\n    \"homeAddressStreet2\": \"<string>\",\n    \"npi\": \"3262938706\",\n    \"militaryWaiver\": \"<boolean>\",\n    \"middleName\": \"<string>\"\n  }\n]",
 																	"options": {
 																		"raw": {
 																			"headerFamily": "json",
@@ -412,12 +828,12 @@
 																	"variable": [
 																		{
 																			"key": "compact",
-																			"value": "octp",
+																			"value": "<string>",
 																			"description": "(Required) "
 																		},
 																		{
 																			"key": "jurisdiction",
-																			"value": "oh",
+																			"value": "<string>",
 																			"description": "(Required) "
 																		}
 																	]
@@ -445,7 +861,7 @@
 																		],
 																		"body": {
 																			"mode": "raw",
-																			"raw": "[\n  {\n    \"dateOfBirth\": \"<date>\",\n    \"dateOfExpiration\": \"<date>\",\n    \"dateOfIssuance\": \"<date>\",\n    \"dateOfRenewal\": \"<date>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\",\n    \"homeAddressCity\": \"<string>\",\n    \"homeAddressPostalCode\": \"<string>\",\n    \"homeAddressState\": \"<string>\",\n    \"homeAddressStreet1\": \"<string>\",\n    \"licenseType\": \"occupational therapist\",\n    \"ssn\": \"570-59-6499\",\n    \"status\": \"active\",\n    \"homeAddressStreet2\": \"<string>\",\n    \"npi\": \"2274917788\",\n    \"militaryWaiver\": \"<boolean>\",\n    \"middleName\": \"<string>\"\n  },\n  {\n    \"dateOfBirth\": \"<date>\",\n    \"dateOfExpiration\": \"<date>\",\n    \"dateOfIssuance\": \"<date>\",\n    \"dateOfRenewal\": \"<date>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\",\n    \"homeAddressCity\": \"<string>\",\n    \"homeAddressPostalCode\": \"<string>\",\n    \"homeAddressState\": \"<string>\",\n    \"homeAddressStreet1\": \"<string>\",\n    \"licenseType\": \"licensed mental health counselor\",\n    \"ssn\": \"545-69-3639\",\n    \"status\": \"active\",\n    \"homeAddressStreet2\": \"<string>\",\n    \"npi\": \"2104480011\",\n    \"militaryWaiver\": \"<boolean>\",\n    \"middleName\": \"<string>\"\n  }\n]",
+																			"raw": "[\n  {\n    \"dateOfBirth\": \"2512-05-24\",\n    \"dateOfExpiration\": \"1625-00-06\",\n    \"dateOfIssuance\": \"1576-07-02\",\n    \"dateOfRenewal\": \"1374-07-38\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\",\n    \"homeAddressCity\": \"<string>\",\n    \"homeAddressPostalCode\": \"<string>\",\n    \"homeAddressState\": \"<string>\",\n    \"homeAddressStreet1\": \"<string>\",\n    \"licenseType\": \"occupational therapy assistant\",\n    \"ssn\": \"557-23-0406\",\n    \"status\": \"active\",\n    \"homeAddressStreet2\": \"<string>\",\n    \"npi\": \"7500286789\",\n    \"militaryWaiver\": \"<boolean>\",\n    \"middleName\": \"<string>\"\n  },\n  {\n    \"dateOfBirth\": \"1744-05-16\",\n    \"dateOfExpiration\": \"2921-05-28\",\n    \"dateOfIssuance\": \"2278-02-34\",\n    \"dateOfRenewal\": \"2366-04-32\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\",\n    \"homeAddressCity\": \"<string>\",\n    \"homeAddressPostalCode\": \"<string>\",\n    \"homeAddressState\": \"<string>\",\n    \"homeAddressStreet1\": \"<string>\",\n    \"licenseType\": \"licensed clinical mental health counselor\",\n    \"ssn\": \"946-99-8502\",\n    \"status\": \"active\",\n    \"homeAddressStreet2\": \"<string>\",\n    \"npi\": \"3262938706\",\n    \"militaryWaiver\": \"<boolean>\",\n    \"middleName\": \"<string>\"\n  }\n]",
 																			"options": {
 																				"raw": {
 																					"headerFamily": "json",
@@ -505,6 +921,26 @@
 												{
 													"name": "/v1/compacts/:compact/providers/query",
 													"request": {
+														"auth": {
+															"type": "apikey",
+															"apikey": [
+																{
+																	"key": "key",
+																	"value": "Authorization",
+																	"type": "string"
+																},
+																{
+																	"key": "value",
+																	"value": "{{apiKey}}",
+																	"type": "string"
+																},
+																{
+																	"key": "in",
+																	"value": "header",
+																	"type": "string"
+																}
+															]
+														},
 														"method": "POST",
 														"header": [
 															{
@@ -518,7 +954,7 @@
 														],
 														"body": {
 															"mode": "raw",
-															"raw": "{\n  \"query\": {\n  }\n}",
+															"raw": "{\n  \"query\": {\n    \"providerId\": \"6cf694c5-feee-4828-b551-74803f28cf41\",\n    \"jurisdiction\": \"nh\",\n    \"ssn\": \"737-44-2309\"\n  },\n  \"pagination\": {\n    \"lastKey\": \"<string>\",\n    \"pageSize\": \"<integer>\"\n  },\n  \"sorting\": {\n    \"key\": \"familyName\",\n    \"direction\": \"ascending\"\n  }\n}",
 															"options": {
 																"raw": {
 																	"headerFamily": "json",
@@ -541,7 +977,7 @@
 															"variable": [
 																{
 																	"key": "compact",
-																	"value": "octp",
+																	"value": "<string>",
 																	"description": "(Required) "
 																}
 															]
@@ -569,7 +1005,7 @@
 																],
 																"body": {
 																	"mode": "raw",
-																	"raw": "{\n  \"query\": {\n    \"providerId\": \"ab30ba7c-fcb9-49a2-be35-46845c871a8e\",\n    \"jurisdiction\": \"wv\",\n    \"ssn\": \"556-53-4961\"\n  },\n  \"pagination\": {\n    \"lastKey\": \"<string>\",\n    \"pageSize\": \"<integer>\"\n  },\n  \"sorting\": {\n    \"key\": \"dateOfUpdate\",\n    \"direction\": \"descending\"\n  }\n}",
+																	"raw": "{\n  \"query\": {\n    \"providerId\": \"6cf694c5-feee-4828-b551-74803f28cf41\",\n    \"jurisdiction\": \"nh\",\n    \"ssn\": \"737-44-2309\"\n  },\n  \"pagination\": {\n    \"lastKey\": \"<string>\",\n    \"pageSize\": \"<integer>\"\n  },\n  \"sorting\": {\n    \"key\": \"familyName\",\n    \"direction\": \"ascending\"\n  }\n}",
 																	"options": {
 																		"raw": {
 																			"headerFamily": "json",
@@ -606,7 +1042,7 @@
 																}
 															],
 															"cookie": [],
-															"body": "{\n  \"pagination\": {\n    \"pageSize\": \"<integer>\"\n  },\n  \"sorting\": {\n    \"key\": \"familyName\",\n    \"direction\": \"ascending\"\n  },\n  \"providers\": [\n    {\n      \"birthMonthDay\": \"<date>\",\n      \"compact\": \"coun\",\n      \"dateOfBirth\": \"<date>\",\n      \"dateOfExpiration\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"givenName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"homeAddressState\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"licenseJurisdiction\": \"va\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"privilegeJurisdictions\": [\n        \"co\",\n        \"ms\"\n      ],\n      \"providerId\": \"02557c89-2750-4b4c-b201-f21d4ca05b3c\",\n      \"ssn\": \"657-56-0269\",\n      \"status\": \"inactive\",\n      \"type\": \"provider\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"6340836452\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"middleName\": \"<string>\"\n    },\n    {\n      \"birthMonthDay\": \"<date>\",\n      \"compact\": \"coun\",\n      \"dateOfBirth\": \"<date>\",\n      \"dateOfExpiration\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"givenName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"homeAddressState\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"licenseJurisdiction\": \"oh\",\n      \"licenseType\": \"occupational therapy assistant\",\n      \"privilegeJurisdictions\": [\n        \"ms\",\n        \"ne\"\n      ],\n      \"providerId\": \"d5228dee-af84-4049-8a99-4bee57ea049c\",\n      \"ssn\": \"461-97-8979\",\n      \"status\": \"active\",\n      \"type\": \"provider\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"0726853498\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"middleName\": \"<string>\"\n    }\n  ]\n}"
+															"body": "{\n  \"pagination\": {\n    \"prevLastKey\": {},\n    \"lastKey\": {},\n    \"pageSize\": \"<integer>\"\n  },\n  \"sorting\": {\n    \"key\": \"dateOfUpdate\",\n    \"direction\": \"ascending\"\n  },\n  \"providers\": [\n    {\n      \"birthMonthDay\": \"18-00\",\n      \"compact\": \"coun\",\n      \"dateOfBirth\": \"2658-00-25\",\n      \"dateOfExpiration\": \"1591-14-07\",\n      \"dateOfUpdate\": \"2177-10-15\",\n      \"familyName\": \"<string>\",\n      \"givenName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"homeAddressState\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"licenseJurisdiction\": \"la\",\n      \"licenseType\": \"audiologist\",\n      \"privilegeJurisdictions\": [\n        \"nv\",\n        \"wv\"\n      ],\n      \"providerId\": \"110e48fd-8b1c-4b5a-bfb2-e8adf4ebc10f\",\n      \"ssn\": \"016-09-3804\",\n      \"status\": \"inactive\",\n      \"type\": \"provider\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"0507595919\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"middleName\": \"<string>\"\n    },\n    {\n      \"birthMonthDay\": \"15-39\",\n      \"compact\": \"coun\",\n      \"dateOfBirth\": \"1080-18-12\",\n      \"dateOfExpiration\": \"2292-19-17\",\n      \"dateOfUpdate\": \"2899-13-05\",\n      \"familyName\": \"<string>\",\n      \"givenName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"homeAddressState\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"licenseJurisdiction\": \"me\",\n      \"licenseType\": \"licensed mental health counselor\",\n      \"privilegeJurisdictions\": [\n        \"vi\",\n        \"tn\"\n      ],\n      \"providerId\": \"1ea5240c-0dcd-4cdc-838c-7f5720ece3f3\",\n      \"ssn\": \"950-42-0597\",\n      \"status\": \"inactive\",\n      \"type\": \"provider\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"8397527290\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"middleName\": \"<string>\"\n    }\n  ]\n}"
 														}
 													]
 												}
@@ -618,6 +1054,26 @@
 												{
 													"name": "/v1/compacts/:compact/providers/:providerId",
 													"request": {
+														"auth": {
+															"type": "apikey",
+															"apikey": [
+																{
+																	"key": "key",
+																	"value": "Authorization",
+																	"type": "string"
+																},
+																{
+																	"key": "value",
+																	"value": "{{apiKey}}",
+																	"type": "string"
+																},
+																{
+																	"key": "in",
+																	"value": "header",
+																	"type": "string"
+																}
+															]
+														},
 														"method": "GET",
 														"header": [
 															{
@@ -640,12 +1096,12 @@
 															"variable": [
 																{
 																	"key": "compact",
-																	"value": "aslp",
+																	"value": "<string>",
 																	"description": "(Required) "
 																},
 																{
 																	"key": "providerId",
-																	"value": "f2222756-be0a-4b60-94be-ed41f2596426",
+																	"value": "<string>",
 																	"description": "(Required) "
 																}
 															]
@@ -699,7 +1155,7 @@
 																}
 															],
 															"cookie": [],
-															"body": "{\n  \"birthMonthDay\": \"<date>\",\n  \"compact\": \"aslp\",\n  \"dateOfBirth\": \"<date>\",\n  \"dateOfExpiration\": \"<date>\",\n  \"dateOfUpdate\": \"<date>\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"licensed professional counselor\",\n  \"licenses\": [\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"5379023477\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"sd\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"687-65-6371\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"01f0e4b9-9356-4043-b8be-faf5f4377318\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"7457842116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"ky\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"122-13-5882\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"5d132506-d13a-472a-be47-c5fde42deb1d\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"ok\",\n    \"ok\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"mi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"aslp\",\n      \"providerId\": \"42ac3726-b81a-466f-b7ad-f9d0974ebe4f\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"coun\",\n      \"providerId\": \"bab44873-e09e-40ec-86eb-0d1c983c6e8d\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"providerId\": \"b461a1f5-8a5f-4665-9030-0953edfbe2d7\",\n  \"ssn\": \"217-46-5795\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"4851189695\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
+															"body": "{\n  \"birthMonthDay\": \"17-15\",\n  \"compact\": \"coun\",\n  \"dateOfBirth\": \"1967-13-28\",\n  \"dateOfExpiration\": \"2902-06-14\",\n  \"dateOfUpdate\": \"2357-06-00\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"audiologist\",\n  \"licenses\": [\n    {\n      \"compact\": \"octp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"3687035116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"az\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"1656-09-04\",\n      \"history\": [\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"3639794259\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2242-09-27\",\n            \"dateOfIssuance\": \"2917-01-28\",\n            \"ssn\": \"568-80-2215\",\n            \"licenseType\": \"licensed professional clinical counselor\",\n            \"dateOfExpiration\": \"2550-12-09\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1151-03-24\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"oh\",\n          \"updatedValues\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"9363868396\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"1004-03-39\",\n            \"dateOfIssuance\": \"2283-04-25\",\n            \"ssn\": \"398-71-9571\",\n            \"licenseType\": \"speech-language pathologist\",\n            \"dateOfExpiration\": \"1699-00-37\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1504-16-38\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"active\"\n          },\n          \"type\": \"licenseUpdate\",\n          \"dateOfUpdate\": \"1969-18-33\",\n          \"updateType\": \"other\"\n        },\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"5999402212\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2613-08-00\",\n            \"dateOfIssuance\": \"1394-01-17\",\n            \"ssn\": \"835-85-9851\",\n            \"licenseType\": \"speech and language pathologist\",\n            \"dateOfExpiration\": \"2328-08-04\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"2272-10-21\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"sd\",\n          \"updatedValues\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"4527504991\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"1052-13-17\",\n            \"dateOfIssuance\": \"2326-10-00\",\n            \"ssn\": \"268-68-9389\",\n            \"licenseType\": \"speech and language pathologist\",\n            \"dateOfExpiration\": \"2514-14-18\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1049-07-24\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"licenseUpdate\",\n          \"dateOfUpdate\": \"1341-06-02\",\n          \"updateType\": \"other\"\n        }\n      ],\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"2243-06-26\",\n      \"ssn\": \"354-78-7111\",\n      \"licenseType\": \"licensed professional counselor\",\n      \"dateOfExpiration\": \"2960-18-12\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"ddd406f3-915b-425a-a23d-3dfa4b95d667\",\n      \"dateOfRenewal\": \"1458-08-11\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"1915-18-00\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"6007489998\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"oh\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"1983-07-36\",\n      \"history\": [\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"5567418323\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2688-07-33\",\n            \"dateOfIssuance\": \"1775-15-24\",\n            \"ssn\": \"047-60-3174\",\n            \"licenseType\": \"speech-language pathologist\",\n            \"dateOfExpiration\": \"2004-02-21\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"2688-13-29\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"active\"\n          },\n          \"jurisdiction\": \"ar\",\n          \"updatedValues\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"0058048111\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2764-09-27\",\n            \"dateOfIssuance\": \"1907-01-27\",\n            \"ssn\": \"302-03-2027\",\n            \"licenseType\": \"speech-language pathologist\",\n            \"dateOfExpiration\": \"1185-07-16\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1265-17-04\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"licenseUpdate\",\n          \"dateOfUpdate\": \"2172-18-26\",\n          \"updateType\": \"renewal\"\n        },\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"octp\",\n          \"previous\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"4362213057\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2997-08-33\",\n            \"dateOfIssuance\": \"2017-17-27\",\n            \"ssn\": \"048-61-8440\",\n            \"licenseType\": \"speech and language pathologist\",\n            \"dateOfExpiration\": \"2547-19-21\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1098-01-04\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"ia\",\n          \"updatedValues\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"9706509045\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2767-09-32\",\n            \"dateOfIssuance\": \"1430-19-32\",\n            \"ssn\": \"631-76-8505\",\n            \"licenseType\": \"occupational therapist\",\n            \"dateOfExpiration\": \"2248-19-14\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"2523-11-38\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"licenseUpdate\",\n          \"dateOfUpdate\": \"2100-05-32\",\n          \"updateType\": \"deactivation\"\n        }\n      ],\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"1125-08-28\",\n      \"ssn\": \"806-66-3183\",\n      \"licenseType\": \"occupational therapy assistant\",\n      \"dateOfExpiration\": \"1852-16-13\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"e932a0f0-4448-42be-adfd-511dadd9f0d6\",\n      \"dateOfRenewal\": \"1952-08-26\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"2710-10-29\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"vi\",\n    \"nv\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"2849-01-09\",\n      \"compact\": \"coun\",\n      \"providerId\": \"5659fbd8-e635-4564-ad23-98c84ecc032f\",\n      \"history\": [\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"aslp\",\n          \"previous\": {\n            \"licenseJurisdiction\": \"sc\",\n            \"dateOfExpiration\": \"1888-04-17\",\n            \"compact\": \"octp\",\n            \"providerId\": \"c7ebb912-8c0c-4567-bbe8-95309a2bd062\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"1331-04-08\",\n            \"dateOfUpdate\": \"2815-15-05\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"nm\",\n          \"updatedValues\": {\n            \"licenseJurisdiction\": \"fl\",\n            \"dateOfExpiration\": \"1732-00-18\",\n            \"compact\": \"coun\",\n            \"providerId\": \"099aa11a-5e1c-46da-b445-3fcdc4208587\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"1074-14-04\",\n            \"dateOfUpdate\": \"2532-19-34\",\n            \"status\": \"active\"\n          },\n          \"type\": \"privilegeUpdate\",\n          \"dateOfUpdate\": \"2423-13-08\",\n          \"updateType\": \"deactivation\"\n        },\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"licenseJurisdiction\": \"co\",\n            \"dateOfExpiration\": \"1908-09-32\",\n            \"compact\": \"octp\",\n            \"providerId\": \"5a7b0999-7b11-49af-ac6d-ad1b50f41361\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2155-17-16\",\n            \"dateOfUpdate\": \"2113-16-19\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"pa\",\n          \"updatedValues\": {\n            \"licenseJurisdiction\": \"tx\",\n            \"dateOfExpiration\": \"1442-16-32\",\n            \"compact\": \"aslp\",\n            \"providerId\": \"b127bef6-9abe-4623-a213-f300234332ab\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2995-16-33\",\n            \"dateOfUpdate\": \"1316-07-01\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"privilegeUpdate\",\n          \"dateOfUpdate\": \"2942-19-12\",\n          \"updateType\": \"deactivation\"\n        }\n      ],\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"2197-14-03\",\n      \"dateOfUpdate\": \"2845-05-00\",\n      \"status\": \"active\"\n    },\n    {\n      \"licenseJurisdiction\": \"mt\",\n      \"dateOfExpiration\": \"1321-04-10\",\n      \"compact\": \"coun\",\n      \"providerId\": \"d449ee00-ac8f-4013-b7d8-38b5c27539df\",\n      \"history\": [\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"aslp\",\n          \"previous\": {\n            \"licenseJurisdiction\": \"pa\",\n            \"dateOfExpiration\": \"2815-07-04\",\n            \"compact\": \"octp\",\n            \"providerId\": \"048ef952-684a-4634-907a-ad8d8565787c\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2000-03-14\",\n            \"dateOfUpdate\": \"2505-13-02\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"ct\",\n          \"updatedValues\": {\n            \"licenseJurisdiction\": \"ct\",\n            \"dateOfExpiration\": \"2007-09-18\",\n            \"compact\": \"coun\",\n            \"providerId\": \"fd92b74d-764a-4e07-888a-9f569b127b1f\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2556-10-37\",\n            \"dateOfUpdate\": \"2679-14-38\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"privilegeUpdate\",\n          \"dateOfUpdate\": \"2850-18-00\",\n          \"updateType\": \"renewal\"\n        },\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"licenseJurisdiction\": \"nh\",\n            \"dateOfExpiration\": \"1570-13-31\",\n            \"compact\": \"coun\",\n            \"providerId\": \"5b8984cd-31b1-4c50-9d1e-80a4e81d3a05\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2348-00-21\",\n            \"dateOfUpdate\": \"1258-02-07\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"vt\",\n          \"updatedValues\": {\n            \"licenseJurisdiction\": \"ks\",\n            \"dateOfExpiration\": \"2767-19-39\",\n            \"compact\": \"aslp\",\n            \"providerId\": \"ab71c97b-2dc4-4174-89b0-a423e300f046\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"1188-12-25\",\n            \"dateOfUpdate\": \"1375-07-13\",\n            \"status\": \"active\"\n          },\n          \"type\": \"privilegeUpdate\",\n          \"dateOfUpdate\": \"2278-07-09\",\n          \"updateType\": \"renewal\"\n        }\n      ],\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"2918-18-36\",\n      \"dateOfUpdate\": \"1865-03-27\",\n      \"status\": \"inactive\"\n    }\n  ],\n  \"providerId\": \"f9db62c4-0e3d-4efc-aa7e-d96f4f9e542a\",\n  \"ssn\": \"587-77-6841\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"3156399059\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
 														}
 													]
 												}
@@ -716,6 +1172,26 @@
 												{
 													"name": "/v1/compacts/:compact/staff-users/:userId",
 													"request": {
+														"auth": {
+															"type": "apikey",
+															"apikey": [
+																{
+																	"key": "key",
+																	"value": "Authorization",
+																	"type": "string"
+																},
+																{
+																	"key": "value",
+																	"value": "{{apiKey}}",
+																	"type": "string"
+																},
+																{
+																	"key": "in",
+																	"value": "header",
+																	"type": "string"
+																}
+															]
+														},
 														"method": "GET",
 														"header": [
 															{
@@ -738,12 +1214,13 @@
 															"variable": [
 																{
 																	"key": "compact",
-																	"value": "octp",
+																	"value": "<string>",
 																	"description": "(Required) "
 																},
 																{
 																	"key": "userId",
-																	"value": "a458f488-10f1-702d-3f31-bf1e2ecd8a01"
+																	"value": "<string>",
+																	"description": "(Required) "
 																}
 															]
 														}
@@ -765,7 +1242,7 @@
 																	}
 																],
 																"url": {
-																	"raw": "{{baseUrl}}/v1/compacts/:compact/providers/:providerId",
+																	"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users/:userId",
 																	"host": [
 																		"{{baseUrl}}"
 																	],
@@ -773,15 +1250,180 @@
 																		"v1",
 																		"compacts",
 																		":compact",
-																		"providers",
-																		":providerId"
+																		"staff-users",
+																		":userId"
 																	],
 																	"variable": [
 																		{
 																			"key": "compact"
 																		},
 																		{
-																			"key": "providerId"
+																			"key": "userId"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																},
+																{
+																	"key": "Access-Control-Allow-Origin",
+																	"value": "<string>",
+																	"description": {
+																		"content": "",
+																		"type": "text/plain"
+																	}
+																}
+															],
+															"cookie": [],
+															"body": "{\n  \"attributes\": {\n    \"email\": \"<string>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\"\n  },\n  \"permissions\": {\n    \"amet1\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"fugiatfc\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"officia_6_0\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"deserunt50\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"veniam_5\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  },\n  \"userId\": \"<string>\"\n}"
+														},
+														{
+															"name": "404 response",
+															"originalRequest": {
+																"method": "GET",
+																"header": [
+																	{
+																		"key": "Accept",
+																		"value": "application/json"
+																	},
+																	{
+																		"key": "Authorization",
+																		"value": "<API Key>",
+																		"description": "Added as a part of security scheme: apikey"
+																	}
+																],
+																"url": {
+																	"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users/:userId",
+																	"host": [
+																		"{{baseUrl}}"
+																	],
+																	"path": [
+																		"v1",
+																		"compacts",
+																		":compact",
+																		"staff-users",
+																		":userId"
+																	],
+																	"variable": [
+																		{
+																			"key": "compact"
+																		},
+																		{
+																			"key": "userId"
+																		}
+																	]
+																}
+															},
+															"status": "Not Found",
+															"code": 404,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n  \"message\": \"<string>\"\n}"
+														}
+													]
+												},
+												{
+													"name": "/v1/compacts/:compact/staff-users/:userId",
+													"request": {
+														"auth": {
+															"type": "apikey",
+															"apikey": [
+																{
+																	"key": "key",
+																	"value": "Authorization",
+																	"type": "string"
+																},
+																{
+																	"key": "value",
+																	"value": "{{apiKey}}",
+																	"type": "string"
+																},
+																{
+																	"key": "in",
+																	"value": "header",
+																	"type": "string"
+																}
+															]
+														},
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Accept",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users/:userId",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"v1",
+																"compacts",
+																":compact",
+																"staff-users",
+																":userId"
+															],
+															"variable": [
+																{
+																	"key": "compact",
+																	"value": "<string>",
+																	"description": "(Required) "
+																},
+																{
+																	"key": "userId",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "200 response",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [
+																	{
+																		"key": "Accept",
+																		"value": "application/json"
+																	},
+																	{
+																		"key": "Authorization",
+																		"value": "<API Key>",
+																		"description": "Added as a part of security scheme: apikey"
+																	}
+																],
+																"url": {
+																	"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users/:userId",
+																	"host": [
+																		"{{baseUrl}}"
+																	],
+																	"path": [
+																		"v1",
+																		"compacts",
+																		":compact",
+																		"staff-users",
+																		":userId"
+																	],
+																	"variable": [
+																		{
+																			"key": "compact"
+																		},
+																		{
+																			"key": "userId"
 																		}
 																	]
 																}
@@ -796,15 +1438,88 @@
 																}
 															],
 															"cookie": [],
-															"body": "{\n  \"birthMonthDay\": \"<date>\",\n  \"compact\": \"aslp\",\n  \"dateOfBirth\": \"<date>\",\n  \"dateOfExpiration\": \"<date>\",\n  \"dateOfUpdate\": \"<date>\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"licensed professional counselor\",\n  \"licenses\": [\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"5379023477\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"sd\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"687-65-6371\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"01f0e4b9-9356-4043-b8be-faf5f4377318\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"7457842116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"ky\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"122-13-5882\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"5d132506-d13a-472a-be47-c5fde42deb1d\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"ok\",\n    \"ok\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"mi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"aslp\",\n      \"providerId\": \"42ac3726-b81a-466f-b7ad-f9d0974ebe4f\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"coun\",\n      \"providerId\": \"bab44873-e09e-40ec-86eb-0d1c983c6e8d\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"providerId\": \"b461a1f5-8a5f-4665-9030-0953edfbe2d7\",\n  \"ssn\": \"217-46-5795\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"4851189695\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
+															"body": "{\n  \"message\": \"<string>\"\n}"
+														},
+														{
+															"name": "404 response",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [
+																	{
+																		"key": "Accept",
+																		"value": "application/json"
+																	},
+																	{
+																		"key": "Authorization",
+																		"value": "<API Key>",
+																		"description": "Added as a part of security scheme: apikey"
+																	}
+																],
+																"url": {
+																	"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users/:userId",
+																	"host": [
+																		"{{baseUrl}}"
+																	],
+																	"path": [
+																		"v1",
+																		"compacts",
+																		":compact",
+																		"staff-users",
+																		":userId"
+																	],
+																	"variable": [
+																		{
+																			"key": "compact"
+																		},
+																		{
+																			"key": "userId"
+																		}
+																	]
+																}
+															},
+															"status": "Not Found",
+															"code": 404,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n  \"message\": \"<string>\"\n}"
 														}
 													]
 												},
 												{
 													"name": "/v1/compacts/:compact/staff-users/:userId",
 													"request": {
+														"auth": {
+															"type": "apikey",
+															"apikey": [
+																{
+																	"key": "key",
+																	"value": "Authorization",
+																	"type": "string"
+																},
+																{
+																	"key": "value",
+																	"value": "{{apiKey}}",
+																	"type": "string"
+																},
+																{
+																	"key": "in",
+																	"value": "header",
+																	"type": "string"
+																}
+															]
+														},
 														"method": "PATCH",
 														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
 															{
 																"key": "Accept",
 																"value": "application/json"
@@ -812,9 +1527,10 @@
 														],
 														"body": {
 															"mode": "raw",
-															"raw": "{\n    \"permissions\": {\n        \"octp\": {\n            \"jurisdictions\": {\n                \"oh\": {\n                    \"actions\": {\n                        \"write\": true\n                    }\n                }\n            }\n        }\n    }\n}",
+															"raw": "{\n  \"permissions\": {\n    \"occaecat_0b8\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"sed_42\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"anim_e\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  }\n}",
 															"options": {
 																"raw": {
+																	"headerFamily": "json",
 																	"language": "json"
 																}
 															}
@@ -834,12 +1550,13 @@
 															"variable": [
 																{
 																	"key": "compact",
-																	"value": "octp",
+																	"value": "<string>",
 																	"description": "(Required) "
 																},
 																{
 																	"key": "userId",
-																	"value": "a458f488-10f1-702d-3f31-bf1e2ecd8a01"
+																	"value": "<string>",
+																	"description": "(Required) "
 																}
 															]
 														}
@@ -848,8 +1565,12 @@
 														{
 															"name": "200 response",
 															"originalRequest": {
-																"method": "GET",
+																"method": "PATCH",
 																"header": [
+																	{
+																		"key": "Content-Type",
+																		"value": "application/json"
+																	},
 																	{
 																		"key": "Accept",
 																		"value": "application/json"
@@ -860,8 +1581,18 @@
 																		"description": "Added as a part of security scheme: apikey"
 																	}
 																],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n  \"permissions\": {\n    \"occaecat_0b8\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"sed_42\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"anim_e\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  }\n}",
+																	"options": {
+																		"raw": {
+																			"headerFamily": "json",
+																			"language": "json"
+																		}
+																	}
+																},
 																"url": {
-																	"raw": "{{baseUrl}}/v1/compacts/:compact/providers/:providerId",
+																	"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users/:userId",
 																	"host": [
 																		"{{baseUrl}}"
 																	],
@@ -869,15 +1600,15 @@
 																		"v1",
 																		"compacts",
 																		":compact",
-																		"providers",
-																		":providerId"
+																		"staff-users",
+																		":userId"
 																	],
 																	"variable": [
 																		{
 																			"key": "compact"
 																		},
 																		{
-																			"key": "providerId"
+																			"key": "userId"
 																		}
 																	]
 																}
@@ -889,10 +1620,81 @@
 																{
 																	"key": "Content-Type",
 																	"value": "application/json"
+																},
+																{
+																	"key": "Access-Control-Allow-Origin",
+																	"value": "<string>",
+																	"description": {
+																		"content": "",
+																		"type": "text/plain"
+																	}
 																}
 															],
 															"cookie": [],
-															"body": "{\n  \"birthMonthDay\": \"<date>\",\n  \"compact\": \"aslp\",\n  \"dateOfBirth\": \"<date>\",\n  \"dateOfExpiration\": \"<date>\",\n  \"dateOfUpdate\": \"<date>\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"licensed professional counselor\",\n  \"licenses\": [\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"5379023477\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"sd\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"687-65-6371\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"01f0e4b9-9356-4043-b8be-faf5f4377318\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"7457842116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"ky\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"122-13-5882\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"5d132506-d13a-472a-be47-c5fde42deb1d\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"ok\",\n    \"ok\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"mi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"aslp\",\n      \"providerId\": \"42ac3726-b81a-466f-b7ad-f9d0974ebe4f\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"coun\",\n      \"providerId\": \"bab44873-e09e-40ec-86eb-0d1c983c6e8d\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"providerId\": \"b461a1f5-8a5f-4665-9030-0953edfbe2d7\",\n  \"ssn\": \"217-46-5795\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"4851189695\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
+															"body": "{\n  \"attributes\": {\n    \"email\": \"<string>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\"\n  },\n  \"permissions\": {\n    \"amet1\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"fugiatfc\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"officia_6_0\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"deserunt50\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"veniam_5\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  },\n  \"userId\": \"<string>\"\n}"
+														},
+														{
+															"name": "404 response",
+															"originalRequest": {
+																"method": "PATCH",
+																"header": [
+																	{
+																		"key": "Content-Type",
+																		"value": "application/json"
+																	},
+																	{
+																		"key": "Accept",
+																		"value": "application/json"
+																	},
+																	{
+																		"key": "Authorization",
+																		"value": "<API Key>",
+																		"description": "Added as a part of security scheme: apikey"
+																	}
+																],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n  \"permissions\": {\n    \"occaecat_0b8\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"sed_42\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"anim_e\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  }\n}",
+																	"options": {
+																		"raw": {
+																			"headerFamily": "json",
+																			"language": "json"
+																		}
+																	}
+																},
+																"url": {
+																	"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users/:userId",
+																	"host": [
+																		"{{baseUrl}}"
+																	],
+																	"path": [
+																		"v1",
+																		"compacts",
+																		":compact",
+																		"staff-users",
+																		":userId"
+																	],
+																	"variable": [
+																		{
+																			"key": "compact"
+																		},
+																		{
+																			"key": "userId"
+																		}
+																	]
+																}
+															},
+															"status": "Not Found",
+															"code": 404,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n  \"message\": \"<string>\"\n}"
 														}
 													]
 												}
@@ -901,6 +1703,26 @@
 										{
 											"name": "/v1/compacts/:compact/staff-users",
 											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "key",
+															"value": "Authorization",
+															"type": "string"
+														},
+														{
+															"key": "value",
+															"value": "{{apiKey}}",
+															"type": "string"
+														},
+														{
+															"key": "in",
+															"value": "header",
+															"type": "string"
+														}
+													]
+												},
 												"method": "GET",
 												"header": [
 													{
@@ -922,7 +1744,7 @@
 													"variable": [
 														{
 															"key": "compact",
-															"value": "octp",
+															"value": "<string>",
 															"description": "(Required) "
 														}
 													]
@@ -945,7 +1767,7 @@
 															}
 														],
 														"url": {
-															"raw": "{{baseUrl}}/v1/compacts/:compact/providers/:providerId",
+															"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users",
 															"host": [
 																"{{baseUrl}}"
 															],
@@ -953,15 +1775,11 @@
 																"v1",
 																"compacts",
 																":compact",
-																"providers",
-																":providerId"
+																"staff-users"
 															],
 															"variable": [
 																{
 																	"key": "compact"
-																},
-																{
-																	"key": "providerId"
 																}
 															]
 														}
@@ -973,18 +1791,50 @@
 														{
 															"key": "Content-Type",
 															"value": "application/json"
+														},
+														{
+															"key": "Access-Control-Allow-Origin",
+															"value": "<string>",
+															"description": {
+																"content": "",
+																"type": "text/plain"
+															}
 														}
 													],
 													"cookie": [],
-													"body": "{\n  \"birthMonthDay\": \"<date>\",\n  \"compact\": \"aslp\",\n  \"dateOfBirth\": \"<date>\",\n  \"dateOfExpiration\": \"<date>\",\n  \"dateOfUpdate\": \"<date>\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"licensed professional counselor\",\n  \"licenses\": [\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"5379023477\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"sd\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"687-65-6371\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"01f0e4b9-9356-4043-b8be-faf5f4377318\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"7457842116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"ky\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"122-13-5882\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"5d132506-d13a-472a-be47-c5fde42deb1d\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"ok\",\n    \"ok\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"mi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"aslp\",\n      \"providerId\": \"42ac3726-b81a-466f-b7ad-f9d0974ebe4f\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"coun\",\n      \"providerId\": \"bab44873-e09e-40ec-86eb-0d1c983c6e8d\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"providerId\": \"b461a1f5-8a5f-4665-9030-0953edfbe2d7\",\n  \"ssn\": \"217-46-5795\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"4851189695\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
+													"body": "{\n  \"pagination\": {\n    \"prevLastKey\": {},\n    \"lastKey\": {},\n    \"pageSize\": \"<integer>\"\n  },\n  \"users\": [\n    {\n      \"attributes\": {\n        \"email\": \"<string>\",\n        \"familyName\": \"<string>\",\n        \"givenName\": \"<string>\"\n      },\n      \"permissions\": {\n        \"velita\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"read\": \"<boolean>\",\n            \"admin\": \"<boolean>\"\n          },\n          \"jurisdictions\": {\n            \"nulla4_a\": {\n              \"actions\": {\n                \"readPrivate\": \"<boolean>\",\n                \"admin\": \"<boolean>\",\n                \"write\": \"<boolean>\"\n              }\n            },\n            \"ad0\": {\n              \"actions\": {\n                \"readPrivate\": \"<boolean>\",\n                \"admin\": \"<boolean>\",\n                \"write\": \"<boolean>\"\n              }\n            },\n            \"est012\": {\n              \"actions\": {\n                \"readPrivate\": \"<boolean>\",\n                \"admin\": \"<boolean>\",\n                \"write\": \"<boolean>\"\n              }\n            }\n          }\n        }\n      },\n      \"userId\": \"<string>\"\n    },\n    {\n      \"attributes\": {\n        \"email\": \"<string>\",\n        \"familyName\": \"<string>\",\n        \"givenName\": \"<string>\"\n      },\n      \"permissions\": {\n        \"eiusmodf\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"read\": \"<boolean>\",\n            \"admin\": \"<boolean>\"\n          },\n          \"jurisdictions\": {\n            \"nulla_b\": {\n              \"actions\": {\n                \"readPrivate\": \"<boolean>\",\n                \"admin\": \"<boolean>\",\n                \"write\": \"<boolean>\"\n              }\n            }\n          }\n        }\n      },\n      \"userId\": \"<string>\"\n    }\n  ]\n}"
 												}
 											]
 										},
 										{
 											"name": "/v1/compacts/:compact/staff-users",
 											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "key",
+															"value": "Authorization",
+															"type": "string"
+														},
+														{
+															"key": "value",
+															"value": "{{apiKey}}",
+															"type": "string"
+														},
+														{
+															"key": "in",
+															"value": "header",
+															"type": "string"
+														}
+													]
+												},
 												"method": "POST",
 												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
 													{
 														"key": "Accept",
 														"value": "application/json"
@@ -992,9 +1842,10 @@
 												],
 												"body": {
 													"mode": "raw",
-													"raw": "{\n    \"attributes\": {\n        \"email\": \"justin+board-staff@inspiringapps.com\",\n        \"givenName\": \"Justin\",\n        \"familyName\": \"Frahm\"\n    },\n    \"permissions\": {\n        \"octp\": {\n            \"actions\": {\n                \"read\": true\n            },\n            \"jurisdictions\": {\n                \"oh\": {\n                    \"actions\": {\n                        \"write\": true\n                    }\n                }\n            }\n        }\n    }\n}",
+													"raw": "{\n  \"attributes\": {\n    \"email\": \"<string>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\"\n  },\n  \"permissions\": {\n    \"nisi7d\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"esse_e59\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"eu_a\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"sint599\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"labore_143\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"proident1\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"nostrudc\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"nisi_0ed\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  }\n}",
 													"options": {
 														"raw": {
+															"headerFamily": "json",
 															"language": "json"
 														}
 													}
@@ -1013,9 +1864,496 @@
 													"variable": [
 														{
 															"key": "compact",
-															"value": "octp",
+															"value": "<string>",
 															"description": "(Required) "
 														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "200 response",
+													"originalRequest": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															},
+															{
+																"key": "Authorization",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n  \"attributes\": {\n    \"email\": \"<string>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\"\n  },\n  \"permissions\": {\n    \"nisi7d\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"esse_e59\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"eu_a\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"sint599\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"labore_143\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"proident1\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"nostrudc\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"nisi_0ed\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  }\n}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/v1/compacts/:compact/staff-users",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"v1",
+																"compacts",
+																":compact",
+																"staff-users"
+															],
+															"variable": [
+																{
+																	"key": "compact"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														},
+														{
+															"key": "Access-Control-Allow-Origin",
+															"value": "<string>",
+															"description": {
+																"content": "",
+																"type": "text/plain"
+															}
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"attributes\": {\n    \"email\": \"<string>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\"\n  },\n  \"permissions\": {\n    \"amet1\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"fugiatfc\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"officia_6_0\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"deserunt50\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"veniam_5\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  },\n  \"userId\": \"<string>\"\n}"
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "provider-users",
+					"item": [
+						{
+							"name": "me",
+							"item": [
+								{
+									"name": "military-affiliation",
+									"item": [
+										{
+											"name": "/v1/provider-users/me/military-affiliation",
+											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "key",
+															"value": "Authorization",
+															"type": "string"
+														},
+														{
+															"key": "value",
+															"value": "{{apiKey}}",
+															"type": "string"
+														},
+														{
+															"key": "in",
+															"value": "header",
+															"type": "string"
+														}
+													]
+												},
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"affiliationType\": \"militaryMemberSpouse\",\n  \"fileNames\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/v1/provider-users/me/military-affiliation",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"provider-users",
+														"me",
+														"military-affiliation"
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "200 response",
+													"originalRequest": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															},
+															{
+																"key": "Authorization",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n  \"affiliationType\": \"militaryMemberSpouse\",\n  \"fileNames\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/v1/provider-users/me/military-affiliation",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"v1",
+																"provider-users",
+																"me",
+																"military-affiliation"
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"affiliationType\": \"militaryMemberSpouse\",\n  \"dateOfUpdate\": \"2518-12-25\",\n  \"dateOfUpload\": \"2480-11-24\",\n  \"documentUploadFields\": [\n    {\n      \"fields\": {\n        \"estb5\": \"<string>\",\n        \"pariatur_0\": \"<string>\",\n        \"sed_2\": \"<string>\"\n      },\n      \"url\": \"<string>\"\n    },\n    {\n      \"fields\": {\n        \"sintffd\": \"<string>\"\n      },\n      \"url\": \"<string>\"\n    }\n  ],\n  \"status\": \"<string>\",\n  \"fileNames\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}"
+												}
+											]
+										},
+										{
+											"name": "/v1/provider-users/me/military-affiliation",
+											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "key",
+															"value": "Authorization",
+															"type": "string"
+														},
+														{
+															"key": "value",
+															"value": "{{apiKey}}",
+															"type": "string"
+														},
+														{
+															"key": "in",
+															"value": "header",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"status\": \"inactive\"\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/v1/provider-users/me/military-affiliation",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"provider-users",
+														"me",
+														"military-affiliation"
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "200 response",
+													"originalRequest": {
+														"method": "PATCH",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "Accept",
+																"value": "application/json"
+															},
+															{
+																"key": "Authorization",
+																"value": "<API Key>",
+																"description": "Added as a part of security scheme: apikey"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n  \"status\": \"inactive\"\n}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/v1/provider-users/me/military-affiliation",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"v1",
+																"provider-users",
+																"me",
+																"military-affiliation"
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n  \"message\": \"<string>\"\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "/v1/provider-users/me",
+									"request": {
+										"auth": {
+											"type": "apikey",
+											"apikey": [
+												{
+													"key": "key",
+													"value": "Authorization",
+													"type": "string"
+												},
+												{
+													"key": "value",
+													"value": "{{apiKey}}",
+													"type": "string"
+												},
+												{
+													"key": "in",
+													"value": "header",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/v1/provider-users/me",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"provider-users",
+												"me"
+											]
+										}
+									},
+									"response": [
+										{
+											"name": "200 response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													},
+													{
+														"key": "Authorization",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/v1/provider-users/me",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"provider-users",
+														"me"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"birthMonthDay\": \"17-15\",\n  \"compact\": \"coun\",\n  \"dateOfBirth\": \"1967-13-28\",\n  \"dateOfExpiration\": \"2902-06-14\",\n  \"dateOfUpdate\": \"2357-06-00\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"audiologist\",\n  \"licenses\": [\n    {\n      \"compact\": \"octp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"3687035116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"az\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"1656-09-04\",\n      \"history\": [\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"3639794259\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2242-09-27\",\n            \"dateOfIssuance\": \"2917-01-28\",\n            \"ssn\": \"568-80-2215\",\n            \"licenseType\": \"licensed professional clinical counselor\",\n            \"dateOfExpiration\": \"2550-12-09\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1151-03-24\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"oh\",\n          \"updatedValues\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"9363868396\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"1004-03-39\",\n            \"dateOfIssuance\": \"2283-04-25\",\n            \"ssn\": \"398-71-9571\",\n            \"licenseType\": \"speech-language pathologist\",\n            \"dateOfExpiration\": \"1699-00-37\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1504-16-38\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"active\"\n          },\n          \"type\": \"licenseUpdate\",\n          \"dateOfUpdate\": \"1969-18-33\",\n          \"updateType\": \"other\"\n        },\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"5999402212\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2613-08-00\",\n            \"dateOfIssuance\": \"1394-01-17\",\n            \"ssn\": \"835-85-9851\",\n            \"licenseType\": \"speech and language pathologist\",\n            \"dateOfExpiration\": \"2328-08-04\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"2272-10-21\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"sd\",\n          \"updatedValues\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"4527504991\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"1052-13-17\",\n            \"dateOfIssuance\": \"2326-10-00\",\n            \"ssn\": \"268-68-9389\",\n            \"licenseType\": \"speech and language pathologist\",\n            \"dateOfExpiration\": \"2514-14-18\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1049-07-24\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"licenseUpdate\",\n          \"dateOfUpdate\": \"1341-06-02\",\n          \"updateType\": \"other\"\n        }\n      ],\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"2243-06-26\",\n      \"ssn\": \"354-78-7111\",\n      \"licenseType\": \"licensed professional counselor\",\n      \"dateOfExpiration\": \"2960-18-12\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"ddd406f3-915b-425a-a23d-3dfa4b95d667\",\n      \"dateOfRenewal\": \"1458-08-11\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"1915-18-00\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"6007489998\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"oh\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"1983-07-36\",\n      \"history\": [\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"5567418323\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2688-07-33\",\n            \"dateOfIssuance\": \"1775-15-24\",\n            \"ssn\": \"047-60-3174\",\n            \"licenseType\": \"speech-language pathologist\",\n            \"dateOfExpiration\": \"2004-02-21\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"2688-13-29\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"active\"\n          },\n          \"jurisdiction\": \"ar\",\n          \"updatedValues\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"0058048111\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2764-09-27\",\n            \"dateOfIssuance\": \"1907-01-27\",\n            \"ssn\": \"302-03-2027\",\n            \"licenseType\": \"speech-language pathologist\",\n            \"dateOfExpiration\": \"1185-07-16\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1265-17-04\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"licenseUpdate\",\n          \"dateOfUpdate\": \"2172-18-26\",\n          \"updateType\": \"renewal\"\n        },\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"octp\",\n          \"previous\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"4362213057\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2997-08-33\",\n            \"dateOfIssuance\": \"2017-17-27\",\n            \"ssn\": \"048-61-8440\",\n            \"licenseType\": \"speech and language pathologist\",\n            \"dateOfExpiration\": \"2547-19-21\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"1098-01-04\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"ia\",\n          \"updatedValues\": {\n            \"homeAddressStreet2\": \"<string>\",\n            \"npi\": \"9706509045\",\n            \"homeAddressPostalCode\": \"<string>\",\n            \"givenName\": \"<string>\",\n            \"homeAddressStreet1\": \"<string>\",\n            \"militaryWaiver\": \"<boolean>\",\n            \"dateOfBirth\": \"2767-09-32\",\n            \"dateOfIssuance\": \"1430-19-32\",\n            \"ssn\": \"631-76-8505\",\n            \"licenseType\": \"occupational therapist\",\n            \"dateOfExpiration\": \"2248-19-14\",\n            \"homeAddressState\": \"<string>\",\n            \"dateOfRenewal\": \"2523-11-38\",\n            \"familyName\": \"<string>\",\n            \"homeAddressCity\": \"<string>\",\n            \"middleName\": \"<string>\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"licenseUpdate\",\n          \"dateOfUpdate\": \"2100-05-32\",\n          \"updateType\": \"deactivation\"\n        }\n      ],\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"1125-08-28\",\n      \"ssn\": \"806-66-3183\",\n      \"licenseType\": \"occupational therapy assistant\",\n      \"dateOfExpiration\": \"1852-16-13\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"e932a0f0-4448-42be-adfd-511dadd9f0d6\",\n      \"dateOfRenewal\": \"1952-08-26\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"2710-10-29\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"vi\",\n    \"nv\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"2849-01-09\",\n      \"compact\": \"coun\",\n      \"providerId\": \"5659fbd8-e635-4564-ad23-98c84ecc032f\",\n      \"history\": [\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"aslp\",\n          \"previous\": {\n            \"licenseJurisdiction\": \"sc\",\n            \"dateOfExpiration\": \"1888-04-17\",\n            \"compact\": \"octp\",\n            \"providerId\": \"c7ebb912-8c0c-4567-bbe8-95309a2bd062\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"1331-04-08\",\n            \"dateOfUpdate\": \"2815-15-05\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"nm\",\n          \"updatedValues\": {\n            \"licenseJurisdiction\": \"fl\",\n            \"dateOfExpiration\": \"1732-00-18\",\n            \"compact\": \"coun\",\n            \"providerId\": \"099aa11a-5e1c-46da-b445-3fcdc4208587\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"1074-14-04\",\n            \"dateOfUpdate\": \"2532-19-34\",\n            \"status\": \"active\"\n          },\n          \"type\": \"privilegeUpdate\",\n          \"dateOfUpdate\": \"2423-13-08\",\n          \"updateType\": \"deactivation\"\n        },\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"licenseJurisdiction\": \"co\",\n            \"dateOfExpiration\": \"1908-09-32\",\n            \"compact\": \"octp\",\n            \"providerId\": \"5a7b0999-7b11-49af-ac6d-ad1b50f41361\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2155-17-16\",\n            \"dateOfUpdate\": \"2113-16-19\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"pa\",\n          \"updatedValues\": {\n            \"licenseJurisdiction\": \"tx\",\n            \"dateOfExpiration\": \"1442-16-32\",\n            \"compact\": \"aslp\",\n            \"providerId\": \"b127bef6-9abe-4623-a213-f300234332ab\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2995-16-33\",\n            \"dateOfUpdate\": \"1316-07-01\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"privilegeUpdate\",\n          \"dateOfUpdate\": \"2942-19-12\",\n          \"updateType\": \"deactivation\"\n        }\n      ],\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"2197-14-03\",\n      \"dateOfUpdate\": \"2845-05-00\",\n      \"status\": \"active\"\n    },\n    {\n      \"licenseJurisdiction\": \"mt\",\n      \"dateOfExpiration\": \"1321-04-10\",\n      \"compact\": \"coun\",\n      \"providerId\": \"d449ee00-ac8f-4013-b7d8-38b5c27539df\",\n      \"history\": [\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"aslp\",\n          \"previous\": {\n            \"licenseJurisdiction\": \"pa\",\n            \"dateOfExpiration\": \"2815-07-04\",\n            \"compact\": \"octp\",\n            \"providerId\": \"048ef952-684a-4634-907a-ad8d8565787c\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2000-03-14\",\n            \"dateOfUpdate\": \"2505-13-02\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"ct\",\n          \"updatedValues\": {\n            \"licenseJurisdiction\": \"ct\",\n            \"dateOfExpiration\": \"2007-09-18\",\n            \"compact\": \"coun\",\n            \"providerId\": \"fd92b74d-764a-4e07-888a-9f569b127b1f\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2556-10-37\",\n            \"dateOfUpdate\": \"2679-14-38\",\n            \"status\": \"inactive\"\n          },\n          \"type\": \"privilegeUpdate\",\n          \"dateOfUpdate\": \"2850-18-00\",\n          \"updateType\": \"renewal\"\n        },\n        {\n          \"removedValues\": [\n            \"<string>\",\n            \"<string>\"\n          ],\n          \"compact\": \"coun\",\n          \"previous\": {\n            \"licenseJurisdiction\": \"nh\",\n            \"dateOfExpiration\": \"1570-13-31\",\n            \"compact\": \"coun\",\n            \"providerId\": \"5b8984cd-31b1-4c50-9d1e-80a4e81d3a05\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"2348-00-21\",\n            \"dateOfUpdate\": \"1258-02-07\",\n            \"status\": \"inactive\"\n          },\n          \"jurisdiction\": \"vt\",\n          \"updatedValues\": {\n            \"licenseJurisdiction\": \"ks\",\n            \"dateOfExpiration\": \"2767-19-39\",\n            \"compact\": \"aslp\",\n            \"providerId\": \"ab71c97b-2dc4-4174-89b0-a423e300f046\",\n            \"type\": \"privilege\",\n            \"dateOfIssuance\": \"1188-12-25\",\n            \"dateOfUpdate\": \"1375-07-13\",\n            \"status\": \"active\"\n          },\n          \"type\": \"privilegeUpdate\",\n          \"dateOfUpdate\": \"2278-07-09\",\n          \"updateType\": \"renewal\"\n        }\n      ],\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"2918-18-36\",\n      \"dateOfUpdate\": \"1865-03-27\",\n      \"status\": \"inactive\"\n    }\n  ],\n  \"providerId\": \"f9db62c4-0e3d-4efc-aa7e-d96f4f9e542a\",\n  \"ssn\": \"587-77-6841\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"3156399059\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
+										}
+									]
+								}
+							]
+						}
+					],
+					"auth": {
+						"type": "bearer",
+						"bearer": [
+							{
+								"key": "token",
+								"value": "{{idToken}}",
+								"type": "string"
+							}
+						]
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "purchases",
+					"item": [
+						{
+							"name": "privileges",
+							"item": [
+								{
+									"name": "options",
+									"item": [
+										{
+											"name": "/v1/purchases/privileges/options",
+											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "key",
+															"value": "Authorization",
+															"type": "string"
+														},
+														{
+															"key": "value",
+															"value": "{{apiKey}}",
+															"type": "string"
+														},
+														{
+															"key": "in",
+															"value": "header",
+															"type": "string"
+														}
+													]
+												},
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/v1/purchases/privileges/options",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"purchases",
+														"privileges",
+														"options"
 													]
 												}
 											},
@@ -1036,24 +2374,15 @@
 															}
 														],
 														"url": {
-															"raw": "{{baseUrl}}/v1/compacts/:compact/providers/:providerId",
+															"raw": "{{baseUrl}}/v1/purchases/privileges/options",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"v1",
-																"compacts",
-																":compact",
-																"providers",
-																":providerId"
-															],
-															"variable": [
-																{
-																	"key": "compact"
-																},
-																{
-																	"key": "providerId"
-																}
+																"purchases",
+																"privileges",
+																"options"
 															]
 														}
 													},
@@ -1067,9 +2396,121 @@
 														}
 													],
 													"cookie": [],
-													"body": "{\n  \"birthMonthDay\": \"<date>\",\n  \"compact\": \"aslp\",\n  \"dateOfBirth\": \"<date>\",\n  \"dateOfExpiration\": \"<date>\",\n  \"dateOfUpdate\": \"<date>\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"licensed professional counselor\",\n  \"licenses\": [\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"5379023477\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"sd\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"687-65-6371\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"01f0e4b9-9356-4043-b8be-faf5f4377318\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"7457842116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"ky\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"122-13-5882\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"5d132506-d13a-472a-be47-c5fde42deb1d\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"ok\",\n    \"ok\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"mi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"aslp\",\n      \"providerId\": \"42ac3726-b81a-466f-b7ad-f9d0974ebe4f\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"coun\",\n      \"providerId\": \"bab44873-e09e-40ec-86eb-0d1c983c6e8d\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"providerId\": \"b461a1f5-8a5f-4665-9030-0953edfbe2d7\",\n  \"ssn\": \"217-46-5795\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"4851189695\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
+													"body": "{\n  \"items\": [\n    {\n      \"compactCommissionFee\": {\n        \"feeAmount\": \"<number>\",\n        \"feeType\": \"FLAT_RATE\"\n      },\n      \"compactName\": \"<string>\",\n      \"type\": \"compact\"\n    },\n    {\n      \"compactCommissionFee\": {\n        \"feeAmount\": \"<number>\",\n        \"feeType\": \"FLAT_RATE\"\n      },\n      \"compactName\": \"<string>\",\n      \"type\": \"compact\"\n    }\n  ],\n  \"pagination\": {\n    \"prevLastKey\": {},\n    \"lastKey\": {},\n    \"pageSize\": \"<integer>\"\n  }\n}"
 												}
 											]
+										}
+									]
+								},
+								{
+									"name": "/v1/purchases/privileges",
+									"request": {
+										"auth": {
+											"type": "apikey",
+											"apikey": [
+												{
+													"key": "key",
+													"value": "Authorization",
+													"type": "string"
+												},
+												{
+													"key": "value",
+													"value": "{{apiKey}}",
+													"type": "string"
+												},
+												{
+													"key": "in",
+													"value": "header",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"attestations\": [\n    {\n      \"attestationId\": \"<string>\",\n      \"version\": \"7633206726\"\n    },\n    {\n      \"attestationId\": \"<string>\",\n      \"version\": \"126973496\"\n    }\n  ],\n  \"orderInformation\": {\n    \"billing\": {\n      \"firstName\": \"<string>\",\n      \"lastName\": \"<string>\",\n      \"state\": \"<string>\",\n      \"streetAddress\": \"<string>\",\n      \"zip\": \"<string>\",\n      \"streetAddress2\": \"<string>\"\n    },\n    \"card\": {\n      \"cvv\": \"<string>\",\n      \"expiration\": \"<string>\",\n      \"number\": \"<string>\"\n    }\n  },\n  \"selectedJurisdictions\": [\n    \"wy\",\n    \"ky\"\n  ]\n}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/v1/purchases/privileges",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"v1",
+												"purchases",
+												"privileges"
+											]
+										}
+									},
+									"response": [
+										{
+											"name": "200 response",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													},
+													{
+														"key": "Authorization",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"attestations\": [\n    {\n      \"attestationId\": \"<string>\",\n      \"version\": \"7633206726\"\n    },\n    {\n      \"attestationId\": \"<string>\",\n      \"version\": \"126973496\"\n    }\n  ],\n  \"orderInformation\": {\n    \"billing\": {\n      \"firstName\": \"<string>\",\n      \"lastName\": \"<string>\",\n      \"state\": \"<string>\",\n      \"streetAddress\": \"<string>\",\n      \"zip\": \"<string>\",\n      \"streetAddress2\": \"<string>\"\n    },\n    \"card\": {\n      \"cvv\": \"<string>\",\n      \"expiration\": \"<string>\",\n      \"number\": \"<string>\"\n    }\n  },\n  \"selectedJurisdictions\": [\n    \"wy\",\n    \"ky\"\n  ]\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/v1/purchases/privileges",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"purchases",
+														"privileges"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"transactionId\": \"<string>\",\n  \"message\": \"<string>\"\n}"
 										}
 									]
 								}
@@ -1086,6 +2527,26 @@
 								{
 									"name": "/v1/staff-users/me",
 									"request": {
+										"auth": {
+											"type": "apikey",
+											"apikey": [
+												{
+													"key": "key",
+													"value": "Authorization",
+													"type": "string"
+												},
+												{
+													"key": "value",
+													"value": "{{apiKey}}",
+													"type": "string"
+												},
+												{
+													"key": "in",
+													"value": "header",
+													"type": "string"
+												}
+											]
+										},
 										"method": "GET",
 										"header": [
 											{
@@ -1122,24 +2583,14 @@
 													}
 												],
 												"url": {
-													"raw": "{{baseUrl}}/v1/compacts/:compact/providers/:providerId",
+													"raw": "{{baseUrl}}/v1/staff-users/me",
 													"host": [
 														"{{baseUrl}}"
 													],
 													"path": [
 														"v1",
-														"compacts",
-														":compact",
-														"providers",
-														":providerId"
-													],
-													"variable": [
-														{
-															"key": "compact"
-														},
-														{
-															"key": "providerId"
-														}
+														"staff-users",
+														"me"
 													]
 												}
 											},
@@ -1150,18 +2601,89 @@
 												{
 													"key": "Content-Type",
 													"value": "application/json"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "<string>",
+													"description": {
+														"content": "",
+														"type": "text/plain"
+													}
 												}
 											],
 											"cookie": [],
-											"body": "{\n  \"birthMonthDay\": \"<date>\",\n  \"compact\": \"aslp\",\n  \"dateOfBirth\": \"<date>\",\n  \"dateOfExpiration\": \"<date>\",\n  \"dateOfUpdate\": \"<date>\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"licensed professional counselor\",\n  \"licenses\": [\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"5379023477\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"sd\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"687-65-6371\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"01f0e4b9-9356-4043-b8be-faf5f4377318\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"7457842116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"ky\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"122-13-5882\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"5d132506-d13a-472a-be47-c5fde42deb1d\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"ok\",\n    \"ok\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"mi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"aslp\",\n      \"providerId\": \"42ac3726-b81a-466f-b7ad-f9d0974ebe4f\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"coun\",\n      \"providerId\": \"bab44873-e09e-40ec-86eb-0d1c983c6e8d\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"providerId\": \"b461a1f5-8a5f-4665-9030-0953edfbe2d7\",\n  \"ssn\": \"217-46-5795\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"4851189695\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
+											"body": "{\n  \"attributes\": {\n    \"email\": \"<string>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\"\n  },\n  \"permissions\": {\n    \"amet1\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"fugiatfc\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"officia_6_0\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"deserunt50\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"veniam_5\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  },\n  \"userId\": \"<string>\"\n}"
+										},
+										{
+											"name": "404 response",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													},
+													{
+														"key": "Authorization",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/v1/staff-users/me",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"staff-users",
+														"me"
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"message\": \"<string>\"\n}"
 										}
 									]
 								},
 								{
 									"name": "/v1/staff-users/me",
 									"request": {
+										"auth": {
+											"type": "apikey",
+											"apikey": [
+												{
+													"key": "key",
+													"value": "Authorization",
+													"type": "string"
+												},
+												{
+													"key": "value",
+													"value": "{{apiKey}}",
+													"type": "string"
+												},
+												{
+													"key": "in",
+													"value": "header",
+													"type": "string"
+												}
+											]
+										},
 										"method": "PATCH",
 										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
 											{
 												"key": "Accept",
 												"value": "application/json"
@@ -1169,9 +2691,10 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"attributes\": {\n        \"givenName\": \"Justin\",\n        \"familyName\": \"Frahm\"\n    }\n}",
+											"raw": "{\n  \"attributes\": {\n    \"givenName\": \"<string>\",\n    \"familyName\": \"<string>\"\n  }\n}",
 											"options": {
 												"raw": {
+													"headerFamily": "json",
 													"language": "json"
 												}
 											}
@@ -1192,8 +2715,12 @@
 										{
 											"name": "200 response",
 											"originalRequest": {
-												"method": "GET",
+												"method": "PATCH",
 												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
 													{
 														"key": "Accept",
 														"value": "application/json"
@@ -1204,25 +2731,25 @@
 														"description": "Added as a part of security scheme: apikey"
 													}
 												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"attributes\": {\n    \"givenName\": \"<string>\",\n    \"familyName\": \"<string>\"\n  }\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
 												"url": {
-													"raw": "{{baseUrl}}/v1/compacts/:compact/providers/:providerId",
+													"raw": "{{baseUrl}}/v1/staff-users/me",
 													"host": [
 														"{{baseUrl}}"
 													],
 													"path": [
 														"v1",
-														"compacts",
-														":compact",
-														"providers",
-														":providerId"
-													],
-													"variable": [
-														{
-															"key": "compact"
-														},
-														{
-															"key": "providerId"
-														}
+														"staff-users",
+														"me"
 													]
 												}
 											},
@@ -1233,10 +2760,71 @@
 												{
 													"key": "Content-Type",
 													"value": "application/json"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "<string>",
+													"description": {
+														"content": "",
+														"type": "text/plain"
+													}
 												}
 											],
 											"cookie": [],
-											"body": "{\n  \"birthMonthDay\": \"<date>\",\n  \"compact\": \"aslp\",\n  \"dateOfBirth\": \"<date>\",\n  \"dateOfExpiration\": \"<date>\",\n  \"dateOfUpdate\": \"<date>\",\n  \"familyName\": \"<string>\",\n  \"givenName\": \"<string>\",\n  \"homeAddressCity\": \"<string>\",\n  \"homeAddressPostalCode\": \"<string>\",\n  \"homeAddressState\": \"<string>\",\n  \"homeAddressStreet1\": \"<string>\",\n  \"licenseJurisdiction\": \"ct\",\n  \"licenseType\": \"licensed professional counselor\",\n  \"licenses\": [\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"5379023477\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"sd\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"687-65-6371\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"01f0e4b9-9356-4043-b8be-faf5f4377318\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    },\n    {\n      \"compact\": \"aslp\",\n      \"homeAddressStreet2\": \"<string>\",\n      \"npi\": \"7457842116\",\n      \"homeAddressPostalCode\": \"<string>\",\n      \"jurisdiction\": \"ky\",\n      \"givenName\": \"<string>\",\n      \"homeAddressStreet1\": \"<string>\",\n      \"militaryWaiver\": \"<boolean>\",\n      \"dateOfBirth\": \"<date>\",\n      \"type\": \"license-home\",\n      \"dateOfIssuance\": \"<date>\",\n      \"ssn\": \"122-13-5882\",\n      \"licenseType\": \"licensed clinical mental health counselor\",\n      \"dateOfExpiration\": \"<date>\",\n      \"homeAddressState\": \"<string>\",\n      \"providerId\": \"5d132506-d13a-472a-be47-c5fde42deb1d\",\n      \"dateOfRenewal\": \"<date>\",\n      \"familyName\": \"<string>\",\n      \"homeAddressCity\": \"<string>\",\n      \"middleName\": \"<string>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"privilegeJurisdictions\": [\n    \"ok\",\n    \"ok\"\n  ],\n  \"privileges\": [\n    {\n      \"licenseJurisdiction\": \"mi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"aslp\",\n      \"providerId\": \"42ac3726-b81a-466f-b7ad-f9d0974ebe4f\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"inactive\"\n    },\n    {\n      \"licenseJurisdiction\": \"hi\",\n      \"dateOfExpiration\": \"<date>\",\n      \"compact\": \"coun\",\n      \"providerId\": \"bab44873-e09e-40ec-86eb-0d1c983c6e8d\",\n      \"type\": \"privilege\",\n      \"dateOfIssuance\": \"<date>\",\n      \"dateOfUpdate\": \"<date>\",\n      \"status\": \"active\"\n    }\n  ],\n  \"providerId\": \"b461a1f5-8a5f-4665-9030-0953edfbe2d7\",\n  \"ssn\": \"217-46-5795\",\n  \"status\": \"active\",\n  \"type\": \"provider\",\n  \"homeAddressStreet2\": \"<string>\",\n  \"npi\": \"4851189695\",\n  \"militaryWaiver\": \"<boolean>\",\n  \"middleName\": \"<string>\"\n}"
+											"body": "{\n  \"attributes\": {\n    \"email\": \"<string>\",\n    \"familyName\": \"<string>\",\n    \"givenName\": \"<string>\"\n  },\n  \"permissions\": {\n    \"amet1\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"fugiatfc\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    },\n    \"officia_6_0\": {\n      \"actions\": {\n        \"readPrivate\": \"<boolean>\",\n        \"read\": \"<boolean>\",\n        \"admin\": \"<boolean>\"\n      },\n      \"jurisdictions\": {\n        \"deserunt50\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        },\n        \"veniam_5\": {\n          \"actions\": {\n            \"readPrivate\": \"<boolean>\",\n            \"admin\": \"<boolean>\",\n            \"write\": \"<boolean>\"\n          }\n        }\n      }\n    }\n  },\n  \"userId\": \"<string>\"\n}"
+										},
+										{
+											"name": "404 response",
+											"originalRequest": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"key": "Accept",
+														"value": "application/json"
+													},
+													{
+														"key": "Authorization",
+														"value": "<API Key>",
+														"description": "Added as a part of security scheme: apikey"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"attributes\": {\n    \"givenName\": \"<string>\",\n    \"familyName\": \"<string>\"\n  }\n}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/v1/staff-users/me",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"v1",
+														"staff-users",
+														"me"
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"message\": \"<string>\"\n}"
 										}
 									]
 								}

--- a/backend/compact-connect/lambdas/python/common/tests/function/test_data_model/test_user_client.py
+++ b/backend/compact-connect/lambdas/python/common/tests/function/test_data_model/test_user_client.py
@@ -9,7 +9,7 @@ from .. import TstFunction
 
 @mock_aws
 class TestClient(TstFunction):
-    def test_get_user(self):
+    def test_get_user_in_compact(self):
         user_id = self._load_user_data()
 
         from cc_common.data_model.user_client import UserClient
@@ -22,7 +22,7 @@ class TestClient(TstFunction):
         self.assertEqual({'type', 'userId', 'attributes', 'permissions', 'dateOfUpdate', 'compact'}, user.keys())
         self.assertEqual(UUID(user_id), user['userId'])
 
-    def test_get_user_not_found(self):
+    def test_get_user_in_compact_not_found(self):
         """User ID not found should raise an exception"""
         from cc_common.data_model.user_client import UserClient
         from cc_common.exceptions import CCNotFoundException
@@ -310,3 +310,23 @@ class TestClient(TstFunction):
             {'actions': {'read'}, 'jurisdictions': {'oh': {'write', 'admin'}, 'ne': {'write', 'admin'}}},
             second_user['permissions'],
         )
+
+    def test_delete_user_in_compact(self):
+        user_id = self._load_user_data()
+
+        from cc_common.data_model.user_client import UserClient
+
+        client = UserClient(self.config)
+
+        client.delete_user(compact='aslp', user_id=user_id)
+
+    def test_delete_user_in_compact_not_found(self):
+        """User ID not found should raise an exception"""
+        from cc_common.data_model.user_client import UserClient
+        from cc_common.exceptions import CCNotFoundException
+
+        client = UserClient(self.config)
+
+        # This user isn't in the DB, so it should raise an exception
+        with self.assertRaises(CCNotFoundException):
+            client.get_user_in_compact(compact='aslp', user_id='123')

--- a/backend/compact-connect/lambdas/python/common/tests/function/test_data_model/test_user_client.py
+++ b/backend/compact-connect/lambdas/python/common/tests/function/test_data_model/test_user_client.py
@@ -126,6 +126,20 @@ class TestClient(TstFunction):
         sorted_family_names = sorted(family_names)
         self.assertEqual(sorted_family_names, family_names)
 
+    def test_update_user_permissions_not_found(self):
+        from cc_common.data_model.user_client import UserClient
+        from cc_common.exceptions import CCNotFoundException
+
+        client = UserClient(self.config)
+
+        with self.assertRaises(CCNotFoundException):
+            client.update_user_permissions(
+                compact='aslp',
+                user_id='does-not-exist',
+                jurisdiction_action_additions={'oh': {'admin'}},
+                jurisdiction_action_removals={'oh': {'write'}},
+            )
+
     def test_update_user_permissions_jurisdiction_actions(self):
         user_id = UUID(self._load_user_data())
 
@@ -234,6 +248,18 @@ class TestClient(TstFunction):
         self.assertEqual({'givenName': 'Bob', 'familyName': 'Smith', 'email': 'justin@example.org'}, user['attributes'])
         # Checking that we're getting the whole object, not just changes
         self.assertFalse({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'} - user.keys())
+
+    def test_update_user_attributes_not_found(self):
+        from cc_common.data_model.user_client import UserClient
+        from cc_common.exceptions import CCNotFoundException
+
+        client = UserClient(self.config)
+
+        with self.assertRaises(CCNotFoundException):
+            client.update_user_attributes(
+                user_id='does-not-exist',
+                attributes={'givenName': 'Bob', 'familyName': 'Smith'},
+            )
 
     def test_create_new_user(self):
         from cc_common.data_model.user_client import UserClient

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/__init__.py
@@ -70,10 +70,14 @@ class TstFunction(TstLambdas):
         cognito_client = boto3.client('cognito-idp')
         cognito_client.delete_user_pool(UserPoolId=self._user_pool_id)
 
-    def _load_user_data(self) -> str:
+    def _load_user_data(self, second_jurisdiction: str = None) -> str:
         with open('../common/tests/resources/dynamo/user.json') as f:
             # This item is saved in its serialized form, so we have to deserialize it first
             item = TypeDeserializer().deserialize({'M': json.load(f)})
+
+        # Add write permissions to a second jurisdiction
+        if second_jurisdiction:
+            item['permissions']['jurisdictions'][second_jurisdiction] = {'write'}
 
         logger.info('Loading user: %s', item)
         self._table.put_item(Item=item)

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_delete_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_delete_user.py
@@ -1,0 +1,131 @@
+import json
+
+from moto import mock_aws
+
+from .. import TstFunction
+
+
+@mock_aws
+class TestDeleteUser(TstFunction):
+    def _assert_user_gone(self):
+        user = self._table.get_item(
+            Key={'pk': 'USER#a4182428-d061-701c-82e5-a3d1d547d797', 'sk': 'COMPACT#aslp'},
+        ).get('Item')
+        self.assertEqual(None, user)
+
+    def _assert_user_not_gone(self):
+        user = self._table.get_item(
+            Key={'pk': 'USER#a4182428-d061-701c-82e5-a3d1d547d797', 'sk': 'COMPACT#aslp'},
+        ).get('Item')
+        self.assertNotEqual(None, user)
+
+    def test_delete_user_not_found_compact_admin(self):
+        from handlers.users import delete_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for all of aslp
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/aslp.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = None
+
+        # We haven't loaded any users, so this won't find a user
+        resp = delete_user(event, self.mock_context)
+
+        self.assertEqual(404, resp['statusCode'])
+
+    def test_delete_user_not_found_jurisdiction_admin(self):
+        from handlers.users import delete_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for all of aslp
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/oh.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = None
+
+        # We haven't loaded any users, so this won't find a user
+        resp = delete_user(event, self.mock_context)
+
+        self.assertEqual(404, resp['statusCode'])
+
+    def test_delete_user_compact_admin(self):
+        self._load_user_data(second_jurisdiction='ne')
+
+        from handlers.users import delete_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for all of aslp
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/aslp.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = None
+
+        resp = delete_user(event, self.mock_context)
+
+        self.assertEqual(200, resp['statusCode'])
+
+        body = json.loads(resp['body'])
+        self.assertEqual({'message': 'User deleted'}, body)
+        self._assert_user_gone()
+
+    def test_delete_user_jurisdiction_admin(self):
+        # This user has permissions in oh
+        self._load_user_data()
+
+        from handlers.users import delete_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for aslp/oh
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/oh.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = None
+
+        resp = delete_user(event, self.mock_context)
+
+        self.assertEqual(200, resp['statusCode'])
+
+        body = json.loads(resp['body'])
+        self.assertEqual({'message': 'User deleted'}, body)
+        self._assert_user_gone()
+
+    def test_delete_user_outside_jurisdiction(self):
+        self._load_user_data()
+
+        from handlers.users import delete_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for aslp/ne, user does not have aslp/oh permissions
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/ne.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = None
+
+        resp = delete_user(event, self.mock_context)
+
+        self.assertEqual(404, resp['statusCode'])
+        self._assert_user_not_gone()
+
+    def test_delete_user_second_jurisdiction(self):
+        self._load_user_data(second_jurisdiction='ne')
+
+        from handlers.users import delete_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for aslp/ne, user does not have aslp/oh permissions
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/ne.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = None
+
+        resp = delete_user(event, self.mock_context)
+
+        self.assertEqual(403, resp['statusCode'])
+        self._assert_user_not_gone()

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -195,6 +195,23 @@ class TestPatchUser(TstFunction):
 
         self.assertEqual(403, resp['statusCode'])
 
+    def test_patch_user_not_found(self):
+        from handlers.users import patch_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The caller has admin permission for aslp/oh not aslp/ne
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin aslp/oh.admin'
+        # The staff user does not exist
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = json.dumps({'permissions': {'aslp': {'jurisdictions': {'oh': {'actions': {'admin': True}}}}}})
+
+        resp = patch_user(event, self.mock_context)
+
+        self.assertEqual(404, resp['statusCode'])
+        self.assertEqual({'message': 'User not found'}, json.loads(resp['body']))
+
     def test_patch_user_allows_adding_read_private_permission(self):
         self._load_user_data()
 

--- a/backend/compact-connect/stacks/api_stack/v1_api/staff_users.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/staff_users.py
@@ -13,7 +13,6 @@ from aws_cdk.aws_dynamodb import ITable
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from common_constructs.python_function import PythonFunction
-from common_constructs.stack import Stack
 
 # Importing module level to allow lazy loading for typing
 from stacks import persistent_stack as ps
@@ -34,7 +33,7 @@ class StaffUsers:
     ):
         super().__init__()
 
-        self.stack = Stack.of(admin_resource)
+        self.stack: ps.PersistentStack = ps.PersistentStack.of(admin_resource)
         self.admin_resource = admin_resource
         self.api: cc_api.CCApi = admin_resource.api
         self.api_model = api_model
@@ -55,6 +54,7 @@ class StaffUsers:
         # <base-url>/{userId}
         self._add_get_user(self.user_id_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
         self._add_patch_user(self.user_id_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
+        self._add_delete_user(self.user_id_resource, admin_scopes, env_vars=env_vars, persistent_stack=persistent_stack)
 
         self.me_resource = self_resource.add_resource('me')
         # <base-url>/me
@@ -74,7 +74,7 @@ class StaffUsers:
         get_me_handler = self._get_me_handler(
             env_vars=env_vars,
             data_encryption_key=persistent_stack.shared_encryption_key,
-            users_table=persistent_stack.staff_users.user_table,
+            user_table=persistent_stack.staff_users.user_table,
         )
 
         # Add the GET method to the me_resource
@@ -88,13 +88,19 @@ class StaffUsers:
                     response_models={'application/json': self.api_model.get_staff_user_me_model},
                     response_parameters={'method.response.header.Access-Control-Allow-Origin': True},
                 ),
+                MethodResponse(
+                    status_code='404',
+                    response_models={
+                        'application/json': self.api_model.message_response_model,
+                    },
+                ),
             ],
             authorization_type=AuthorizationType.COGNITO,
             authorizer=self.api.staff_users_authorizer,
             authorization_scopes=scopes,
         )
 
-    def _get_me_handler(self, env_vars: dict, data_encryption_key: IKey, users_table: ITable):
+    def _get_me_handler(self, env_vars: dict, data_encryption_key: IKey, user_table: ITable):
         handler = PythonFunction(
             self.stack,
             'GetMeStaffUserHandler',
@@ -104,7 +110,7 @@ class StaffUsers:
             environment=env_vars,
         )
         data_encryption_key.grant_decrypt(handler)
-        users_table.grant_read_data(handler)
+        user_table.grant_read_data(handler)
 
         self.log_groups.append(handler.log_group)
 
@@ -131,7 +137,7 @@ class StaffUsers:
         patch_me_handler = self._patch_me_handler(
             env_vars=env_vars,
             data_encryption_key=persistent_stack.shared_encryption_key,
-            users_table=persistent_stack.staff_users.user_table,
+            user_table=persistent_stack.staff_users.user_table,
             user_pool=persistent_stack.staff_users,
         )
 
@@ -147,13 +153,19 @@ class StaffUsers:
                     response_models={'application/json': self.api_model.get_staff_user_me_model},
                     response_parameters={'method.response.header.Access-Control-Allow-Origin': True},
                 ),
+                MethodResponse(
+                    status_code='404',
+                    response_models={
+                        'application/json': self.api_model.message_response_model,
+                    },
+                ),
             ],
             authorization_type=AuthorizationType.COGNITO,
             authorizer=self.api.staff_users_authorizer,
             authorization_scopes=scopes,
         )
 
-    def _patch_me_handler(self, env_vars: dict, data_encryption_key: IKey, users_table: ITable, user_pool: IUserPool):
+    def _patch_me_handler(self, env_vars: dict, data_encryption_key: IKey, user_table: ITable, user_pool: IUserPool):
         handler = PythonFunction(
             self.stack,
             'PatchMeStaffUserHandler',
@@ -163,7 +175,7 @@ class StaffUsers:
             environment=env_vars,
         )
         data_encryption_key.grant_encrypt_decrypt(handler)
-        users_table.grant_read_write_data(handler)
+        user_table.grant_read_write_data(handler)
         user_pool.grant(handler, 'cognito-idp:AdminUpdateUserAttributes')
 
         self.log_groups.append(handler.log_group)
@@ -191,7 +203,7 @@ class StaffUsers:
         get_users_handler = self._get_users_handler(
             env_vars=env_vars,
             data_encryption_key=persistent_stack.shared_encryption_key,
-            users_table=persistent_stack.staff_users.user_table,
+            user_table=persistent_stack.staff_users.user_table,
         )
         # Add the GET method to the users resource
         users_resource.add_method(
@@ -210,7 +222,7 @@ class StaffUsers:
             authorization_scopes=scopes,
         )
 
-    def _get_users_handler(self, env_vars: dict, data_encryption_key: IKey, users_table: ITable):
+    def _get_users_handler(self, env_vars: dict, data_encryption_key: IKey, user_table: ITable):
         handler = PythonFunction(
             self.stack,
             'GetStaffUsersHandler',
@@ -220,7 +232,7 @@ class StaffUsers:
             environment=env_vars,
         )
         data_encryption_key.grant_decrypt(handler)
-        users_table.grant_read_data(handler)
+        user_table.grant_read_data(handler)
 
         self.log_groups.append(handler.log_group)
 
@@ -247,7 +259,7 @@ class StaffUsers:
         get_user_handler = self._get_user_handler(
             env_vars=env_vars,
             data_encryption_key=persistent_stack.shared_encryption_key,
-            users_table=persistent_stack.staff_users.user_table,
+            user_table=persistent_stack.staff_users.user_table,
         )
 
         # Add the GET method to the user_id resource
@@ -261,13 +273,19 @@ class StaffUsers:
                     response_models={'application/json': self.api_model.get_staff_user_me_model},
                     response_parameters={'method.response.header.Access-Control-Allow-Origin': True},
                 ),
+                MethodResponse(
+                    status_code='404',
+                    response_models={
+                        'application/json': self.api_model.message_response_model,
+                    },
+                ),
             ],
             authorization_type=AuthorizationType.COGNITO,
             authorizer=self.api.staff_users_authorizer,
             authorization_scopes=scopes,
         )
 
-    def _get_user_handler(self, env_vars: dict, data_encryption_key: IKey, users_table: ITable):
+    def _get_user_handler(self, env_vars: dict, data_encryption_key: IKey, user_table: ITable):
         handler = PythonFunction(
             self.stack,
             'GetStaffUserHandler',
@@ -277,7 +295,7 @@ class StaffUsers:
             environment=env_vars,
         )
         data_encryption_key.grant_decrypt(handler)
-        users_table.grant_read_data(handler)
+        user_table.grant_read_data(handler)
 
         self.log_groups.append(handler.log_group)
 
@@ -304,7 +322,7 @@ class StaffUsers:
         self.patch_user_handler = self._patch_user_handler(
             env_vars=env_vars,
             data_encryption_key=persistent_stack.shared_encryption_key,
-            users_table=persistent_stack.staff_users.user_table,
+            user_table=persistent_stack.staff_users.user_table,
         )
 
         # Add the PATCH method to the me_resource
@@ -319,13 +337,19 @@ class StaffUsers:
                     response_models={'application/json': self.api_model.get_staff_user_me_model},
                     response_parameters={'method.response.header.Access-Control-Allow-Origin': True},
                 ),
+                MethodResponse(
+                    status_code='404',
+                    response_models={
+                        'application/json': self.api_model.message_response_model,
+                    },
+                ),
             ],
             authorization_type=AuthorizationType.COGNITO,
             authorizer=self.api.staff_users_authorizer,
             authorization_scopes=scopes,
         )
 
-    def _patch_user_handler(self, env_vars: dict, data_encryption_key: IKey, users_table: ITable):
+    def _patch_user_handler(self, env_vars: dict, data_encryption_key: IKey, user_table: ITable):
         handler = PythonFunction(
             self.stack,
             'PatchUserHandler',
@@ -335,9 +359,84 @@ class StaffUsers:
             environment=env_vars,
         )
         data_encryption_key.grant_encrypt_decrypt(handler)
-        users_table.grant_read_write_data(handler)
+        user_table.grant_read_write_data(handler)
 
         self.log_groups.append(handler.log_group)
+
+        NagSuppressions.add_resource_suppressions_by_path(
+            self.stack,
+            path=f'{handler.node.path}/ServiceRole/DefaultPolicy/Resource',
+            suppressions=[
+                {
+                    'id': 'AwsSolutions-IAM5',
+                    'reason': 'The actions in this policy are specifically what this lambda needs to read '
+                    'and is scoped to one table and encryption key.',
+                },
+            ],
+        )
+        return handler
+
+    def _add_delete_user(
+        self,
+        user_id_resource: Resource,
+        scopes: list[str],
+        *,
+        env_vars: dict[str, str],
+        persistent_stack: ps.PersistentStack,
+    ) -> None:
+        """Add DELETE method to delete a staff user's record.
+
+        Args:
+            user_id_resource: The API Gateway Resource to add the method to
+            scopes: List of OAuth scopes required for this endpoint
+            env_vars: Environment variables to pass to the Lambda function
+            persistent_stack: Stack containing persistent resources
+        """
+        self.delete_user_handler = self._delete_user_handler(
+            env_vars=env_vars,
+            data_encryption_key=persistent_stack.shared_encryption_key,
+            user_table=persistent_stack.staff_users.user_table,
+        )
+
+        # Add the method to the resource
+        user_id_resource.add_method(
+            'DELETE',
+            LambdaIntegration(self.delete_user_handler),
+            authorization_type=AuthorizationType.COGNITO,
+            authorizer=self.api.staff_users_authorizer,
+            authorization_scopes=scopes,
+            method_responses=[
+                MethodResponse(
+                    status_code='200',
+                    response_models={
+                        'application/json': self.api_model.message_response_model,
+                    },
+                ),
+                MethodResponse(
+                    status_code='404',
+                    response_models={
+                        'application/json': self.api_model.message_response_model,
+                    },
+                ),
+            ],
+        )
+
+        # Add the function's log group to the list for retention setting
+        self.log_groups.append(self.delete_user_handler.log_group)
+
+    def _delete_user_handler(self, env_vars: dict, data_encryption_key: IKey, user_table: ITable):
+        handler = PythonFunction(
+            self.stack,
+            'DeleteStaffUserFunction',
+            lambda_dir='staff-users',
+            index=os.path.join('handlers', 'users.py'),
+            handler='delete_user',
+            environment=env_vars,
+        )
+
+        # Grant permissions to the function
+        data_encryption_key.grant_encrypt_decrypt(handler)
+        user_table.grant_read_write_data(handler)
 
         NagSuppressions.add_resource_suppressions_by_path(
             self.stack,
@@ -362,7 +461,7 @@ class StaffUsers:
         self.post_user_handler = self._post_user_handler(
             env_vars=env_vars,
             data_encryption_key=persistent_stack.shared_encryption_key,
-            users_table=persistent_stack.staff_users.user_table,
+            user_table=persistent_stack.staff_users.user_table,
             user_pool=persistent_stack.staff_users,
         )
 
@@ -384,7 +483,7 @@ class StaffUsers:
             authorization_scopes=scopes,
         )
 
-    def _post_user_handler(self, env_vars: dict, data_encryption_key: IKey, users_table: ITable, user_pool: IUserPool):
+    def _post_user_handler(self, env_vars: dict, data_encryption_key: IKey, user_table: ITable, user_pool: IUserPool):
         handler = PythonFunction(
             self.stack,
             'PostStaffUserHandler',
@@ -394,7 +493,7 @@ class StaffUsers:
             environment=env_vars,
         )
         data_encryption_key.grant_encrypt_decrypt(handler)
-        users_table.grant_read_write_data(handler)
+        user_table.grant_read_write_data(handler)
         user_pool.grant(
             handler,
             'cognito-idp:AdminCreateUser',

--- a/backend/compact-connect/tests/app/test_api/test_staff_users_api.py
+++ b/backend/compact-connect/tests/app/test_api/test_staff_users_api.py
@@ -1,4 +1,4 @@
-from aws_cdk.assertions import Capture, Template
+from aws_cdk.assertions import Capture, Match, Template
 from aws_cdk.aws_apigateway import CfnMethod, CfnModel, CfnResource
 from aws_cdk.aws_lambda import CfnFunction
 
@@ -99,6 +99,10 @@ class TestStaffUsersApi(TestApi):
                     {
                         'ResponseModels': {'application/json': {'Ref': patch_method_response_model_logical_id_capture}},
                         'StatusCode': '200',
+                    },
+                    {
+                        'ResponseModels': {'application/json': {'Ref': Match.any_value()}},
+                        'StatusCode': '404',
                     },
                 ],
             },


### PR DESCRIPTION
### Description List
- Added DELETE method to /v1/compacts/:compact/staff-users/:userId to delete staff-user's compact permission record
- Identified and fixed a bug in the PATCH /v1/compacts/:compact/staff-users/:userId endpoint, if the user does not exist.
- Removed API change summary from README since it seemed low value to developers and was not being maintained
- Removed OPTIONS methods from openapi spec doc, since they were cluttering up the doc and making it harder to parse.

Closes #
#475 