### PR TITLE
Feat/staff user status

### DIFF
--- a/backend/compact-connect/bin/create_staff_user.py
+++ b/backend/compact-connect/bin/create_staff_user.py
@@ -30,7 +30,7 @@ os.environ['COMPACTS'] = json.dumps(COMPACTS)
 os.environ['JURISDICTIONS'] = json.dumps(JURISDICTIONS)
 
 # We have to import this after we've mucked with our path and environment
-from cc_common.data_model.schema.user import UserRecordSchema  # noqa: E402
+from cc_common.data_model.schema.user.record import UserRecordSchema  # noqa: E402
 
 USER_POOL_ID = os.environ['USER_POOL_ID']
 USER_TABLE_NAME = os.environ['USER_TABLE_NAME']

--- a/backend/compact-connect/bin/create_staff_user.py
+++ b/backend/compact-connect/bin/create_staff_user.py
@@ -30,6 +30,7 @@ os.environ['COMPACTS'] = json.dumps(COMPACTS)
 os.environ['JURISDICTIONS'] = json.dumps(JURISDICTIONS)
 
 # We have to import this after we've mucked with our path and environment
+from cc_common.data_model.schema.common import StaffUserStatus  # noqa: E402
 from cc_common.data_model.schema.user.record import UserRecordSchema  # noqa: E402
 
 USER_POOL_ID = os.environ['USER_POOL_ID']
@@ -49,6 +50,7 @@ def create_compact_ed_user(*, email: str, compact: str, user_attributes: dict):
             {
                 'type': 'user',
                 'userId': sub,
+                'status': StaffUserStatus.ACTIVE.value,
                 'compact': compact,
                 'attributes': user_attributes,
                 'permissions': {'actions': {'read', 'admin'}, 'jurisdictions': {}},
@@ -65,6 +67,7 @@ def create_board_ed_user(*, email: str, compact: str, jurisdiction: str, user_at
             {
                 'type': 'user',
                 'userId': sub,
+                'status': StaffUserStatus.ACTIVE.value,
                 'compact': compact,
                 'attributes': user_attributes,
                 'permissions': {'actions': {'read'}, 'jurisdictions': {jurisdiction: {'write', 'admin'}}},

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/__init__.py
@@ -5,4 +5,4 @@ from .jurisdiction.record import JurisdictionRecordSchema
 from .license.record import LicenseRecordSchema
 from .privilege.record import PrivilegeRecordSchema
 from .provider.record import ProviderRecordSchema
-from .user import UserRecordSchema
+from .user.record import UserRecordSchema

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/common.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/common.py
@@ -68,7 +68,7 @@ class UpdateCategory(CCEnum):
     OTHER = 'other'
 
 
-class ProviderStatus(CCEnum):
+class ProviderEligibilityStatus(CCEnum):
     ACTIVE = 'active'
     INACTIVE = 'inactive'
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/common.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/common.py
@@ -68,7 +68,12 @@ class UpdateCategory(CCEnum):
     OTHER = 'other'
 
 
-class Status(CCEnum):
+class ProviderStatus(CCEnum):
+    ACTIVE = 'active'
+    INACTIVE = 'inactive'
+
+
+class StaffUserStatus(CCEnum):
     ACTIVE = 'active'
     INACTIVE = 'inactive'
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/fields.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/fields.py
@@ -2,7 +2,7 @@ from marshmallow.fields import List, String
 from marshmallow.validate import OneOf, Regexp
 
 from cc_common.config import config
-from cc_common.data_model.schema.common import ProviderStatus, UpdateCategory
+from cc_common.data_model.schema.common import ProviderEligibilityStatus, UpdateCategory
 
 
 class SocialSecurityNumber(String):
@@ -39,7 +39,7 @@ class Jurisdiction(String):
 
 class ActiveInactive(String):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, validate=OneOf([entry.value for entry in ProviderStatus]), **kwargs)
+        super().__init__(*args, validate=OneOf([entry.value for entry in ProviderEligibilityStatus]), **kwargs)
 
 
 class UpdateType(String):

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/fields.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/fields.py
@@ -2,7 +2,7 @@ from marshmallow.fields import List, String
 from marshmallow.validate import OneOf, Regexp
 
 from cc_common.config import config
-from cc_common.data_model.schema.common import Status, UpdateCategory
+from cc_common.data_model.schema.common import ProviderStatus, UpdateCategory
 
 
 class SocialSecurityNumber(String):
@@ -39,7 +39,7 @@ class Jurisdiction(String):
 
 class ActiveInactive(String):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, validate=OneOf([entry.value for entry in Status]), **kwargs)
+        super().__init__(*args, validate=OneOf([entry.value for entry in ProviderStatus]), **kwargs)
 
 
 class UpdateType(String):

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/user/api.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/user/api.py
@@ -5,6 +5,7 @@ from marshmallow.fields import Boolean, Dict, Nested, Raw, String
 from marshmallow.validate import Length, OneOf
 
 from cc_common.config import config
+from cc_common.data_model.schema.common import StaffUserStatus
 
 
 class UserAttributesAPISchema(Schema):
@@ -41,6 +42,7 @@ class UserAPISchema(Schema):
 
     type = String(required=True, allow_none=False, validate=OneOf(['user']))
     userId = Raw(required=True, allow_none=False)
+    status = String(required=True, allow_none=False, validate=OneOf([status.value for status in StaffUserStatus]))
     dateOfUpdate = Raw(required=True, allow_none=False)
     attributes = Nested(UserAttributesAPISchema(), required=True, allow_none=False)
     permissions = Dict(

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/user/api.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/user/api.py
@@ -1,76 +1,16 @@
 # ruff: noqa: N801, N815  invalid-name
 
-from marshmallow import Schema, post_dump, post_load, pre_dump, pre_load
-from marshmallow.fields import UUID, Boolean, Dict, Nested, Raw, String
+from marshmallow import Schema, post_dump, pre_load
+from marshmallow.fields import Boolean, Dict, Nested, Raw, String
 from marshmallow.validate import Length, OneOf
 
 from cc_common.config import config
-from cc_common.data_model.schema.base_record import BaseRecordSchema
-from cc_common.data_model.schema.fields import Set
 
 
-class CompactPermissionsRecordSchema(Schema):
-    actions = Set(String, required=False, allow_none=False)
-    jurisdictions = Dict(
-        keys=String(validate=OneOf(config.jurisdictions)),
-        values=Set(String, required=False, allow_none=False),
-        dump_default={},
-        required=True,
-        allow_none=False,
-    )
-
-    @post_dump
-    def drop_empty_actions(self, data, **kwargs):  # noqa: ARG002 unused-kwargs
-        """
-        DynamoDB doesn't like empty sets, so we will make a point to drop an actions field entirely,
-        if it is empty.
-        """
-        if not data.get('actions', {}):
-            data.pop('actions', None)
-        empty_jurisdictions = [jurisdiction for jurisdiction, actions in data['jurisdictions'].items() if not actions]
-        for jurisdiction in empty_jurisdictions:
-            del data['jurisdictions'][jurisdiction]
-        return data
-
-
-class UserAttributesSchema(Schema):
+class UserAttributesAPISchema(Schema):
     email = String(required=True, allow_none=False, validate=Length(1, 100))
     givenName = String(required=True, allow_none=False, validate=Length(1, 100))
     familyName = String(required=True, allow_none=False, validate=Length(1, 100))
-
-
-@BaseRecordSchema.register_schema('user')
-class UserRecordSchema(BaseRecordSchema):
-    _record_type = 'user'
-
-    # Provided fields
-    userId = UUID(required=True, allow_none=False)
-    attributes = Nested(UserAttributesSchema(), required=True, allow_none=False)
-    compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
-    permissions = Nested(CompactPermissionsRecordSchema(), required=True, allow_none=False)
-
-    # Generated fields
-    famGiv = String(required=True, allow_none=False)
-
-    @pre_dump
-    def generate_pk(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
-        in_data['pk'] = f'USER#{in_data['userId']}'
-        return in_data
-
-    @pre_dump
-    def generate_sk(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
-        in_data['sk'] = f'COMPACT#{in_data['compact']}'
-        return in_data
-
-    @pre_dump
-    def generate_fam_giv(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
-        in_data['famGiv'] = '#'.join([in_data['attributes']['familyName'], in_data['attributes']['givenName']])
-        return in_data
-
-    @post_load
-    def drop_fam_giv(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
-        del in_data['famGiv']
-        return in_data
 
 
 class CompactActionPermissionAPISchema(Schema):
@@ -102,7 +42,7 @@ class UserAPISchema(Schema):
     type = String(required=True, allow_none=False, validate=OneOf(['user']))
     userId = Raw(required=True, allow_none=False)
     dateOfUpdate = Raw(required=True, allow_none=False)
-    attributes = Nested(UserAttributesSchema(), required=True, allow_none=False)
+    attributes = Nested(UserAttributesAPISchema(), required=True, allow_none=False)
     permissions = Dict(
         keys=String(validate=OneOf(config.compacts)),  # Key is one compact
         values=Nested(CompactPermissionsAPISchema(), required=True, allow_none=False),

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/user/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/user/record.py
@@ -1,0 +1,73 @@
+# ruff: noqa: N801, N815  invalid-name
+
+from marshmallow import Schema, post_dump, post_load, pre_dump
+from marshmallow.fields import UUID, Dict, Nested, String
+from marshmallow.validate import Length, OneOf
+
+from cc_common.config import config
+from cc_common.data_model.schema.base_record import BaseRecordSchema
+from cc_common.data_model.schema.fields import Set
+
+
+class CompactPermissionsRecordSchema(Schema):
+    actions = Set(String, required=False, allow_none=False)
+    jurisdictions = Dict(
+        keys=String(validate=OneOf(config.jurisdictions)),
+        values=Set(String, required=False, allow_none=False),
+        dump_default={},
+        required=True,
+        allow_none=False,
+    )
+
+    @post_dump
+    def drop_empty_actions(self, data, **kwargs):  # noqa: ARG002 unused-kwargs
+        """
+        DynamoDB doesn't like empty sets, so we will make a point to drop an actions field entirely,
+        if it is empty.
+        """
+        if not data.get('actions', {}):
+            data.pop('actions', None)
+        empty_jurisdictions = [jurisdiction for jurisdiction, actions in data['jurisdictions'].items() if not actions]
+        for jurisdiction in empty_jurisdictions:
+            del data['jurisdictions'][jurisdiction]
+        return data
+
+
+class UserAttributesRecordSchema(Schema):
+    email = String(required=True, allow_none=False, validate=Length(1, 100))
+    givenName = String(required=True, allow_none=False, validate=Length(1, 100))
+    familyName = String(required=True, allow_none=False, validate=Length(1, 100))
+
+
+@BaseRecordSchema.register_schema('user')
+class UserRecordSchema(BaseRecordSchema):
+    _record_type = 'user'
+
+    # Provided fields
+    userId = UUID(required=True, allow_none=False)
+    attributes = Nested(UserAttributesRecordSchema(), required=True, allow_none=False)
+    compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
+    permissions = Nested(CompactPermissionsRecordSchema(), required=True, allow_none=False)
+
+    # Generated fields
+    famGiv = String(required=True, allow_none=False)
+
+    @pre_dump
+    def generate_pk(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
+        in_data['pk'] = f'USER#{in_data['userId']}'
+        return in_data
+
+    @pre_dump
+    def generate_sk(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
+        in_data['sk'] = f'COMPACT#{in_data['compact']}'
+        return in_data
+
+    @pre_dump
+    def generate_fam_giv(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
+        in_data['famGiv'] = '#'.join([in_data['attributes']['familyName'], in_data['attributes']['givenName']])
+        return in_data
+
+    @post_load
+    def drop_fam_giv(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
+        del in_data['famGiv']
+        return in_data

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/user/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/user/record.py
@@ -6,6 +6,7 @@ from marshmallow.validate import Length, OneOf
 
 from cc_common.config import config
 from cc_common.data_model.schema.base_record import BaseRecordSchema
+from cc_common.data_model.schema.common import StaffUserStatus
 from cc_common.data_model.schema.fields import Set
 
 
@@ -48,18 +49,19 @@ class UserRecordSchema(BaseRecordSchema):
     attributes = Nested(UserAttributesRecordSchema(), required=True, allow_none=False)
     compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
     permissions = Nested(CompactPermissionsRecordSchema(), required=True, allow_none=False)
+    status = String(required=True, allow_none=False, validate=OneOf([status.value for status in StaffUserStatus]))
 
     # Generated fields
     famGiv = String(required=True, allow_none=False)
 
     @pre_dump
     def generate_pk(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
-        in_data['pk'] = f'USER#{in_data['userId']}'
+        in_data['pk'] = f'USER#{in_data["userId"]}'
         return in_data
 
     @pre_dump
     def generate_sk(self, in_data, **kwargs):  # noqa: ARG002 unused-kwargs
-        in_data['sk'] = f'COMPACT#{in_data['compact']}'
+        in_data['sk'] = f'COMPACT#{in_data["compact"]}'
         return in_data
 
     @pre_dump

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/user_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/user_client.py
@@ -5,6 +5,7 @@ from botocore.exceptions import ClientError
 
 from cc_common.config import _Config, logger
 from cc_common.data_model.query_paginator import paginated_query
+from cc_common.data_model.schema.common import StaffUserStatus
 from cc_common.data_model.schema.user.record import (
     CompactPermissionsRecordSchema,
     UserAttributesRecordSchema,
@@ -302,7 +303,13 @@ class UserClient:
 
         try:
             user = self.schema.dump(
-                {'userId': user_id, 'compact': compact, 'attributes': attributes, 'permissions': permissions},
+                {
+                    'userId': user_id,
+                    'compact': compact,
+                    'attributes': attributes,
+                    'permissions': permissions,
+                    'status': StaffUserStatus.INACTIVE.value,
+                },
             )
             # If the user doesn't already exist, add them
             self.config.users_table.put_item(

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/user_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/user_client.py
@@ -5,7 +5,11 @@ from botocore.exceptions import ClientError
 
 from cc_common.config import _Config, logger
 from cc_common.data_model.query_paginator import paginated_query
-from cc_common.data_model.schema.user import CompactPermissionsRecordSchema, UserAttributesSchema, UserRecordSchema
+from cc_common.data_model.schema.user.record import (
+    CompactPermissionsRecordSchema,
+    UserAttributesRecordSchema,
+    UserRecordSchema,
+)
 from cc_common.exceptions import CCInvalidRequestException, CCNotFoundException
 from cc_common.utils import get_sub_from_user_attributes
 
@@ -16,7 +20,7 @@ class UserClient:
     def __init__(self, config: _Config):
         self.config = config
         self.schema = UserRecordSchema()
-        self.user_attributes_schema = UserAttributesSchema()
+        self.user_attributes_schema = UserAttributesRecordSchema()
         self.compact_permissions_schema = CompactPermissionsRecordSchema()
 
     @paginated_query

--- a/backend/compact-connect/lambdas/python/common/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/tests/function/__init__.py
@@ -200,6 +200,7 @@ class TstFunction(TstLambdas):
 
     def _create_compact_staff_user(self, compacts: list[str]):
         """Create a compact-staff style user for each jurisdiction in the provided compact."""
+        from cc_common.data_model.schema.common import StaffUserStatus
         from cc_common.data_model.schema.user.record import UserRecordSchema
 
         schema = UserRecordSchema()
@@ -213,6 +214,7 @@ class TstFunction(TstLambdas):
                     {
                         'userId': sub,
                         'compact': compact,
+                        'status': StaffUserStatus.INACTIVE.value,
                         'attributes': {
                             'email': email,
                             'familyName': self.faker.unique.last_name(),
@@ -226,6 +228,7 @@ class TstFunction(TstLambdas):
 
     def _create_board_staff_users(self, compacts: list[str]):
         """Create a board-staff style user for each jurisdiction in the provided compact."""
+        from cc_common.data_model.schema.common import StaffUserStatus
         from cc_common.data_model.schema.user.record import UserRecordSchema
 
         schema = UserRecordSchema()
@@ -240,6 +243,7 @@ class TstFunction(TstLambdas):
                         {
                             'userId': sub,
                             'compact': compact,
+                            'status': StaffUserStatus.INACTIVE.value,
                             'attributes': {
                                 'email': email,
                                 'familyName': self.faker.unique.last_name(),

--- a/backend/compact-connect/lambdas/python/common/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/tests/function/__init__.py
@@ -200,7 +200,7 @@ class TstFunction(TstLambdas):
 
     def _create_compact_staff_user(self, compacts: list[str]):
         """Create a compact-staff style user for each jurisdiction in the provided compact."""
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         schema = UserRecordSchema()
 
@@ -226,7 +226,7 @@ class TstFunction(TstLambdas):
 
     def _create_board_staff_users(self, compacts: list[str]):
         """Create a board-staff style user for each jurisdiction in the provided compact."""
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         schema = UserRecordSchema()
 

--- a/backend/compact-connect/lambdas/python/common/tests/function/test_data_model/test_user_client.py
+++ b/backend/compact-connect/lambdas/python/common/tests/function/test_data_model/test_user_client.py
@@ -1,7 +1,6 @@
 import json
 from uuid import UUID
 
-from cc_common.exceptions import CCInvalidRequestException
 from moto import mock_aws
 
 from .. import TstFunction
@@ -19,7 +18,9 @@ class TestClient(TstFunction):
         user = client.get_user_in_compact(compact='aslp', user_id=user_id)
 
         # Verify that we're getting the expected fields
-        self.assertEqual({'type', 'userId', 'attributes', 'permissions', 'dateOfUpdate', 'compact'}, user.keys())
+        self.assertEqual(
+            {'type', 'userId', 'attributes', 'permissions', 'dateOfUpdate', 'compact', 'status'}, user.keys()
+        )
         self.assertEqual(UUID(user_id), user['userId'])
 
     def test_get_user_not_found(self):
@@ -57,7 +58,9 @@ class TestClient(TstFunction):
 
         # Verify that we're getting the expected fields
         for user in resp['items']:
-            self.assertEqual({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'}, user.keys())
+            self.assertEqual(
+                {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'}, user.keys()
+            )
 
         # Verify we're seeing the expected sorting
         family_names = [user['attributes']['familyName'] for user in resp['items']]
@@ -89,7 +92,9 @@ class TestClient(TstFunction):
 
         # Verify that we're getting the expected fields
         for user in resp['items']:
-            self.assertEqual({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'}, user.keys())
+            self.assertEqual(
+                {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'}, user.keys()
+            )
 
         # Verify we're seeing the expected sorting
         family_names = [user['attributes']['familyName'] for user in resp['items']]
@@ -119,7 +124,9 @@ class TestClient(TstFunction):
 
         # Verify that we're getting the expected fields
         for user in resp['items']:
-            self.assertEqual({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'}, user.keys())
+            self.assertEqual(
+                {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'}, user.keys()
+            )
 
         # Verify we're seeing the expected sorting
         family_names = [user['attributes']['familyName'] for user in resp['items']]
@@ -146,7 +153,9 @@ class TestClient(TstFunction):
             resp['permissions'],
         )
         # Just checking that we're getting the whole object, not just changes
-        self.assertFalse({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'} - resp.keys())
+        self.assertFalse(
+            {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'} - resp.keys()
+        )
 
     def test_update_user_permissions_board_to_compact_admin(self):
         # The sample user looks like board staff in aslp/oh
@@ -166,7 +175,9 @@ class TestClient(TstFunction):
         self.assertEqual(user_id, resp['userId'])
         self.assertEqual({'actions': {'readPrivate', 'admin'}, 'jurisdictions': {}}, resp['permissions'])
         # Checking that we're getting the whole object, not just changes
-        self.assertFalse({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'} - resp.keys())
+        self.assertFalse(
+            {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'} - resp.keys()
+        )
 
     def test_update_user_permissions_compact_to_board_admin(self):
         from boto3.dynamodb.types import TypeDeserializer
@@ -193,10 +204,13 @@ class TestClient(TstFunction):
         self.assertEqual(user_id, resp['userId'])
         self.assertEqual({'actions': {'read'}, 'jurisdictions': {'oh': {'write', 'admin'}}}, resp['permissions'])
         # Checking that we're getting the whole object, not just changes
-        self.assertFalse({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'} - resp.keys())
+        self.assertFalse(
+            {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'} - resp.keys()
+        )
 
     def test_update_user_permissions_no_change(self):
         from boto3.dynamodb.types import TypeDeserializer
+        from cc_common.exceptions import CCInvalidRequestException
 
         with open('tests/resources/dynamo/user.json') as f:
             user_data = TypeDeserializer().deserialize({'M': json.load(f)})
@@ -233,9 +247,12 @@ class TestClient(TstFunction):
         self.assertEqual(user_id, user['userId'])
         self.assertEqual({'givenName': 'Bob', 'familyName': 'Smith', 'email': 'justin@example.org'}, user['attributes'])
         # Checking that we're getting the whole object, not just changes
-        self.assertFalse({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'} - user.keys())
+        self.assertFalse(
+            {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'} - user.keys()
+        )
 
     def test_create_new_user(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
         from cc_common.data_model.user_client import UserClient
 
         client = UserClient(self.config)
@@ -246,7 +263,11 @@ class TestClient(TstFunction):
             permissions={'actions': {'read'}, 'jurisdictions': {'oh': {'write', 'admin'}}},
         )
 
-        self.assertEqual({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'}, resp.keys())
+        self.assertEqual(
+            {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'},
+            resp.keys(),
+        )
+        self.assertEqual(StaffUserStatus.INACTIVE.value, resp['status'])
         self.assertEqual({'givenName': 'Bob', 'familyName': 'Smith', 'email': 'bob@example.org'}, resp['attributes'])
         self.assertEqual({'actions': {'read'}, 'jurisdictions': {'oh': {'write', 'admin'}}}, resp['permissions'])
 
@@ -256,6 +277,7 @@ class TestClient(TstFunction):
         we're looking at here is that we have two sets of permissions (DB records, internally) but that they share the
         same userId.
         """
+        from cc_common.data_model.schema.common import StaffUserStatus
         from cc_common.data_model.user_client import UserClient
 
         client = UserClient(self.config)
@@ -275,7 +297,10 @@ class TestClient(TstFunction):
         )
 
         self.assertEqual(first_user['userId'], second_user['userId'])
-        self.assertEqual({'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate'}, second_user.keys())
+        self.assertEqual(
+            {'type', 'userId', 'compact', 'attributes', 'permissions', 'dateOfUpdate', 'status'},
+            second_user.keys(),
+        )
         self.assertEqual(
             {'givenName': 'Bob', 'familyName': 'Smith', 'email': 'bob@example.org'},
             second_user['attributes'],
@@ -283,6 +308,7 @@ class TestClient(TstFunction):
         # The second user should see the second compact permissions, not the first, since they are presented separately
         self.assertEqual('octp', second_user['compact'])
         self.assertEqual({'actions': {'read'}, 'jurisdictions': {'ne': {'write', 'admin'}}}, second_user['permissions'])
+        self.assertEqual(StaffUserStatus.INACTIVE.value, second_user['status'])
 
     def test_create_existing_user_same_compact(self):
         from cc_common.data_model.user_client import UserClient

--- a/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/user.json
+++ b/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/user.json
@@ -20,6 +20,9 @@
   "userId": {
     "S": "a4182428-d061-701c-82e5-a3d1d547d797"
   },
+  "status": {
+    "S": "inactive"
+  },
   "attributes": {
     "M": {
       "email": {

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/ingest.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/ingest.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from boto3.dynamodb.types import TypeSerializer
 from cc_common.config import config, logger
 from cc_common.data_model.schema import LicenseRecordSchema, ProviderRecordSchema
-from cc_common.data_model.schema.common import Status, UpdateCategory
+from cc_common.data_model.schema.common import ProviderStatus, UpdateCategory
 from cc_common.data_model.schema.license.ingest import LicenseIngestSchema
 from cc_common.data_model.schema.license.record import LicenseUpdateRecordSchema
 from cc_common.exceptions import CCNotFoundException
@@ -154,7 +154,7 @@ def _populate_update_record(*, existing_license: dict, updated_values: dict, rem
             and updated_values['dateOfRenewal'] > original_values['dateOfRenewal']
         ):
             update_type = UpdateCategory.RENEWAL
-    elif updated_values == {'jurisdictionStatus': Status.INACTIVE}:
+    elif updated_values == {'jurisdictionStatus': ProviderStatus.INACTIVE.value}:
         update_type = UpdateCategory.DEACTIVATION
     if update_type is None:
         update_type = UpdateCategory.OTHER
@@ -180,7 +180,11 @@ def _populate_update_record(*, existing_license: dict, updated_values: dict, rem
 def _find_best_license(all_licenses: Iterable) -> dict:
     # Last issued active license, if there are any active licenses
     latest_active_licenses = sorted(
-        [license_data for license_data in all_licenses if license_data['jurisdictionStatus'] == 'active'],
+        [
+            license_data
+            for license_data in all_licenses
+            if license_data['jurisdictionStatus'] == ProviderStatus.ACTIVE.value
+        ],
         key=lambda x: x['dateOfIssuance'],
         reverse=True,
     )

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/ingest.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/ingest.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from boto3.dynamodb.types import TypeSerializer
 from cc_common.config import config, logger
 from cc_common.data_model.schema import LicenseRecordSchema, ProviderRecordSchema
-from cc_common.data_model.schema.common import ProviderStatus, UpdateCategory
+from cc_common.data_model.schema.common import ProviderEligibilityStatus, UpdateCategory
 from cc_common.data_model.schema.license.ingest import LicenseIngestSchema
 from cc_common.data_model.schema.license.record import LicenseUpdateRecordSchema
 from cc_common.exceptions import CCNotFoundException
@@ -154,7 +154,7 @@ def _populate_update_record(*, existing_license: dict, updated_values: dict, rem
             and updated_values['dateOfRenewal'] > original_values['dateOfRenewal']
         ):
             update_type = UpdateCategory.RENEWAL
-    elif updated_values == {'jurisdictionStatus': ProviderStatus.INACTIVE.value}:
+    elif updated_values == {'jurisdictionStatus': ProviderEligibilityStatus.INACTIVE.value}:
         update_type = UpdateCategory.DEACTIVATION
     if update_type is None:
         update_type = UpdateCategory.OTHER
@@ -183,7 +183,7 @@ def _find_best_license(all_licenses: Iterable) -> dict:
         [
             license_data
             for license_data in all_licenses
-            if license_data['jurisdictionStatus'] == ProviderStatus.ACTIVE.value
+            if license_data['jurisdictionStatus'] == ProviderEligibilityStatus.ACTIVE.value
         ],
         key=lambda x: x['dateOfIssuance'],
         reverse=True,

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_main.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_main.py
@@ -9,6 +9,7 @@ from tests import TstLambdas
 @mock_aws
 class TestCustomizeScopes(TstLambdas):
     def test_happy_path(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
         from main import customize_scopes
 
         with open('tests/resources/pre-token-event.json') as f:
@@ -21,6 +22,7 @@ class TestCustomizeScopes(TstLambdas):
                 'pk': f'USER#{sub}',
                 'sk': 'COMPACT#aslp',
                 'compact': 'aslp',
+                'status': StaffUserStatus.INACTIVE.value,
                 'permissions': {
                     'jurisdictions': {
                         # should correspond to the 'aslp/write' and 'aslp/al.write' scopes
@@ -36,6 +38,55 @@ class TestCustomizeScopes(TstLambdas):
             sorted(['profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write']),
             sorted(resp['response']['claimsAndScopeOverrideDetails']['accessTokenGeneration']['scopesToAdd']),
         )
+        # Check that the user's status is updated in the DB
+        record = self._table.get_item(Key={'pk': f'USER#{sub}', 'sk': 'COMPACT#aslp'})
+        self.assertEqual(StaffUserStatus.ACTIVE.value, record['Item']['status'])
+
+    def test_multiple_compact(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
+        from main import customize_scopes
+
+        with open('tests/resources/pre-token-event.json') as f:
+            event = json.load(f)
+        sub = event['request']['userAttributes']['sub']
+
+        # Create a DB record for this user's permissions, one for each of two compacts
+        for compact in ['aslp', 'octp']:
+            self._table.put_item(
+                Item={
+                    'pk': f'USER#{sub}',
+                    'sk': f'COMPACT#{compact}',
+                    'compact': compact,
+                    'status': StaffUserStatus.INACTIVE.value,
+                    'permissions': {
+                        'jurisdictions': {
+                            # should correspond to the 'aslp/write' and 'aslp/al.write' scopes
+                            'al': {'write'}
+                        },
+                    },
+                }
+            )
+
+        resp = customize_scopes(event, self.mock_context)
+
+        self.assertEqual(
+            sorted(
+                [
+                    'profile',
+                    'aslp/readGeneral',
+                    'aslp/write',
+                    'aslp/al.write',
+                    'octp/readGeneral',
+                    'octp/write',
+                    'octp/al.write',
+                ]
+            ),
+            sorted(resp['response']['claimsAndScopeOverrideDetails']['accessTokenGeneration']['scopesToAdd']),
+        )
+        # Check that the user's status is updated in the DB
+        for compact in ['aslp', 'octp']:
+            record = self._table.get_item(Key={'pk': f'USER#{sub}', 'sk': f'COMPACT#{compact}'})
+            self.assertEqual(StaffUserStatus.ACTIVE.value, record['Item']['status'])
 
     def test_unauthenticated(self):
         """
@@ -53,7 +104,7 @@ class TestCustomizeScopes(TstLambdas):
 
         self.assertEqual(None, resp['response']['claimsAndScopeOverrideDetails'])
 
-    @patch('main.UserScopes', autospec=True)
+    @patch('main.UserData', autospec=True)
     def test_error_getting_scopes(self, mock_get_scopes):
         """
         If something goes wrong calculating scopes, we will return none.

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/tests/test_user_scopes.py
@@ -12,7 +12,7 @@ class TestGetUserScopesFromDB(TstLambdas):
         self._user_sub = str(uuid4())
 
     def test_compact_ed_user(self):
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # Create a DB record for a typical compact executive director's permissions
         self._table.put_item(
@@ -24,14 +24,14 @@ class TestGetUserScopesFromDB(TstLambdas):
             }
         )
 
-        scopes = UserScopes(self._user_sub)
+        user_data = UserData(self._user_sub)
 
         self.assertEqual(
-            {'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/aslp.admin', 'aslp/aslp.readPrivate'}, scopes
+            {'profile', 'aslp/readGeneral', 'aslp/admin', 'aslp/aslp.admin', 'aslp/aslp.readPrivate'}, user_data.scopes
         )
 
     def test_board_ed_user(self):
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # Create a DB record for a typical board executive director's permissions
         self._table.put_item(
@@ -43,7 +43,7 @@ class TestGetUserScopesFromDB(TstLambdas):
             }
         )
 
-        scopes = UserScopes(self._user_sub)
+        user_data = UserData(self._user_sub)
 
         self.assertEqual(
             {
@@ -55,7 +55,7 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'aslp/al.write',
                 'aslp/al.readPrivate',
             },
-            scopes,
+            user_data.scopes,
         )
 
     def test_board_ed_user_multi_compact(self):
@@ -63,7 +63,7 @@ class TestGetUserScopesFromDB(TstLambdas):
         There is a small number of expected users who will represent multiple compacts within a state.
         We'll specifically verify handling of what their permissions may look like.
         """
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # Create a DB record for a board executive director's permissions
         self._table.put_item(
@@ -83,7 +83,7 @@ class TestGetUserScopesFromDB(TstLambdas):
             }
         )
 
-        scopes = UserScopes(self._user_sub)
+        user_data = UserData(self._user_sub)
 
         self.assertEqual(
             {
@@ -99,11 +99,11 @@ class TestGetUserScopesFromDB(TstLambdas):
                 'octp/al.admin',
                 'octp/al.write',
             },
-            scopes,
+            user_data.scopes,
         )
 
     def test_board_staff(self):
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # Create a DB record for a typical board staff user's permissions
         self._table.put_item(
@@ -119,23 +119,23 @@ class TestGetUserScopesFromDB(TstLambdas):
             }
         )
 
-        scopes = UserScopes(self._user_sub)
+        user_data = UserData(self._user_sub)
 
-        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write'}, scopes)
+        self.assertEqual({'profile', 'aslp/readGeneral', 'aslp/write', 'aslp/al.write'}, user_data.scopes)
 
     def test_missing_user(self):
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # We didn't specifically add a user for this test, so they will be missing
         with self.assertRaises(RuntimeError):
-            UserScopes(self._user_sub)
+            UserData(self._user_sub)
 
     def test_disallowed_compact(self):
         """
         If a user's permissions list an invalid compact, we will refuse to give them
         any scopes at all.
         """
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # Create a DB record with permissions for an unsupported compact
         self._table.put_item(
@@ -156,14 +156,14 @@ class TestGetUserScopesFromDB(TstLambdas):
         )
 
         with self.assertRaises(ValueError):
-            UserScopes(self._user_sub)
+            UserData(self._user_sub)
 
     def test_disallowed_compact_action(self):
         """
         If a user's permissions list an invalid compact, we will refuse to give them
         any scopes at all.
         """
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # Create a DB record with permissions for an unsupported compact action
         self._table.put_item(
@@ -180,14 +180,14 @@ class TestGetUserScopesFromDB(TstLambdas):
         )
 
         with self.assertRaises(ValueError):
-            UserScopes(self._user_sub)
+            UserData(self._user_sub)
 
     def test_disallowed_jurisdiction(self):
         """
         If a user's permissions list an invalid jurisdiction, we will refuse to give them
         any scopes at all.
         """
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # Create a DB record with permissions for an unsupported jurisdiction
         self._table.put_item(
@@ -200,14 +200,14 @@ class TestGetUserScopesFromDB(TstLambdas):
         )
 
         with self.assertRaises(ValueError):
-            UserScopes(self._user_sub)
+            UserData(self._user_sub)
 
     def test_disallowed_action(self):
         """
         If a user's permissions list an invalid action, we will refuse to give them
         any scopes at all.
         """
-        from user_scopes import UserScopes
+        from user_data import UserData
 
         # Create a DB record with permissions for an unsupported jurisdiction action
         self._table.put_item(
@@ -220,4 +220,4 @@ class TestGetUserScopesFromDB(TstLambdas):
         )
 
         with self.assertRaises(ValueError):
-            UserScopes(self._user_sub)
+            UserData(self._user_sub)

--- a/backend/compact-connect/lambdas/python/staff-users/handlers/__init__.py
+++ b/backend/compact-connect/lambdas/python/staff-users/handlers/__init__.py
@@ -1,5 +1,5 @@
 from aws_lambda_powertools import Logger
-from cc_common.data_model.schema.user import UserAPISchema
+from cc_common.data_model.schema.user.api import UserAPISchema
 
 logger = Logger()
 user_api_schema = UserAPISchema()

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/__init__.py
@@ -81,7 +81,7 @@ class TstFunction(TstLambdas):
 
     def _create_compact_staff_user(self, compacts: list[str]):
         """Create a compact-staff style user for each jurisdiction in the provided compact."""
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         schema = UserRecordSchema()
 
@@ -107,7 +107,7 @@ class TstFunction(TstLambdas):
 
     def _create_board_staff_users(self, compacts: list[str]):
         """Create a board-staff style user for each jurisdiction in the provided compact."""
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         schema = UserRecordSchema()
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/__init__.py
@@ -81,6 +81,7 @@ class TstFunction(TstLambdas):
 
     def _create_compact_staff_user(self, compacts: list[str]):
         """Create a compact-staff style user for each jurisdiction in the provided compact."""
+        from cc_common.data_model.schema.common import StaffUserStatus
         from cc_common.data_model.schema.user.record import UserRecordSchema
 
         schema = UserRecordSchema()
@@ -94,6 +95,7 @@ class TstFunction(TstLambdas):
                     {
                         'userId': sub,
                         'compact': compact,
+                        'status': StaffUserStatus.INACTIVE.value,
                         'attributes': {
                             'email': email,
                             'familyName': self.faker.unique.last_name(),
@@ -107,6 +109,7 @@ class TstFunction(TstLambdas):
 
     def _create_board_staff_users(self, compacts: list[str]):
         """Create a board-staff style user for each jurisdiction in the provided compact."""
+        from cc_common.data_model.schema.common import StaffUserStatus
         from cc_common.data_model.schema.user.record import UserRecordSchema
 
         schema = UserRecordSchema()
@@ -121,6 +124,7 @@ class TstFunction(TstLambdas):
                         {
                             'userId': sub,
                             'compact': compact,
+                            'status': StaffUserStatus.INACTIVE.value,
                             'attributes': {
                                 'email': email,
                                 'familyName': self.faker.unique.last_name(),

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_get_me.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_get_me.py
@@ -44,7 +44,7 @@ class TestGetMe(TstFunction):
 
         body = json.loads(resp['body'])
 
-        self.assertEqual({'type', 'dateOfUpdate', 'userId', 'attributes', 'permissions'}, body.keys())
+        self.assertEqual({'type', 'dateOfUpdate', 'userId', 'attributes', 'permissions', 'status'}, body.keys())
         # Verify we've successfully merged permissions from two compacts
         self.assertEqual(
             {

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_get_users.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_get_users.py
@@ -25,6 +25,8 @@ class TestGetUsers(TstFunction):
         self.assertEqual([], json.loads(resp['body'])['users'])
 
     def test_get_users_compact_admin(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
+
         # One user who is a compact admin in both aslp and octp
         self._create_compact_staff_user(compacts=['aslp', 'octp'])
         # One board user in each test jurisdiction (oh, ne, ky) with permissions in aslp and octp.
@@ -47,6 +49,9 @@ class TestGetUsers(TstFunction):
         body = json.loads(resp['body'])
 
         self.assertEqual(4, len(body['users']))
+        for user in body['users']:
+            # These are brand-new users, so they should all be inactive
+            self.assertEqual(StaffUserStatus.INACTIVE.value, user['status'])
 
     def test_get_users_paginated(self):
         self._create_compact_staff_user(compacts=['aslp', 'octp'])

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -10,6 +10,7 @@ class TestPatchUser(TstFunction):
     def test_patch_user(self):
         self._load_user_data()
 
+        from cc_common.data_model.schema.common import StaffUserStatus
         from handlers.users import patch_user
 
         with open('tests/resources/api-event.json') as f:
@@ -28,6 +29,7 @@ class TestPatchUser(TstFunction):
             {
                 'attributes': {'email': 'justin@example.org', 'familyName': 'Williams', 'givenName': 'Justin'},
                 'dateOfUpdate': '2024-09-12T23:59:59+00:00',
+                'status': StaffUserStatus.INACTIVE.value,
                 'permissions': {
                     'aslp': {
                         'actions': {'readPrivate': True},
@@ -41,6 +43,9 @@ class TestPatchUser(TstFunction):
         )
 
     def test_patch_user_document_path_overlap(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
+        from handlers.users import patch_user
+
         user = {
             'pk': 'USER#648864e8-10f1-702f-e666-2e0ff3482502',
             'sk': 'COMPACT#octp',
@@ -49,6 +54,7 @@ class TestPatchUser(TstFunction):
                 'familyName': 'User',
                 'givenName': 'Test',
             },
+            'status': StaffUserStatus.INACTIVE.value,
             'compact': 'octp',
             'dateOfUpdate': '2024-09-12T12:34:56+00:00',
             'famGiv': 'User#Test',
@@ -57,8 +63,6 @@ class TestPatchUser(TstFunction):
             'userId': '648864e8-10f1-702f-e666-2e0ff3482502',
         }
         self._table.put_item(Item=user)
-
-        from handlers.users import patch_user
 
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
@@ -101,11 +105,13 @@ class TestPatchUser(TstFunction):
                 },
                 'type': 'user',
                 'userId': '648864e8-10f1-702f-e666-2e0ff3482502',
+                'status': StaffUserStatus.INACTIVE.value,
             },
             user,
         )
 
     def test_patch_user_add_to_empty_actions(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
         from handlers.users import patch_user, post_user
 
         with open('tests/resources/api-event.json') as f:
@@ -140,9 +146,13 @@ class TestPatchUser(TstFunction):
         del user['userId']
         del user['dateOfUpdate']
 
+        # Add status to the comparison
+        api_user['status'] = StaffUserStatus.INACTIVE.value
+
         self.assertEqual(api_user, user)
 
     def test_patch_user_remove_all_actions(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
         from handlers.users import patch_user, post_user
 
         with open('tests/resources/api-event.json') as f:
@@ -175,6 +185,9 @@ class TestPatchUser(TstFunction):
         del user['userId']
         del user['dateOfUpdate']
 
+        # Add status to the comparison
+        api_user['status'] = StaffUserStatus.INACTIVE.value
+
         api_user['permissions'] = {'aslp': {'jurisdictions': {}}}
         self.assertEqual(api_user, user)
 
@@ -198,6 +211,7 @@ class TestPatchUser(TstFunction):
     def test_patch_user_allows_adding_read_private_permission(self):
         self._load_user_data()
 
+        from cc_common.data_model.schema.common import StaffUserStatus
         from handlers.users import patch_user
 
         with open('tests/resources/api-event.json') as f:
@@ -229,6 +243,7 @@ class TestPatchUser(TstFunction):
             {
                 'attributes': {'email': 'justin@example.org', 'familyName': 'Williams', 'givenName': 'Justin'},
                 'dateOfUpdate': '2024-09-12T23:59:59+00:00',
+                'status': StaffUserStatus.INACTIVE.value,
                 'permissions': {
                     'aslp': {
                         'actions': {'readPrivate': True},

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
@@ -8,6 +8,7 @@ from .. import TstFunction
 @mock_aws
 class TestPostUser(TstFunction):
     def test_post_user(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
         from handlers.users import post_user
 
         with open('tests/resources/api-event.json') as f:
@@ -34,9 +35,13 @@ class TestPostUser(TstFunction):
         del user['userId']
         del user['dateOfUpdate']
 
+        # Add status to the comparison
+        api_user['status'] = StaffUserStatus.INACTIVE.value
+
         self.assertEqual(api_user, user)
 
     def test_post_user_no_compact_perms_round_trip(self):
+        from cc_common.data_model.schema.common import StaffUserStatus
         from handlers.users import get_one_user, post_user
 
         with open('tests/resources/api-event.json') as f:
@@ -63,6 +68,9 @@ class TestPostUser(TstFunction):
         del user['dateOfUpdate']
         # The aslp.actions and aslp.jurisdictions.oh fields should be removed, since they are empty
         api_user['permissions'] = {'aslp': {'jurisdictions': {}}}
+
+        # Add status to the comparison
+        api_user['status'] = StaffUserStatus.INACTIVE.value
 
         self.assertEqual(api_user, user)
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/resources/api/user-response.json
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/resources/api/user-response.json
@@ -7,6 +7,7 @@
     "givenName": "Justin",
     "familyName": "Williams"
   },
+  "status": "inactive",
   "permissions": {
     "aslp": {
       "actions": {

--- a/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_data_model/test_paginated.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_data_model/test_paginated.py
@@ -15,7 +15,7 @@ class TestPaginated(TstLambdas):
 
     def test_pagination_parameters(self):
         from cc_common.data_model.query_paginator import paginated_query
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         calls = []
 
@@ -61,7 +61,7 @@ class TestPaginated(TstLambdas):
         multiple times to fill out the requested page size.
         """
         from cc_common.data_model.query_paginator import paginated_query
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         calls = []
 
@@ -118,7 +118,7 @@ class TestPaginated(TstLambdas):
         closely at the last_key behavior between each query.
         """
         from cc_common.data_model.query_paginator import paginated_query
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         calls = []
 
@@ -240,7 +240,7 @@ class TestPaginated(TstLambdas):
 
     def test_no_pagination_parameters(self):
         from cc_common.data_model.query_paginator import paginated_query
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         calls = []
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_data_model/test_schema/test_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_data_model/test_schema/test_user.py
@@ -8,7 +8,7 @@ from tests import TstLambdas
 
 class TestUserRecordSchema(TstLambdas):
     def test_transform_api_to_dynamo_permissions(self):
-        from cc_common.data_model.schema.user import UserAPISchema
+        from cc_common.data_model.schema.user.api import UserAPISchema
 
         with open('tests/resources/api/user-post.json') as f:
             api_user = json.load(f)
@@ -25,7 +25,8 @@ class TestUserRecordSchema(TstLambdas):
         self.assertEqual(dynamo_user['permissions'], dumped_user['permissions'])
 
     def test_transform_dynamo_to_api_permissions(self):
-        from cc_common.data_model.schema.user import UserAPISchema, UserRecordSchema
+        from cc_common.data_model.schema.user.api import UserAPISchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         with open('tests/resources/api/user-post.json') as f:
             api_user = json.load(f)
@@ -43,7 +44,7 @@ class TestUserRecordSchema(TstLambdas):
 
     def test_serde_record(self):
         """Test round-trip serialization/deserialization of user records"""
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         with open('../common/tests/resources/dynamo/user.json') as f:
             expected_user = TypeDeserializer().deserialize({'M': json.load(f)})
@@ -58,7 +59,7 @@ class TestUserRecordSchema(TstLambdas):
         self.assertEqual(expected_user, user_data)
 
     def test_invalid_record(self):
-        from cc_common.data_model.schema.user import UserRecordSchema
+        from cc_common.data_model.schema.user.record import UserRecordSchema
 
         with open('../common/tests/resources/dynamo/user.json') as f:
             user_data = TypeDeserializer().deserialize({'M': json.load(f)})

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -330,9 +330,13 @@ class ApiModel:
     def _staff_user_response_schema(self):
         return JsonSchema(
             type=JsonSchemaType.OBJECT,
-            required=['userId', 'attributes', 'permissions'],
+            required=['userId', 'attributes', 'permissions', 'status'],
             additional_properties=False,
-            properties={'userId': JsonSchema(type=JsonSchemaType.STRING), **self._common_staff_user_properties},
+            properties={
+                'userId': JsonSchema(type=JsonSchemaType.STRING),
+                'status': JsonSchema(type=JsonSchemaType.STRING, enum=['active', 'inactive']),
+                **self._common_staff_user_properties,
+            },
         )
 
     @property

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -118,7 +118,7 @@ class StaffUsers(UserPool):
                 'JURISDICTIONS': json.dumps(jurisdictions),
             },
         )
-        self.user_table.grant_read_data(scope_customization_handler)
+        self.user_table.grant_read_write_data(scope_customization_handler)
 
         NagSuppressions.add_resource_suppressions(
             scope_customization_handler,

--- a/backend/compact-connect/tests/resources/snapshots/PATCH_STAFF_USERS_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PATCH_STAFF_USERS_RESPONSE_SCHEMA.json
@@ -4,6 +4,13 @@
     "userId": {
       "type": "string"
     },
+    "status": {
+      "enum": [
+        "active",
+        "inactive"
+      ],
+      "type": "string"
+    },
     "attributes": {
       "additionalProperties": false,
       "properties": {
@@ -80,7 +87,8 @@
   "required": [
     "userId",
     "attributes",
-    "permissions"
+    "permissions",
+    "status"
   ],
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#"

--- a/backend/compact-connect/tests/resources/snapshots/POST_STAFF_USERS_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/POST_STAFF_USERS_RESPONSE_SCHEMA.json
@@ -4,6 +4,13 @@
     "userId": {
       "type": "string"
     },
+    "status": {
+      "enum": [
+        "active",
+        "inactive"
+      ],
+      "type": "string"
+    },
     "attributes": {
       "additionalProperties": false,
       "properties": {
@@ -80,7 +87,8 @@
   "required": [
     "userId",
     "attributes",
-    "permissions"
+    "permissions",
+    "status"
   ],
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#"

--- a/backend/compact-connect/tests/smoke/smoke_common.py
+++ b/backend/compact-connect/tests/smoke/smoke_common.py
@@ -31,7 +31,7 @@ os.environ['COMPACTS'] = json.dumps(COMPACTS)
 os.environ['JURISDICTIONS'] = json.dumps(JURISDICTIONS)
 
 # We have to import this after we've added the common lib to our path and environment
-from cc_common.data_model.schema.user import UserRecordSchema  # noqa: E402
+from cc_common.data_model.schema.user.record import UserRecordSchema  # noqa: E402
 
 _TEST_STAFF_USER_PASSWORD = 'TestPass123!'  # noqa: S105 test credential for test staff user
 _TEMP_STAFF_PASSWORD = 'TempPass123!'  # noqa: S105 temporary password for creating test staff users


### PR DESCRIPTION
### Description List
- Added one-time activated status field to staff user api
- Set status to `inactive` on account creation
- Set status to `active` on log-in

### Note:
This update will break existing staff users until their data can be amended with a new `status` field. I'm happy to do that in our test environments when it is time to merge.

Closes #
Closes #477 