### PR TITLE
Feat/monthly reports

### DIFF
--- a/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
+++ b/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
@@ -2,6 +2,7 @@ import type { LambdaInterface } from '@aws-lambda-powertools/commons/lib/esm/typ
 import { Logger } from '@aws-lambda-powertools/logger';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { SESClient } from '@aws-sdk/client-ses';
+import { S3Client } from '@aws-sdk/client-s3';
 import { Context } from 'aws-lambda';
 
 import { EnvironmentVariablesService } from '../lib/environment-variables-service';
@@ -16,6 +17,7 @@ const logger = new Logger({ logLevel: environmentVariables.getLogLevel() });
 interface LambdaProperties {
     dynamoDBClient: DynamoDBClient;
     sesClient: SESClient;
+    s3Client: S3Client;
 }
 
 export class Lambda implements LambdaInterface {
@@ -35,6 +37,7 @@ export class Lambda implements LambdaInterface {
         this.emailService = new EmailService({
             logger: logger,
             sesClient: props.sesClient,
+            s3Client: props.s3Client,
             compactConfigurationClient: compactConfigurationClient,
             jurisdictionClient: jurisdictionClient
         });
@@ -71,14 +74,15 @@ export class Lambda implements LambdaInterface {
             );
             break;
         case 'CompactTransactionReporting':
-            if (!event.templateVariables?.compactFinancialSummaryReportCSV ||
-                !event.templateVariables?.compactTransactionReportCSV) {
+            if (!event.templateVariables?.reportS3Path) {
                 throw new Error('Missing required template variables for CompactTransactionReporting template');
             }
             await this.emailService.sendCompactTransactionReportEmail(
                 event.compact,
-                event.templateVariables.compactFinancialSummaryReportCSV,
-                event.templateVariables.compactTransactionReportCSV
+                event.templateVariables.reportS3Path,
+                event.templateVariables.reportingCycle,
+                event.templateVariables.startDate,
+                event.templateVariables.endDate
             );
             break;
         case 'JurisdictionTransactionReporting':

--- a/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
+++ b/backend/compact-connect/lambdas/nodejs/email-notification-service/email-notification-service-lambda.ts
@@ -89,13 +89,16 @@ export class Lambda implements LambdaInterface {
             if (!event.jurisdiction) {
                 throw new Error('Missing required jurisdiction field for JurisdictionTransactionReporting template');
             }
-            if (!event.templateVariables?.jurisdictionTransactionReportCSV) {
+            if (!event.templateVariables?.reportS3Path) {
                 throw new Error('Missing required template variables for JurisdictionTransactionReporting template');
             }
             await this.emailService.sendJurisdictionTransactionReportEmail(
                 event.compact,
                 event.jurisdiction,
-                event.templateVariables.jurisdictionTransactionReportCSV
+                event.templateVariables.reportS3Path,
+                event.templateVariables.reportingCycle,
+                event.templateVariables.startDate,
+                event.templateVariables.endDate
             );
             break;
         default:

--- a/backend/compact-connect/lambdas/nodejs/email-notification-service/handler.ts
+++ b/backend/compact-connect/lambdas/nodejs/email-notification-service/handler.ts
@@ -1,10 +1,12 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { SESClient } from '@aws-sdk/client-ses';
+import { S3Client } from '@aws-sdk/client-s3';
 import { Lambda } from './email-notification-service-lambda';
 
 
 const lambda = new Lambda({
     dynamoDBClient: new DynamoDBClient(),
+    s3Client: new S3Client(),
     sesClient: new SESClient(),
 });
 

--- a/backend/compact-connect/lambdas/nodejs/ingest-event-reporter/lambda.ts
+++ b/backend/compact-connect/lambdas/nodejs/ingest-event-reporter/lambda.ts
@@ -1,6 +1,7 @@
 import type { LambdaInterface } from '@aws-lambda-powertools/commons/lib/esm/types';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { S3Client } from '@aws-sdk/client-s3';
 import { SESClient } from '@aws-sdk/client-ses';
 import { Context } from 'aws-lambda';
 
@@ -18,6 +19,7 @@ const logger = new Logger({ logLevel: environmentVariables.getLogLevel() });
 interface LambdaProperties {
     dynamoDBClient: DynamoDBClient;
     sesClient: SESClient;
+    s3Client: S3Client;
 }
 
 /*
@@ -46,6 +48,7 @@ export class Lambda implements LambdaInterface {
         this.emailService = new EmailService({
             logger: logger,
             sesClient: props.sesClient,
+            s3Client: props.s3Client,
             compactConfigurationClient: compactConfigurationClient,
             jurisdictionClient: this.jurisdictionClient
         });

--- a/backend/compact-connect/lambdas/nodejs/lib/email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email-service.ts
@@ -768,7 +768,7 @@ export class EmailService {
                     }
                 },
                 'props': {
-                    'text': '© 2024 CompactConnect'
+                    'text': '© 2025 CompactConnect'
                 }
             }
         };
@@ -819,6 +819,7 @@ export class EmailService {
                 },
                 'style': {
                     'textAlign': 'center',
+                    'color': '#242424',
                     'padding': {
                         'top': 28,
                         'bottom': 12,
@@ -848,6 +849,7 @@ export class EmailService {
                 'style': {
                     'fontSize': 16,
                     'fontWeight': 'normal',
+                    'color': '#A3A3A3',
                     'padding': {
                         'top': 24,
                         'bottom': 24,
@@ -856,6 +858,40 @@ export class EmailService {
                     }
                 },
                 'props': {
+                    'text': bodyText
+                }
+            }
+        };
+
+        report['root']['data']['childrenIds'].push(blockId);
+    }
+
+    /**
+     * Inserts a body text block into the email that can be formatted using markdown.
+     *
+     * @param report The report object to insert the block into.
+     * @param bodyText The text to insert into the block.
+     */
+    private insertMarkdownBody(report: TReaderDocument, bodyText: string) {
+        const blockId = `block-markdown-body`;
+
+        report[blockId] = {
+            'type': 'Text',
+            'data': {
+                'style': {
+                    'fontSize': 16,
+                    'fontWeight': 'normal',
+                    'textAlign': 'left',
+                    'color': '#A3A3A3',
+                    'padding': {
+                        'top': 24,
+                        'bottom': 24,
+                        'right': 40,
+                        'left': 40
+                    }
+                },
+                'props': {
+                    'markdown': true,
                     'text': bodyText
                 }
             }
@@ -892,12 +928,12 @@ export class EmailService {
 
         const report = JSON.parse(JSON.stringify(this.emailTemplate));
         const subject = `${reportingCycle === 'weekly' ? 'Weekly' : 'Monthly'} Report for Compact ${compact.toUpperCase()}`;
-        const bodyText = `Please find attached the ${reportingCycle} transaction reports for your compact for the period ${startDate} to ${endDate}:\n\n` +
-            '1. Financial Summary Report - A summary of all transactions and fees\n' +
-            '2. Transaction Detail Report - A detailed list of all transactions';
+        const bodyText = `Please find attached the ${reportingCycle} settled transaction reports for your compact for the period ${startDate} to ${endDate}:\n\n` +
+            '- Financial Summary Report - A summary of all transactions and fees\n' +
+            '- Transaction Detail Report - A detailed list of all transactions';
 
         this.insertHeader(report, subject);
-        this.insertBody(report, bodyText);
+        this.insertMarkdownBody(report, bodyText);
         this.insertFooter(report);
 
         const htmlContent = renderToStaticMarkup(report, { rootBlockId: 'root' });
@@ -951,8 +987,7 @@ export class EmailService {
 
         const report = JSON.parse(JSON.stringify(this.emailTemplate));
         const subject = `${jurisdictionConfig.jurisdictionName} ${reportingCycle === 'weekly' ? 'Weekly' : 'Monthly'} Report for Compact ${compact.toUpperCase()}`;
-        const bodyText = `Please find attached the ${reportingCycle} transaction report for your jurisdiction for the period ${startDate} to ${endDate}:\n\n` +
-            'Transaction Detail Report - A detailed list of all transactions';
+        const bodyText = `Please find attached the ${reportingCycle} settled transaction report for your jurisdiction for the period ${startDate} to ${endDate}.`;
 
         this.insertHeader(report, subject);
         this.insertBody(report, bodyText);

--- a/backend/compact-connect/lambdas/nodejs/lib/email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email-service.ts
@@ -928,9 +928,9 @@ export class EmailService {
 
         const report = JSON.parse(JSON.stringify(this.emailTemplate));
         const subject = `${reportingCycle === 'weekly' ? 'Weekly' : 'Monthly'} Report for Compact ${compact.toUpperCase()}`;
-        const bodyText = `Please find attached the ${reportingCycle} settled transaction reports for your compact for the period ${startDate} to ${endDate}:\n\n` +
-            '- Financial Summary Report - A summary of all transactions and fees\n' +
-            '- Transaction Detail Report - A detailed list of all transactions';
+        const bodyText = `Please find attached the ${reportingCycle} settled transaction reports for the compact for the period ${startDate} to ${endDate}:\n\n` +
+            '- Financial Summary Report - A summary of all settled transactions and fees\n' +
+            '- Transaction Detail Report - A detailed list of all settled transactions';
 
         this.insertHeader(report, subject);
         this.insertMarkdownBody(report, bodyText);
@@ -945,7 +945,7 @@ export class EmailService {
             errorMessage: 'Unable to send compact transaction report email',
             attachments: [
                 {
-                    filename: `${compact}-transaction-report.zip`,
+                    filename: `${compact}-settled-transaction-report.zip`,
                     content: reportZipBuffer,
                     contentType: 'application/zip'
                 }
@@ -1002,7 +1002,7 @@ export class EmailService {
             errorMessage: 'Unable to send jurisdiction transaction report email',
             attachments: [
                 {
-                    filename: `${jurisdiction}-transaction-report.zip`,
+                    filename: `${jurisdiction}-settled-transaction-report.zip`,
                     content: reportZipBuffer,
                     contentType: 'application/zip'
                 }

--- a/backend/compact-connect/lambdas/nodejs/lib/environment-variables-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/environment-variables-service.ts
@@ -5,7 +5,7 @@ export class EnvironmentVariablesService {
     private readonly uiBasePathUrlVariable = 'UI_BASE_PATH_URL';
     private readonly fromAddressVariable = 'FROM_ADDRESS';
     private readonly debugVariable = 'DEBUG';
-
+    private readonly transactionReportsBucketNameVariable = 'TRANSACTION_REPORTS_BUCKET_NAME';
 
     public getEnvVar(name: string): string {
         return process.env[name]?.trim() || '';
@@ -33,5 +33,9 @@ export class EnvironmentVariablesService {
 
     public getFromAddress() {
         return this.getEnvVar(this.fromAddressVariable);
+    }
+
+    public getTransactionReportsBucketName() {
+        return this.getEnvVar(this.transactionReportsBucketNameVariable);
     }
 }

--- a/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
@@ -239,8 +239,9 @@ describe('EmailNotificationServiceLambda', () => {
             expect(rawEmailString).toContain('Content-Type: application/zip');
             expect(rawEmailString).toContain('Content-Disposition: attachment; filename=aslp-transaction-report.zip');
             expect(rawEmailString).toContain('Weekly Report for Compact ASLP');
-            expect(rawEmailString).toContain('Please find attached the weekly transaction reports for your compact');
-            expect(rawEmailString).toContain('for the period 2024-03-01 to 2024-03-07')
+            expect(rawEmailString).toContain('Please find attached the weekly settled')
+            expect(rawEmailString).toContain('transaction reports for your compact for the period 2024-03-01 to')
+            expect(rawEmailString).toContain('2024-03-07:</p>')
             expect(rawEmailString).toContain('To: summary@example.com');
         });
 
@@ -332,8 +333,9 @@ describe('EmailNotificationServiceLambda', () => {
             expect(rawEmailString).toContain('Content-Type: application/zip');
             expect(rawEmailString).toContain('Content-Disposition: attachment; filename=oh-transaction-report.zip');
             expect(rawEmailString).toContain('Ohio Weekly Report for Compact ASLP');
-            expect(rawEmailString).toContain('Please find attached the weekly transaction report for your');
-            expect(rawEmailString).toContain('jurisdiction for the period 2024-03-01 to 2024-03-07');
+            expect(rawEmailString).toContain('Please find attached the weekly settled');
+            expect(rawEmailString).toContain('transaction report for your jurisdiction for the period 2024-03-01 to');
+            expect(rawEmailString).toContain('2024-03-07.</div>');
             expect(rawEmailString).toContain('To: ohio@example.com');
         });
 

--- a/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
@@ -189,7 +189,7 @@ describe('EmailNotificationServiceLambda', () => {
     });
 
     describe('Compact Transaction Report', () => {
-        const SAMPLE_TRANSACTION_REPORT_EVENT: EmailNotificationEvent = {
+        const SAMPLE_COMPACT_TRANSACTION_REPORT_EVENT: EmailNotificationEvent = {
             template: 'CompactTransactionReporting',
             recipientType: 'COMPACT_SUMMARY_REPORT',
             compact: 'aslp',
@@ -202,7 +202,7 @@ describe('EmailNotificationServiceLambda', () => {
         };
 
         it('should successfully send compact transaction report email', async () => {
-            const response = await lambda.handler(SAMPLE_TRANSACTION_REPORT_EVENT, {} as any);
+            const response = await lambda.handler(SAMPLE_COMPACT_TRANSACTION_REPORT_EVENT, {} as any);
 
             expect(response).toEqual({
                 message: 'Email message sent'
@@ -254,14 +254,14 @@ describe('EmailNotificationServiceLambda', () => {
                 }
             });
 
-            await expect(lambda.handler(SAMPLE_TRANSACTION_REPORT_EVENT, {} as any))
+            await expect(lambda.handler(SAMPLE_COMPACT_TRANSACTION_REPORT_EVENT, {} as any))
                 .rejects
                 .toThrow('No recipients found for compact aslp with recipient type COMPACT_SUMMARY_REPORT');
         });
 
         it('should throw error when required template variables are missing', async () => {
             const eventWithMissingVariables: EmailNotificationEvent = {
-                ...SAMPLE_TRANSACTION_REPORT_EVENT,
+                ...SAMPLE_COMPACT_TRANSACTION_REPORT_EVENT,
                 templateVariables: {}
             };
 
@@ -270,19 +270,19 @@ describe('EmailNotificationServiceLambda', () => {
                 .toThrow('Missing required template variables for CompactTransactionReporting template');
         });
 
-        it('should throw error when S3 fails to return report', async () => {
+        it('should throw error when S3 fails to return compact report', async () => {
             mockS3Client.on(GetObjectCommand).resolves({
                 Body: undefined
             });
 
-            await expect(lambda.handler(SAMPLE_TRANSACTION_REPORT_EVENT, {} as any))
+            await expect(lambda.handler(SAMPLE_COMPACT_TRANSACTION_REPORT_EVENT, {} as any))
                 .rejects
                 .toThrow('Failed to retrieve report from S3: compact/aslp/reports/test-report.zip');
         });
     });
 
     describe('Jurisdiction Transaction Report', () => {
-        const SAMPLE_TRANSACTION_REPORT_EVENT: EmailNotificationEvent = {
+        const SAMPLE_JURISDICTION_TRANSACTION_REPORT_EVENT: EmailNotificationEvent = {
             template: 'JurisdictionTransactionReporting',
             recipientType: 'JURISDICTION_SUMMARY_REPORT',
             compact: 'aslp',
@@ -296,7 +296,7 @@ describe('EmailNotificationServiceLambda', () => {
         };
 
         it('should successfully send jurisdiction transaction report email', async () => {
-            const response = await lambda.handler(SAMPLE_TRANSACTION_REPORT_EVENT, {} as any);
+            const response = await lambda.handler(SAMPLE_JURISDICTION_TRANSACTION_REPORT_EVENT, {} as any);
 
             expect(response).toEqual({
                 message: 'Email message sent'
@@ -348,14 +348,14 @@ describe('EmailNotificationServiceLambda', () => {
                 }
             });
 
-            await expect(lambda.handler(SAMPLE_TRANSACTION_REPORT_EVENT, {} as any))
+            await expect(lambda.handler(SAMPLE_JURISDICTION_TRANSACTION_REPORT_EVENT, {} as any))
                 .rejects
                 .toThrow('No recipients found for jurisdiction oh in compact aslp');
         });
 
         it('should throw error when required template variables are missing', async () => {
             const eventWithMissingVariables: EmailNotificationEvent = {
-                ...SAMPLE_TRANSACTION_REPORT_EVENT,
+                ...SAMPLE_JURISDICTION_TRANSACTION_REPORT_EVENT,
                 templateVariables: {}
             };
 
@@ -366,7 +366,7 @@ describe('EmailNotificationServiceLambda', () => {
 
         it('should throw error when jurisdiction is missing', async () => {
             const eventWithMissingJurisdiction: EmailNotificationEvent = {
-                ...SAMPLE_TRANSACTION_REPORT_EVENT,
+                ...SAMPLE_JURISDICTION_TRANSACTION_REPORT_EVENT,
                 jurisdiction: undefined
             };
 
@@ -375,12 +375,12 @@ describe('EmailNotificationServiceLambda', () => {
                 .toThrow('Missing required jurisdiction field for JurisdictionTransactionReporting template');
         });
 
-        it('should throw error when S3 fails to return report', async () => {
+        it('should throw error when S3 fails to return jurisdiction report', async () => {
             mockS3Client.on(GetObjectCommand).resolves({
                 Body: undefined
             });
 
-            await expect(lambda.handler(SAMPLE_TRANSACTION_REPORT_EVENT, {} as any))
+            await expect(lambda.handler(SAMPLE_JURISDICTION_TRANSACTION_REPORT_EVENT, {} as any))
                 .rejects
                 .toThrow('Failed to retrieve report from S3: compact/aslp/reports/jurisdiction-transactions/jurisdiction/oh/reporting-cycle/weekly/2024/03/07/transaction-report.zip');
         });

--- a/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
@@ -236,11 +236,11 @@ describe('EmailNotificationServiceLambda', () => {
             expect(rawEmailData).toBeDefined();
             const rawEmailString = rawEmailData?.toString();
 
-            expect(rawEmailString).toContain('Content-Type: application/zip');
-            expect(rawEmailString).toContain('Content-Disposition: attachment; filename=aslp-transaction-report.zip');
+            expect(rawEmailString).toContain('Content-Type: application/zip; name=aslp-settled-transaction-report.zip');
+            expect(rawEmailString).toContain('Content-Disposition: attachment;');
             expect(rawEmailString).toContain('Weekly Report for Compact ASLP');
             expect(rawEmailString).toContain('Please find attached the weekly settled')
-            expect(rawEmailString).toContain('transaction reports for your compact for the period 2024-03-01 to')
+            expect(rawEmailString).toContain('transaction reports for the compact for the period 2024-03-01 to')
             expect(rawEmailString).toContain('2024-03-07:</p>')
             expect(rawEmailString).toContain('To: summary@example.com');
         });
@@ -331,7 +331,7 @@ describe('EmailNotificationServiceLambda', () => {
             const rawEmailString = rawEmailData?.toString();
 
             expect(rawEmailString).toContain('Content-Type: application/zip');
-            expect(rawEmailString).toContain('Content-Disposition: attachment; filename=oh-transaction-report.zip');
+            expect(rawEmailString).toContain('Content-Disposition: attachment; filename=oh-settled-transaction-report.zip');
             expect(rawEmailString).toContain('Ohio Weekly Report for Compact ASLP');
             expect(rawEmailString).toContain('Please find attached the weekly settled');
             expect(rawEmailString).toContain('transaction report for your jurisdiction for the period 2024-03-01 to');

--- a/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-notification-service-lambda.test.ts
@@ -239,9 +239,9 @@ describe('EmailNotificationServiceLambda', () => {
             expect(rawEmailString).toContain('Content-Type: application/zip; name=aslp-settled-transaction-report.zip');
             expect(rawEmailString).toContain('Content-Disposition: attachment;');
             expect(rawEmailString).toContain('Weekly Report for Compact ASLP');
-            expect(rawEmailString).toContain('Please find attached the weekly settled')
-            expect(rawEmailString).toContain('transaction reports for the compact for the period 2024-03-01 to')
-            expect(rawEmailString).toContain('2024-03-07:</p>')
+            expect(rawEmailString).toContain('Please find attached the weekly settled');
+            expect(rawEmailString).toContain('transaction reports for the compact for the period 2024-03-01 to');
+            expect(rawEmailString).toContain('2024-03-07:</p>');
             expect(rawEmailString).toContain('To: summary@example.com');
         });
 

--- a/backend/compact-connect/lambdas/nodejs/tests/email-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-service.test.ts
@@ -2,6 +2,9 @@ import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { SendEmailCommand, SendRawEmailCommand, SESClient } from '@aws-sdk/client-ses';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { Readable } from 'stream';
+import { sdkStreamMixin } from '@smithy/util-stream';
 import * as nodemailer from 'nodemailer';
 import { EmailService } from '../lib/email-service';
 import { CompactConfigurationClient } from '../lib/compact-configuration-client';
@@ -11,6 +14,7 @@ import {
     SAMPLE_UNMARSHALLED_INGEST_FAILURE_ERROR_RECORD,
     SAMPLE_UNMARSHALLED_VALIDATION_ERROR_RECORD
 } from './sample-records';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 jest.mock('nodemailer');
 
@@ -46,9 +50,13 @@ const SAMPLE_JURISDICTION_CONFIG = {
 const asSESClient = (mock: ReturnType<typeof mockClient>) =>
     mock as unknown as SESClient;
 
+const asS3Client = (mock: ReturnType<typeof mockClient>) =>
+    mock as unknown as S3Client;
+
 describe('Email Service', () => {
     let emailService: EmailService;
     let mockSESClient: ReturnType<typeof mockClient>;
+    let mockS3Client: ReturnType<typeof mockClient>;
     let mockCompactConfigurationClient: jest.Mocked<CompactConfigurationClient>;
     let mockJurisdictionClient: jest.Mocked<JurisdictionClient>;
     const MOCK_TRANSPORT = {
@@ -58,6 +66,7 @@ describe('Email Service', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockSESClient = mockClient(SESClient);
+        mockS3Client = mockClient(S3Client);
         mockCompactConfigurationClient = {
             getCompactConfiguration: jest.fn()
         } as any;
@@ -69,6 +78,7 @@ describe('Email Service', () => {
         // Reset environment variables
         process.env.FROM_ADDRESS = 'noreply@example.org';
         process.env.UI_BASE_PATH_URL = 'https://app.test.compactconnect.org';
+        process.env.TRANSACTION_REPORTS_BUCKET_NAME = 'test-transaction-reports-bucket';
 
         // Set up default successful responses
         mockSESClient.on(SendEmailCommand).resolves({
@@ -84,6 +94,7 @@ describe('Email Service', () => {
         emailService = new EmailService({
             logger: new Logger({ serviceName: 'test' }),
             sesClient: asSESClient(mockSESClient),
+            s3Client: asS3Client(mockS3Client),
             compactConfigurationClient: mockCompactConfigurationClient,
             jurisdictionClient: mockJurisdictionClient
         });
@@ -327,19 +338,39 @@ describe('Email Service', () => {
     });
 
     describe('Compact Transaction Report', () => {
-        const SAMPLE_SUMMARY_CSV = 'Total Transactions,2\nTotal Compact Fees,$21.00\n';
-        const SAMPLE_DETAIL_CSV = 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n';
-
         beforeEach(() => {
             mockCompactConfigurationClient.getCompactConfiguration.mockResolvedValue(SAMPLE_COMPACT_CONFIG);
+            
+            // Create a mock stream that implements the required AWS SDK interfaces
+            const mockStream = sdkStreamMixin(
+                new Readable({
+                    read() {
+                        this.push(Buffer.from('test data'));
+                        this.push(null);
+                    }
+                })
+            );
+
+            // Mock S3 response
+            mockS3Client.on(GetObjectCommand).resolves({
+                Body: mockStream
+            });
         });
 
-        it('should send email with CSV attachments', async () => {
+        it('should send email with zip attachment', async () => {
             await emailService.sendCompactTransactionReportEmail(
                 'aslp',
-                SAMPLE_SUMMARY_CSV,
-                SAMPLE_DETAIL_CSV
+                'test-bucket/compact/aslp/reports/test-report.zip',
+                'weekly',
+                '2024-03-01',
+                '2024-03-07'
             );
+
+            // Verify S3 was queried for the report
+            expect(mockS3Client).toHaveReceivedCommandWith(GetObjectCommand, {
+                Bucket: 'test-transaction-reports-bucket',
+                Key: 'compact/aslp/reports/test-report.zip'
+            });
 
             // Verify nodemailer transport was created with correct SES config
             expect(nodemailer.createTransport).toHaveBeenCalledWith({
@@ -354,33 +385,30 @@ describe('Email Service', () => {
                 from: 'Compact Connect <noreply@example.org>',
                 to: ['summary@example.com'],
                 subject: 'Weekly Report for Compact ASLP',
-                html: expect.stringContaining('Please find attached the weekly transaction reports for your compact'),
+                html: expect.stringContaining('Please find attached the weekly transaction reports for your compact for the period 2024-03-01 to 2024-03-07'),
                 attachments: [
                     {
-                        filename: 'financial-summary-report.csv',
-                        content: SAMPLE_SUMMARY_CSV,
-                        contentType: 'text/csv'
-                    },
-                    {
-                        filename: 'transaction-detail-report.csv',
-                        content: SAMPLE_DETAIL_CSV,
-                        contentType: 'text/csv'
+                        filename: 'aslp-transaction-report.zip',
+                        content: expect.any(Buffer),
+                        contentType: 'application/zip'
                     }
                 ]
             });
         });
 
-        it('should use compact summary report recipients', async () => {
+        it('should use monthly subject when reporting cycle is monthly', async () => {
             await emailService.sendCompactTransactionReportEmail(
                 'aslp',
-                SAMPLE_SUMMARY_CSV,
-                SAMPLE_DETAIL_CSV
+                'test-bucket/compact/aslp/reports/test-report.zip',
+                'monthly',
+                '2024-03-01',
+                '2024-03-31'
             );
 
-            // Verify the correct recipients were used
             expect(MOCK_TRANSPORT.sendMail).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    to: ['summary@example.com']
+                    subject: 'Monthly Report for Compact ASLP',
+                    html: expect.stringContaining('Please find attached the monthly transaction reports for your compact for the period 2024-03-01 to 2024-03-31')
                 })
             );
         });
@@ -393,9 +421,28 @@ describe('Email Service', () => {
 
             await expect(emailService.sendCompactTransactionReportEmail(
                 'aslp',
-                SAMPLE_SUMMARY_CSV,
-                SAMPLE_DETAIL_CSV
+                'test-bucket/compact/aslp/reports/test-report.zip',
+                'weekly',
+                '2024-03-01',
+                '2024-03-07'
             )).rejects.toThrow('No recipients found for compact aslp with recipient type COMPACT_SUMMARY_REPORT');
+
+            // Verify no email was sent
+            expect(MOCK_TRANSPORT.sendMail).not.toHaveBeenCalled();
+        });
+
+        it('should throw error when S3 fails to return report', async () => {
+            mockS3Client.on(GetObjectCommand).resolves({
+                Body: undefined
+            });
+
+            await expect(emailService.sendCompactTransactionReportEmail(
+                'aslp',
+                'test-bucket/compact/aslp/reports/test-report.zip',
+                'weekly',
+                '2024-03-01',
+                '2024-03-07'
+            )).rejects.toThrow('Failed to retrieve report from S3: test-bucket/compact/aslp/reports/test-report.zip');
 
             // Verify no email was sent
             expect(MOCK_TRANSPORT.sendMail).not.toHaveBeenCalled();

--- a/backend/compact-connect/lambdas/nodejs/tests/email-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-service.test.ts
@@ -390,7 +390,7 @@ describe('Email Service', () => {
                 from: 'Compact Connect <noreply@example.org>',
                 to: ['summary@example.com'],
                 subject: 'Weekly Report for Compact ASLP',
-                html: expect.stringContaining('Please find attached the weekly transaction reports for your compact for the period 2024-03-01 to 2024-03-07'),
+                html: expect.stringContaining('Please find attached the weekly settled transaction reports for your compact for the period 2024-03-01 to 2024-03-07'),
                 attachments: [
                     {
                         filename: 'aslp-transaction-report.zip',
@@ -413,7 +413,7 @@ describe('Email Service', () => {
             expect(MOCK_TRANSPORT.sendMail).toHaveBeenCalledWith(
                 expect.objectContaining({
                     subject: 'Monthly Report for Compact ASLP',
-                    html: expect.stringContaining('Please find attached the monthly transaction reports for your compact for the period 2024-03-01 to 2024-03-31')
+                    html: expect.stringContaining('Please find attached the monthly settled transaction reports for your compact for the period 2024-03-01 to 2024-03-31')
                 })
             );
         });
@@ -504,7 +504,7 @@ describe('Email Service', () => {
                 from: 'Compact Connect <noreply@example.org>',
                 to: ['oh-summary@example.com'],
                 subject: 'Ohio Weekly Report for Compact ASLP',
-                html: expect.stringContaining('Please find attached the weekly transaction report for your jurisdiction for the period 2024-03-01 to 2024-03-07'),
+                html: expect.stringContaining('Please find attached the weekly settled transaction report for your jurisdiction for the period 2024-03-01 to 2024-03-07'),
                 attachments: [
                     {
                         filename: 'oh-transaction-report.zip',
@@ -528,7 +528,7 @@ describe('Email Service', () => {
             expect(MOCK_TRANSPORT.sendMail).toHaveBeenCalledWith(
                 expect.objectContaining({
                     subject: 'Ohio Monthly Report for Compact ASLP',
-                    html: expect.stringContaining('Please find attached the monthly transaction report for your jurisdiction for the period 2024-03-01 to 2024-03-31')
+                    html: expect.stringContaining('Please find attached the monthly settled transaction report for your jurisdiction for the period 2024-03-01 to 2024-03-31')
                 })
             );
         });

--- a/backend/compact-connect/lambdas/nodejs/tests/email-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-service.test.ts
@@ -390,10 +390,10 @@ describe('Email Service', () => {
                 from: 'Compact Connect <noreply@example.org>',
                 to: ['summary@example.com'],
                 subject: 'Weekly Report for Compact ASLP',
-                html: expect.stringContaining('Please find attached the weekly settled transaction reports for your compact for the period 2024-03-01 to 2024-03-07'),
+                html: expect.stringContaining('Please find attached the weekly settled transaction reports for the compact for the period 2024-03-01 to 2024-03-07'),
                 attachments: [
                     {
-                        filename: 'aslp-transaction-report.zip',
+                        filename: 'aslp-settled-transaction-report.zip',
                         content: expect.any(Buffer),
                         contentType: 'application/zip'
                     }
@@ -413,7 +413,7 @@ describe('Email Service', () => {
             expect(MOCK_TRANSPORT.sendMail).toHaveBeenCalledWith(
                 expect.objectContaining({
                     subject: 'Monthly Report for Compact ASLP',
-                    html: expect.stringContaining('Please find attached the monthly settled transaction reports for your compact for the period 2024-03-01 to 2024-03-31')
+                    html: expect.stringContaining('Please find attached the monthly settled transaction reports for the compact for the period 2024-03-01 to 2024-03-31')
                 })
             );
         });
@@ -507,7 +507,7 @@ describe('Email Service', () => {
                 html: expect.stringContaining('Please find attached the weekly settled transaction report for your jurisdiction for the period 2024-03-01 to 2024-03-07'),
                 attachments: [
                     {
-                        filename: 'oh-transaction-report.zip',
+                        filename: 'oh-settled-transaction-report.zip',
                         content: expect.any(Buffer),
                         contentType: 'application/zip'
                     }

--- a/backend/compact-connect/lambdas/nodejs/tests/event-client.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/event-client.test.ts
@@ -2,6 +2,7 @@ import { Logger } from '@aws-lambda-powertools/logger';
 import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import { EventClient } from '../lib/event-client';
+import { describe, it, expect, beforeAll, beforeEach, jest } from '@jest/globals';
 
 
 /*

--- a/backend/compact-connect/lambdas/nodejs/tests/jurisdiction-client.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/jurisdiction-client.test.ts
@@ -3,6 +3,7 @@ import 'aws-sdk-client-mock-jest';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { DynamoDBClient, QueryCommand, GetItemCommand } from '@aws-sdk/client-dynamodb';
 import { JurisdictionClient } from '../lib/jurisdiction-client';
+import { describe, it, expect, beforeAll, beforeEach, jest } from '@jest/globals';
 
 
 const SAMPLE_JURISDICTION_ITEMS = [

--- a/backend/compact-connect/lambdas/nodejs/tests/lambda.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lambda.test.ts
@@ -172,6 +172,7 @@ describe('Nightly runs', () => {
     it('should not send an email if there were no ingest events', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
         const mockS3Client = mockClient(S3Client);
+
         mockDynamoDBClient.on(QueryCommand).callsFake((input) => {
             const tableName = input.TableName;
 
@@ -271,6 +272,7 @@ describe('Weekly runs', () => {
     it('should send an "All\'s Well" email if there were success events without failures', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
         const mockS3Client = mockClient(S3Client);
+
         mockDynamoDBClient.on(QueryCommand).callsFake((input) => {
             const tableName = input.TableName;
 
@@ -335,6 +337,7 @@ describe('Weekly runs', () => {
     it('should send "no license updates" email if there were no events', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
         const mockS3Client = mockClient(S3Client);
+
         mockDynamoDBClient.on(QueryCommand).callsFake((input) => {
             const tableName = input.TableName;
 
@@ -381,6 +384,7 @@ describe('Weekly runs', () => {
     it('should send a report email and not an alls well, when there were errors', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
         const mockS3Client = mockClient(S3Client);
+
         mockDynamoDBClient.on(QueryCommand).callsFake((input) => {
             const tableName = input.TableName;
 

--- a/backend/compact-connect/lambdas/nodejs/tests/lambda.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lambda.test.ts
@@ -3,6 +3,7 @@ import 'aws-sdk-client-mock-jest';
 import { Context, EventBridgeEvent } from 'aws-lambda';
 import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
 import { SendEmailCommand, SESClient } from '@aws-sdk/client-ses';
+import { S3Client } from '@aws-sdk/client-s3';
 
 import { Lambda } from '../ingest-event-reporter/lambda';
 import { EmailService } from '../lib/email-service';
@@ -13,6 +14,7 @@ import {
     SAMPLE_VALIDATION_ERROR_RECORD,
     SAMPLE_INGEST_SUCCESS_RECORD
 } from './sample-records';
+
 
 
 const SAMPLE_NIGHTLY_EVENT: IEventBridgeEvent = {
@@ -47,6 +49,8 @@ const asDynamoDBClient = (mock: ReturnType<typeof mockClient>) =>
   mock as unknown as DynamoDBClient;
 const asSESClient = (mock: ReturnType<typeof mockClient>) =>
     mock as unknown as SESClient;
+const asS3Client = (mock: ReturnType<typeof mockClient>) =>
+    mock as unknown as S3Client;
 
 
 jest.mock('../lib/email-service');
@@ -71,6 +75,7 @@ const mockSendNoLicenseUpdatesEmail = jest.fn(
 
 describe('Nightly runs', () => {
     let mockSESClient: ReturnType<typeof mockClient>;
+    let mockS3Client: ReturnType<typeof mockClient>;
     let mockEmailService: jest.Mocked<EmailService>;
     let lambda: Lambda;
 
@@ -133,6 +138,7 @@ describe('Nightly runs', () => {
 
         lambda = new Lambda({
             dynamoDBClient: asDynamoDBClient(mockDynamoDBClient),
+            s3Client: asS3Client(mockS3Client),
             sesClient: asSESClient(mockSESClient)
         });
 
@@ -165,7 +171,7 @@ describe('Nightly runs', () => {
 
     it('should not send an email if there were no ingest events', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
-
+        const mockS3Client = mockClient(S3Client);
         mockDynamoDBClient.on(QueryCommand).callsFake((input) => {
             const tableName = input.TableName;
 
@@ -185,6 +191,7 @@ describe('Nightly runs', () => {
 
         lambda = new Lambda({
             dynamoDBClient: asDynamoDBClient(mockDynamoDBClient),
+            s3Client: asS3Client(mockS3Client),
             sesClient: asSESClient(mockSESClient)
         });
 
@@ -218,11 +225,13 @@ describe('Nightly runs', () => {
 
     it('should let DynamoDB errors escape', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
+        const mockS3Client = mockClient(S3Client);
 
         mockDynamoDBClient.on(QueryCommand).rejects(new Error('DynamoDB error'));
 
         lambda = new Lambda({
             dynamoDBClient: asDynamoDBClient(mockDynamoDBClient),
+            s3Client: asS3Client(mockS3Client),
             sesClient: asSESClient(mockSESClient)
         });
 
@@ -261,7 +270,7 @@ describe('Weekly runs', () => {
 
     it('should send an "All\'s Well" email if there were success events without failures', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
-
+        const mockS3Client = mockClient(S3Client);
         mockDynamoDBClient.on(QueryCommand).callsFake((input) => {
             const tableName = input.TableName;
 
@@ -300,6 +309,7 @@ describe('Weekly runs', () => {
 
         lambda = new Lambda({
             dynamoDBClient: asDynamoDBClient(mockDynamoDBClient),
+            s3Client: asS3Client(mockS3Client),
             sesClient: asSESClient(mockSESClient)
         });
 
@@ -324,7 +334,7 @@ describe('Weekly runs', () => {
 
     it('should send "no license updates" email if there were no events', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
-
+        const mockS3Client = mockClient(S3Client);
         mockDynamoDBClient.on(QueryCommand).callsFake((input) => {
             const tableName = input.TableName;
 
@@ -345,6 +355,7 @@ describe('Weekly runs', () => {
 
         lambda = new Lambda({
             dynamoDBClient: asDynamoDBClient(mockDynamoDBClient),
+            s3Client: asS3Client(mockS3Client),
             sesClient: asSESClient(mockSESClient)
         });
 
@@ -369,7 +380,7 @@ describe('Weekly runs', () => {
 
     it('should send a report email and not an alls well, when there were errors', async () => {
         const mockDynamoDBClient = mockClient(DynamoDBClient);
-
+        const mockS3Client = mockClient(S3Client);
         mockDynamoDBClient.on(QueryCommand).callsFake((input) => {
             const tableName = input.TableName;
 
@@ -408,6 +419,7 @@ describe('Weekly runs', () => {
 
         lambda = new Lambda({
             dynamoDBClient: asDynamoDBClient(mockDynamoDBClient),
+            s3Client: asS3Client(mockS3Client),
             sesClient: asSESClient(mockSESClient)
         });
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/config.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/config.py
@@ -194,6 +194,10 @@ class _Config:
         return TransactionClient(self)
 
     @property
+    def transaction_reports_bucket_name(self):
+        return os.environ['TRANSACTION_REPORTS_BUCKET_NAME']
+
+    @property
     def transaction_history_table_name(self):
         return os.environ['TRANSACTION_HISTORY_TABLE_NAME']
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
@@ -53,7 +53,6 @@ class TransactionClient:
         """
         # Calculate the month keys we need to query based on the epoch timestamps
         start_date = datetime.fromtimestamp(start_epoch, tz=UTC)
-        end_date = datetime.fromtimestamp(end_epoch, tz=UTC)
 
         # Build query parameters
         query_params = {

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
@@ -111,7 +111,7 @@ class TransactionClient:
             start_sk = f'COMPACT#{compact}#TIME#{start_epoch}'
             end_sk = f'COMPACT#{compact}#TIME#{end_epoch}'
             response = self.config.transaction_history_table.query(
-                KeyConditionExpression=(Key('pk').eq(pk) & Key('sk').gte(start_sk) & Key('sk').lt(end_sk)),
+                KeyConditionExpression=Key('pk').eq(pk) & Key('sk').between(start_sk, end_sk),
                 **query_params,
             )
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/transaction_client.py
@@ -65,14 +65,21 @@ class TransactionClient:
 
         # Generate list of months to query
         current_date = start_date.replace(day=1)
+        current_epoch = current_date.timestamp()
         months_to_query = []
-        while current_date <= end_date:
+        # here we check if the end epoch is greater than the current epoch
+        # if it is, we add the current month to the list of months to query
+        # we then move to the first day of the next month
+        # we repeat this process until the end epoch is less than the current epoch
+        while end_epoch > current_epoch:
             months_to_query.append(current_date.strftime('%Y-%m'))
             # Move to first day of next month
             if current_date.month == 12:
                 current_date = current_date.replace(year=current_date.year + 1, month=1)
             else:
                 current_date = current_date.replace(month=current_date.month + 1)
+
+            current_epoch = current_date.timestamp()
 
         # Query each month in the range
         for month in months_to_query:

--- a/backend/compact-connect/lambdas/python/common/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/tests/function/__init__.py
@@ -37,12 +37,14 @@ class TstFunction(TstLambdas):
         self.create_compact_configuration_table()
         self.create_provider_table()
         self.create_users_table()
+        self.create_transaction_history_table()
 
         # Adding a waiter allows for testing against an actual AWS account, if needed
         waiter = self._compact_configuration_table.meta.client.get_waiter('table_exists')
         waiter.wait(TableName=self._compact_configuration_table.name)
         waiter.wait(TableName=self._provider_table.name)
         waiter.wait(TableName=self._users_table.name)
+        waiter.wait(TableName=self._transaction_history_table.name)
 
         # Create a new Cognito user pool
         cognito_client = boto3.client('cognito-idp')
@@ -122,15 +124,29 @@ class TstFunction(TstLambdas):
             ],
         )
 
+    def create_transaction_history_table(self):
+        self._transaction_history_table = boto3.resource('dynamodb').create_table(
+            KeySchema=[{'AttributeName': 'pk', 'KeyType': 'HASH'}, {'AttributeName': 'sk', 'KeyType': 'RANGE'}],
+            AttributeDefinitions=[
+                {'AttributeName': 'pk', 'AttributeType': 'S'},
+                {'AttributeName': 'sk', 'AttributeType': 'S'},
+            ],
+            TableName=os.environ['TRANSACTION_HISTORY_TABLE_NAME'],
+            BillingMode='PAY_PER_REQUEST',
+        )
+
     def delete_resources(self):
         self._compact_configuration_table.delete()
         self._provider_table.delete()
         self._users_table.delete()
+        self._transaction_history_table.delete()
 
         waiter = self._users_table.meta.client.get_waiter('table_not_exists')
         waiter.wait(TableName=self._compact_configuration_table.name)
         waiter.wait(TableName=self._provider_table.name)
         waiter.wait(TableName=self._users_table.name)
+        waiter = self._transaction_history_table.meta.client.get_waiter('table_not_exists')
+        waiter.wait(TableName=self._transaction_history_table.name)
 
         # Delete the Cognito user pool
         cognito_client = boto3.client('cognito-idp')

--- a/backend/compact-connect/lambdas/python/common/tests/function/test_data_model/test_transaction_client.py
+++ b/backend/compact-connect/lambdas/python/common/tests/function/test_data_model/test_transaction_client.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+from moto import mock_aws
+
+from .. import TstFunction
+
+
+@mock_aws
+class TestClient(TstFunction):
+    def test_transaction_history_edge_times(self):
+        """
+        Test for internal consistency in how transactions are stored and reported, when times land
+        right on the edge of the reporting window.
+        """
+        from cc_common.data_model.transaction_client import TransactionClient
+
+        client = TransactionClient(self.config)
+
+        # Create some records on the edge of the window we want to query
+        start_time_string = '2024-01-01T00:00:00Z'
+        end_time_string = '2024-01-08T00:00:00Z'
+        start_time = datetime.fromisoformat(start_time_string)
+        end_time = datetime.fromisoformat(end_time_string)
+
+        client.store_transactions(
+            compact='aslp',
+            transactions=[
+                # One at the beginning of the window
+                {
+                    'transactionId': '123',
+                    'transactionProcessor': 'authorize.net',
+                    'batch': {'batchId': 'abc', 'settlementTimeUTC': start_time_string},
+                },
+                # One at the end of the window
+                {
+                    'transactionId': '456',
+                    'transactionProcessor': 'authorize.net',
+                    'batch': {'batchId': 'def', 'settlementTimeUTC': end_time_string},
+                },
+            ],
+        )
+
+        # Query the transactions in the window
+        transactions = client.get_transactions_in_range(
+            compact='aslp',
+            start_epoch=int(start_time.timestamp()),
+            end_epoch=int(end_time.timestamp()),
+        )
+
+        # We expect to get the first back but not the second. Any more or less will result in
+        # under or over reporting of transactions across reports.
+        self.assertEqual(
+            {
+                'pk': 'COMPACT#aslp#TRANSACTIONS#MONTH#2024-01',
+                'sk': 'COMPACT#aslp#TIME#1704067200#BATCH#abc#TX#123',
+                'transactionId': '123',
+                'transactionProcessor': 'authorize.net',
+                'batch': {'batchId': 'abc', 'settlementTimeUTC': start_time_string},
+            },
+            transactions[0],
+        )

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_history.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_history.py
@@ -32,8 +32,8 @@ def process_settled_transactions(event: dict, context: LambdaContext) -> dict:  
     current_batch_id = event.get('currentBatchId')
     processed_batch_ids = event.get('processedBatchIds', [])
 
-    # Calculate time range for the last 24 hours
-    end_time = config.current_standard_datetime
+    # This lambda is triggered at noon UTC-4, so we calculate the time range for the last 24 hours
+    end_time = config.current_standard_datetime.replace(hour=16, minute=0, second=0, microsecond=0)
     start_time = end_time - timedelta(days=1)
 
     # Format timestamps for API call

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -117,8 +117,8 @@ def _store_jurisdiction_reports_in_s3(
     """
     date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
     base_path = (
-        f"compact/{compact}/reports/jurisdiction-transactions/"
-        f"jurisdiction/{jurisdiction}/{end_time.strftime('%Y/%m/%d')}"
+        f"compact/{compact}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
+        f"reporting-cycle/{reporting_cycle}/{end_time.strftime('%Y/%m/%d')}"
     )
     
     # Define paths for all report files
@@ -127,7 +127,7 @@ def _store_jurisdiction_reports_in_s3(
         'report_zip': f"{base_path}/{jurisdiction}-{date_range}-report.zip",
     }
     
-    s3_client = boto3.client('s3')
+    s3_client = config.s3_client
     
     # Store gzipped transaction detail
     gzip_buffer = BytesIO()

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -69,12 +69,12 @@ def _get_query_date_range(reporting_cycle: str) -> tuple[datetime, datetime]:
     :return: Tuple of (start_time, end_time) in UTC for DynamoDB queries
     """
     if reporting_cycle == 'weekly':
-        # we can return the start and end times directly because the BETWEEN condition is 
+        # we can return the start and end times directly because the BETWEEN condition is
         # inclusive for the beginning range and exclusive at the end range
         return _get_weekly_date_boundaries(config.current_standard_datetime)
 
-    elif reporting_cycle == 'monthly':
-        start_time, end_time =  _get_monthly_date_boundaries(config.current_standard_datetime)
+    if reporting_cycle == 'monthly':
+        start_time, end_time = _get_monthly_date_boundaries(config.current_standard_datetime)
         query_start = start_time
         # we need to add 1 second to the end time to ensure we capture all settled transactions in the month
         query_end = end_time + timedelta(seconds=1)
@@ -82,7 +82,6 @@ def _get_query_date_range(reporting_cycle: str) -> tuple[datetime, datetime]:
         return query_start, query_end
 
     raise ValueError(f'Invalid reporting cycle: {reporting_cycle}')
-
 
 
 def _store_compact_reports_in_s3(

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -17,7 +17,7 @@ from cc_common.exceptions import CCInternalException, CCNotFoundException
 
 def _get_weekly_date_boundaries(current_time: datetime) -> tuple[datetime, datetime]:
     """Calculate the start and end times for weekly reporting boundaries.
-    
+
     :param current_time: The current time in UTC
     :return: Tuple of (start_time, end_time) for the weekly report boundaries
     """
@@ -30,15 +30,13 @@ def _get_weekly_date_boundaries(current_time: datetime) -> tuple[datetime, datet
 
 def _get_monthly_date_boundaries(current_time: datetime) -> tuple[datetime, datetime]:
     """Calculate the start and end times for monthly reporting boundaries.
-    
+
     :param current_time: The current time in UTC
     :return: Tuple of (start_time, end_time) for the monthly report boundaries
     """
     # Reports run shortly after midnight on the first day of the month
     # End time is the last microsecond of the previous month
-    end_time = current_time.replace(
-        hour=0, minute=0, second=0, microsecond=0
-    ) - timedelta(microseconds=1)
+    end_time = current_time.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(microseconds=1)
     # Start time is the first microsecond of the previous month
     start_time = end_time.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     return start_time, end_time
@@ -54,10 +52,9 @@ def _get_display_date_range(reporting_cycle: str) -> tuple[datetime, datetime]:
     """
     if reporting_cycle == 'weekly':
         return _get_weekly_date_boundaries(config.current_standard_datetime)
-    elif reporting_cycle == 'monthly':
+    if reporting_cycle == 'monthly':
         return _get_monthly_date_boundaries(config.current_standard_datetime)
-    else:
-        raise ValueError(f'Invalid reporting cycle: {reporting_cycle}')
+    raise ValueError(f'Invalid reporting cycle: {reporting_cycle}')
 
 
 def _get_query_date_range(reporting_cycle: str) -> tuple[datetime, datetime]:
@@ -212,7 +209,7 @@ def generate_transaction_reports(event: dict, context: LambdaContext) -> dict:  
 
     # Get both query and display date ranges
     query_start_time, query_end_time = _get_query_date_range(reporting_cycle)
-    
+
     # Convert query times to epochs for DynamoDB
     start_epoch = int(query_start_time.timestamp())
     end_epoch = int(query_end_time.timestamp())

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -105,6 +105,9 @@ def _store_compact_reports_in_s3(
     )
 
     # Define paths for all report files
+    # Currently, we are only sending the .zip file in the email reporting, but we are storing the
+    # .gz files for potential future references as admins may want to pull down reporting for previous
+    # periods
     paths = {
         'financial_summary_gz': f'{base_path}/{compact}-financial-summary-{date_range}.csv.gz',
         'transaction_detail_gz': f'{base_path}/{compact}-transaction-detail-{date_range}.csv.gz',
@@ -162,6 +165,9 @@ def _store_jurisdiction_reports_in_s3(
     )
 
     # Define paths for all report files
+    # Currently, we are only sending the .zip file in the email reporting, but we are storing the
+    # .gz files for potential future references as admins may want to pull down reporting for previous
+    # periods.
     paths = {
         'transaction_detail_gz': f'{base_path}/{jurisdiction}-{date_range}-transaction-detail.csv.gz',
         'report_zip': f'{base_path}/{jurisdiction}-{date_range}-report.zip',

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -78,8 +78,8 @@ def _store_compact_reports_in_s3(
     
     # Define paths for all report files
     paths = {
-        'financial_summary_gz': f"{base_path}/{compact}-{date_range}-financial-summary.csv.gz",
-        'transaction_detail_gz': f"{base_path}/{compact}-{date_range}-transaction-detail.csv.gz",
+        'financial_summary_gz': f"{base_path}/{compact}-financial-summary-{date_range}.csv.gz",
+        'transaction_detail_gz': f"{base_path}/{compact}-transaction-detail-{date_range}.csv.gz",
         'report_zip': f"{base_path}/{compact}-{date_range}-report.zip",
     }
     
@@ -100,8 +100,8 @@ def _store_compact_reports_in_s3(
     # Create and store combined zip with uncompressed CSVs
     zip_buffer = BytesIO()
     with ZipFile(zip_buffer, 'w', compression=ZIP_DEFLATED) as zip_file:
-        zip_file.writestr('financial-summary.csv', summary_report.encode('utf-8'))
-        zip_file.writestr('transaction-detail.csv', transaction_detail.encode('utf-8'))
+        zip_file.writestr(f'{compact}-financial-summary-{date_range}.csv', summary_report.encode('utf-8'))
+        zip_file.writestr(f'{compact}-transaction-detail-{date_range}.csv', transaction_detail.encode('utf-8'))
     s3_client.put_object(Bucket=bucket_name, Key=paths['report_zip'], Body=zip_buffer.getvalue())
     
     return paths
@@ -150,7 +150,7 @@ def _store_jurisdiction_reports_in_s3(
     # Create and store zip with uncompressed CSV
     zip_buffer = BytesIO()
     with ZipFile(zip_buffer, 'w', compression=ZIP_DEFLATED) as zip_file:
-        zip_file.writestr('transaction-detail.csv', transaction_detail.encode('utf-8'))
+        zip_file.writestr(f'{jurisdiction}-transaction-detail-{date_range}.csv', transaction_detail.encode('utf-8'))
     s3_client.put_object(Bucket=bucket_name, Key=paths['report_zip'], Body=zip_buffer.getvalue())
     
     return paths
@@ -391,7 +391,7 @@ def _generate_compact_transaction_report(transactions: list[dict], providers: di
             'Licensee First Name',
             'Licensee Last Name',
             'Licensee Id',
-            'Transaction Date',
+            'Transaction Settlement Date',
             'State',
             'State Fee',
             'Compact Fee',
@@ -461,7 +461,7 @@ def _generate_jurisdiction_reports(
                 'First Name',
                 'Last Name',
                 'Licensee Id',
-                'Transaction Date',
+                'Transaction Settlement Date',
                 'State Fee',
                 'State',
                 'Compact Fee',

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -27,9 +27,7 @@ def _get_date_range_for_reporting_cycle(reporting_cycle: str) -> tuple[datetime,
     if reporting_cycle == 'weekly':
         # This report is run on Friday 10:00 PM UTC
         # we want to capture the full week, so we set the end time to 10:00 PM UTC of the current day
-        end_time = config.current_standard_datetime.replace(
-        hour=22, minute=0, second=0, microsecond=0
-        )
+        end_time = config.current_standard_datetime.replace(hour=22, minute=0, second=0, microsecond=0)
         # Go back 7 days to capture the full week
         start_time = end_time - timedelta(days=7)
     elif reporting_cycle == 'monthly':
@@ -57,7 +55,7 @@ def _store_compact_reports_in_s3(
     bucket_name: str,
 ) -> dict[str, str]:
     """Store compact reports in S3 with appropriate compression formats.
-    
+
     :param compact: Compact name
     :param reporting_cycle: Either 'weekly' or 'monthly'
     :param start_time: Report start time
@@ -72,35 +70,35 @@ def _store_compact_reports_in_s3(
         f"compact/{compact}/reports/compact-transactions/reporting-cycle/{reporting_cycle}/"
         f"{end_time.strftime('%Y/%m/%d')}"
     )
-    
+
     # Define paths for all report files
     paths = {
-        'financial_summary_gz': f"{base_path}/{compact}-financial-summary-{date_range}.csv.gz",
-        'transaction_detail_gz': f"{base_path}/{compact}-transaction-detail-{date_range}.csv.gz",
-        'report_zip': f"{base_path}/{compact}-{date_range}-report.zip",
+        'financial_summary_gz': f'{base_path}/{compact}-financial-summary-{date_range}.csv.gz',
+        'transaction_detail_gz': f'{base_path}/{compact}-transaction-detail-{date_range}.csv.gz',
+        'report_zip': f'{base_path}/{compact}-{date_range}-report.zip',
     }
-    
+
     s3_client = config.s3_client
-    
+
     # Store gzipped financial summary
     gzip_buffer = BytesIO()
     with gzip.GzipFile(fileobj=gzip_buffer, mode='wb') as gz:
         gz.write(summary_report.encode('utf-8'))
     s3_client.put_object(Bucket=bucket_name, Key=paths['financial_summary_gz'], Body=gzip_buffer.getvalue())
-    
+
     # Store gzipped transaction detail
     gzip_buffer = BytesIO()
     with gzip.GzipFile(fileobj=gzip_buffer, mode='wb') as gz:
         gz.write(transaction_detail.encode('utf-8'))
     s3_client.put_object(Bucket=bucket_name, Key=paths['transaction_detail_gz'], Body=gzip_buffer.getvalue())
-    
+
     # Create and store combined zip with uncompressed CSVs
     zip_buffer = BytesIO()
     with ZipFile(zip_buffer, 'w', compression=ZIP_DEFLATED) as zip_file:
         zip_file.writestr(f'{compact}-financial-summary-{date_range}.csv', summary_report.encode('utf-8'))
         zip_file.writestr(f'{compact}-transaction-detail-{date_range}.csv', transaction_detail.encode('utf-8'))
     s3_client.put_object(Bucket=bucket_name, Key=paths['report_zip'], Body=zip_buffer.getvalue())
-    
+
     return paths
 
 
@@ -114,7 +112,7 @@ def _store_jurisdiction_reports_in_s3(
     bucket_name: str,
 ) -> dict[str, str]:
     """Store jurisdiction reports in S3 with appropriate compression formats.
-    
+
     :param compact: Compact name
     :param jurisdiction: Jurisdiction postal code
     :param reporting_cycle: Either 'weekly' or 'monthly'
@@ -129,27 +127,27 @@ def _store_jurisdiction_reports_in_s3(
         f"compact/{compact}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
         f"reporting-cycle/{reporting_cycle}/{end_time.strftime('%Y/%m/%d')}"
     )
-    
+
     # Define paths for all report files
     paths = {
-        'transaction_detail_gz': f"{base_path}/{jurisdiction}-{date_range}-transaction-detail.csv.gz",
-        'report_zip': f"{base_path}/{jurisdiction}-{date_range}-report.zip",
+        'transaction_detail_gz': f'{base_path}/{jurisdiction}-{date_range}-transaction-detail.csv.gz',
+        'report_zip': f'{base_path}/{jurisdiction}-{date_range}-report.zip',
     }
-    
+
     s3_client = config.s3_client
-    
+
     # Store gzipped transaction detail
     gzip_buffer = BytesIO()
     with gzip.GzipFile(fileobj=gzip_buffer, mode='wb') as gz:
         gz.write(transaction_detail.encode('utf-8'))
     s3_client.put_object(Bucket=bucket_name, Key=paths['transaction_detail_gz'], Body=gzip_buffer.getvalue())
-    
+
     # Create and store zip with uncompressed CSV
     zip_buffer = BytesIO()
     with ZipFile(zip_buffer, 'w', compression=ZIP_DEFLATED) as zip_file:
         zip_file.writestr(f'{jurisdiction}-transaction-detail-{date_range}.csv', transaction_detail.encode('utf-8'))
     s3_client.put_object(Bucket=bucket_name, Key=paths['report_zip'], Body=zip_buffer.getvalue())
-    
+
     return paths
 
 
@@ -164,7 +162,7 @@ def generate_transaction_reports(event: dict, context: LambdaContext) -> dict:  
     compact = event['compact']
     reporting_cycle = event['reportingCycle']
     logger.info('Generating transaction reports', compact=compact, reporting_cycle=reporting_cycle)
-    
+
     # this is used to track any errors that occur when generating the reports
     # without preventing valid reports from being sent
     lambda_error_messages = []
@@ -172,7 +170,7 @@ def generate_transaction_reports(event: dict, context: LambdaContext) -> dict:  
     # Initialize clients
     data_client = config.data_client
     transaction_client = config.transaction_client
-    
+
     # Get the S3 bucket name
     bucket_name = config.transaction_reports_bucket_name
 

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -28,12 +28,12 @@ def _get_display_date_range(reporting_cycle: str) -> tuple[datetime, datetime]:
         start_time = end_time - timedelta(days=7)
         return start_time, end_time
     if reporting_cycle == 'monthly':
-        # Reports run shortly after midnight on the first day of the month
-        # knowing this, we can use the current date to get the start and end of the month.
-        # By going back 1 day from the current date, we get the last day of the previous month.
-        end_time = config.current_standard_datetime.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(
-            days=1
-        )
+        # Reports run shortly after midnight on the first day of the month.
+        # Knowing this, we can use the current date to get the start and end of the month.
+        # By going back 1 day from the first day of the current month, we get the last day of the previous month.
+        end_time = config.current_standard_datetime.replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        ) - timedelta(days=1)
         # Start time is the first day of the previous month
         start_time = end_time.replace(day=1)
         return start_time, end_time

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -25,17 +25,15 @@ def _get_date_range_for_reporting_cycle(reporting_cycle: str) -> tuple[datetime,
     """
 
     if reporting_cycle == 'weekly':
-        # Set end time to 11:59:59.999999 UTC of the current day
+        # This report is run on Friday 10:00 PM UTC
+        # we want to capture the full week, so we set the end time to 10:00 PM UTC of the current day
         end_time = config.current_standard_datetime.replace(
-        hour=11, minute=59, second=59, microsecond=999999
+        hour=22, minute=0, second=0, microsecond=0
         )
-        # Go back 7 days and set to noon UTC time (12:00:00.000) to capture the full week
-        start_time_day = (end_time - timedelta(days=7))
-        start_time = start_time_day.replace(
-            hour=12, minute=0, second=0, microsecond=0
-        )
+        # Go back 7 days to capture the full week
+        start_time = end_time - timedelta(days=7)
     elif reporting_cycle == 'monthly':
-        # The monthly report is triggered at midnight UTC of the first day of the month
+        # The monthly report is triggered a little after midnight UTC of the first day of the month
         # we report on the previous month, so we set the end time to 23:59:59.999999 UTC of the previous day
         # to capture the full month
         end_time = config.current_standard_datetime.replace(
@@ -45,7 +43,7 @@ def _get_date_range_for_reporting_cycle(reporting_cycle: str) -> tuple[datetime,
         start_time = end_time.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     else:
         raise ValueError(f'Invalid reporting cycle: {reporting_cycle}')
-    
+
     return start_time, end_time
 
 

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -18,7 +18,7 @@ from cc_common.exceptions import CCInternalException, CCNotFoundException
 def _get_date_range_for_reporting_cycle(reporting_cycle: str) -> tuple[datetime, datetime]:
     """Calculate the start and end dates for the reporting cycle.
 
-    The weekly reporting cycle captures noon to noon of the previous week.
+    The weekly reporting cycle captures the previous week.
     The monthly reporting cycle captures the first day of the month to the last day of the month.
     :param reporting_cycle: Either 'weekly' or 'monthly'
     :return: Tuple of (start_time, end_time) in UTC

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import csv
-import gzip
 import json
 from datetime import datetime, timedelta
 from decimal import Decimal

--- a/backend/compact-connect/lambdas/python/purchases/tests/__init__.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/__init__.py
@@ -17,6 +17,7 @@ class TstLambdas(TestCase):
                 'AWS_DEFAULT_REGION': 'us-east-1',
                 'COMPACT_CONFIGURATION_TABLE_NAME': 'compact-configuration-table',
                 'TRANSACTION_HISTORY_TABLE_NAME': 'transaction-history-table',
+                'TRANSACTION_REPORTS_BUCKET_NAME': 'transaction-report-bucket',
                 'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': 'email-notification-service',
                 'COMPACTS': '["aslp", "octp", "coun"]',
                 'JURISDICTIONS': '["ne", "oh", "ky"]',

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/__init__.py
@@ -35,7 +35,8 @@ class TstFunction(TstLambdas):
         self.create_provider_table()
         self.create_transaction_history_table()
         self._transaction_reports_bucket = boto3.resource('s3').create_bucket(
-            Bucket=os.environ['TRANSACTION_REPORTS_BUCKET_NAME'])
+            Bucket=os.environ['TRANSACTION_REPORTS_BUCKET_NAME']
+        )
 
     def create_compact_configuration_table(self):
         self._compact_configuration_table = boto3.resource('dynamodb').create_table(

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/__init__.py
@@ -34,6 +34,8 @@ class TstFunction(TstLambdas):
         self.create_compact_configuration_table()
         self.create_provider_table()
         self.create_transaction_history_table()
+        self._transaction_reports_bucket = boto3.resource('s3').create_bucket(
+            Bucket=os.environ['TRANSACTION_REPORTS_BUCKET_NAME'])
 
     def create_compact_configuration_table(self):
         self._compact_configuration_table = boto3.resource('dynamodb').create_table(
@@ -92,6 +94,8 @@ class TstFunction(TstLambdas):
         self._compact_configuration_table.delete()
         self._provider_table.delete()
         self._transaction_history_table.delete()
+        self._transaction_reports_bucket.objects.delete()
+        self._transaction_reports_bucket.delete()
 
     def _load_compact_configuration_data(self):
         """Use the canned test resources to load compact and jurisdiction information into the DB"""

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E501  line-too-long The lines displaying the csv file contents are long, but they are necessary for the test.
-import csv
 import json
 from io import BytesIO
 from zipfile import ZipFile
@@ -273,7 +272,7 @@ class TestGenerateTransactionReports(TstFunction):
         
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
-            with zip_file.open('financial-summary.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
                 summary_content = f.read().decode('utf-8')
                 self.assertEqual(
                     'Total Transactions,0\nTotal Compact Fees,$0.00\nState Fees (Ohio),$0.00\n',
@@ -281,10 +280,10 @@ class TestGenerateTransactionReports(TstFunction):
                 )
             
             # Check transaction detail
-            with zip_file.open('transaction-detail.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-transaction-detail-{date_range}.csv') as f:
                 detail_content = f.read().decode('utf-8')
                 self.assertEqual(
-                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\n'
+                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id\n'
                     'No transactions for this period,,,,,,,\n',
                     detail_content
                 )
@@ -296,10 +295,10 @@ class TestGenerateTransactionReports(TstFunction):
         )
         
         with ZipFile(BytesIO(ohio_zip_obj['Body'].read())) as zip_file:
-            with zip_file.open('transaction-detail.csv') as f:
+            with zip_file.open(f'oh-transaction-detail-{date_range}.csv') as f:
                 ohio_content = f.read().decode('utf-8')
                 self.assertEqual(
-                    'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                    'First Name,Last Name,Licensee Id,Transaction Settlement Date,State Fee,State,Compact Fee,Transaction Id\n'
                     'No transactions for this period,,,,,,,\n'
                     ',,,,,,,\n'
                     'Privileges Purchased,Total State Amount,,,,,,\n'
@@ -413,7 +412,7 @@ class TestGenerateTransactionReports(TstFunction):
         
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
-            with zip_file.open('financial-summary.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
                 summary_content = f.read().decode('utf-8')
                 self.assertEqual(
                     'Total Transactions,2\n'
@@ -424,10 +423,10 @@ class TestGenerateTransactionReports(TstFunction):
                 )
             
             # Check transaction detail
-            with zip_file.open('transaction-detail.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-transaction-detail-{date_range}.csv') as f:
                 detail_content = f.read().decode('utf-8')
                 self.assertEqual(
-                    f'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\n'
+                    f'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id\n'
                     f'{mock_user_1["givenName"]},{mock_user_1["familyName"]},{mock_user_1["providerId"]},03-30-2025,OH,100,10.50,{MOCK_TRANSACTION_ID}\n'
                     f'{mock_user_2["givenName"]},{mock_user_2["familyName"]},{mock_user_2["providerId"]},04-01-2025,KY,100,10.50,{MOCK_TRANSACTION_ID}\n',
                     detail_content
@@ -445,11 +444,11 @@ class TestGenerateTransactionReports(TstFunction):
             )
             
             with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
-                with zip_file.open('transaction-detail.csv') as f:
+                with zip_file.open(f'{jurisdiction}-transaction-detail-{date_range}.csv') as f:
                     content = f.read().decode('utf-8')
                     transaction_date = '03-30-2025' if jurisdiction == 'oh' else '04-01-2025'
                     self.assertEqual(
-                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                        'First Name,Last Name,Licensee Id,Transaction Settlement Date,State Fee,State,Compact Fee,Transaction Id\n'
                         f'{user["givenName"]},{user["familyName"]},{user["providerId"]},{transaction_date},100,{jurisdiction.upper()},10.50,{MOCK_TRANSACTION_ID}\n'
                         ',,,,,,,\n'
                         'Privileges Purchased,Total State Amount,,,,,,\n'
@@ -556,7 +555,7 @@ class TestGenerateTransactionReports(TstFunction):
         
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
-            with zip_file.open('financial-summary.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
                 summary_content = f.read().decode('utf-8')
                 self.assertEqual(
                     'Total Transactions,1\n'
@@ -568,10 +567,10 @@ class TestGenerateTransactionReports(TstFunction):
                 )
             
             # Check transaction detail
-            with zip_file.open('transaction-detail.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-transaction-detail-{date_range}.csv') as f:
                 detail_content = f.read().decode('utf-8')
                 expected_lines = [
-                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id']
+                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id']
                 for state in ['OH', 'KY', 'NE']:
                     expected_lines.append(
                         f'{mock_user["givenName"]},{mock_user["familyName"]},{mock_user["providerId"]},03-30-2025,{state},100,10.50,{MOCK_TRANSACTION_ID}'
@@ -590,10 +589,10 @@ class TestGenerateTransactionReports(TstFunction):
             )
             
             with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
-                with zip_file.open('transaction-detail.csv') as f:
+                with zip_file.open(f'{jurisdiction}-transaction-detail-{date_range}.csv') as f:
                     content = f.read().decode('utf-8')
                     self.assertEqual(
-                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                        'First Name,Last Name,Licensee Id,Transaction Settlement Date,State Fee,State,Compact Fee,Transaction Id\n'
                         f'{mock_user["givenName"]},{mock_user["familyName"]},{mock_user["providerId"]},03-30-2025,100,{jurisdiction.upper()},10.50,{MOCK_TRANSACTION_ID}\n'
                         ',,,,,,,\n'
                         'Privileges Purchased,Total State Amount,,,,,,\n'
@@ -654,7 +653,7 @@ class TestGenerateTransactionReports(TstFunction):
         
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
-            with zip_file.open('financial-summary.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
                 summary_content = f.read().decode('utf-8')
                 self.assertEqual(
                     'Total Transactions,600\n'
@@ -665,11 +664,11 @@ class TestGenerateTransactionReports(TstFunction):
                 )
             
             # Check transaction detail
-            with zip_file.open('transaction-detail.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-transaction-detail-{date_range}.csv') as f:
                 detail_content = f.read().decode('utf-8').split('\n')
                 # Verify header
                 self.assertEqual(
-                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id',
+                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id',
                     detail_content[0]
                 )
                 
@@ -702,12 +701,12 @@ class TestGenerateTransactionReports(TstFunction):
             )
             
             with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
-                with zip_file.open('transaction-detail.csv') as f:
+                with zip_file.open(f'{jurisdiction}-transaction-detail-{date_range}.csv') as f:
                     content = f.read().decode('utf-8').split('\n')
                     
                     # Verify header
                     self.assertEqual(
-                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id',
+                        'First Name,Last Name,Licensee Id,Transaction Settlement Date,State Fee,State,Compact Fee,Transaction Id',
                         content[0]
                     )
 
@@ -792,7 +791,7 @@ class TestGenerateTransactionReports(TstFunction):
 
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
-            with zip_file.open('financial-summary.csv') as f:
+            with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
                 summary_content = f.read().decode('utf-8')
                 # Verify compact summary includes unknown jurisdiction
                 self.assertEqual(

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -183,6 +183,8 @@ class TestGenerateTransactionReports(TstFunction):
                 record.update(jurisdiction)
                 self._compact_configuration_table.put_item(Item=record)
 
+    # event bridge triggers the weekly report at noon UTC-4 timezone
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_transaction_reports_sends_csv_with_zero_values_when_no_transactions(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
@@ -194,9 +196,12 @@ class TestGenerateTransactionReports(TstFunction):
 
         # Set up mocked S3 bucket
 
-        # Get the expected date range
-        end_time = self.config.current_standard_datetime.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
-        start_time = end_time - timedelta(days=7)
+        # Calculate expected date range
+        # the end date should be the current day at 11:59:59.999999 UTC
+        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
+        # the start date should be 7 days ago at noon UTC
+        start_time_day = end_time - timedelta(days=7)
+        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         # Generate the reports
@@ -302,7 +307,8 @@ class TestGenerateTransactionReports(TstFunction):
                     ohio_content
                 )
 
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    # event bridge triggers the weekly report at noon UTC-4 timezone
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_collects_transactions_across_two_months(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
@@ -332,8 +338,11 @@ class TestGenerateTransactionReports(TstFunction):
         )
 
         # Calculate expected date range
-        end_time = datetime.fromisoformat('2025-04-03T00:00:00+00:00')  # Next day at midnight
-        start_time = end_time - timedelta(days=7)
+        # the end date should be the current day at 11:59:59.999999 UTC
+        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
+        # the start date should be 7 days ago at noon UTC
+        start_time_day = end_time - timedelta(days=7)
+        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
@@ -448,7 +457,8 @@ class TestGenerateTransactionReports(TstFunction):
                         content
                     )
 
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    # event bridge triggers the weekly report at noon UTC-4 timezone
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_with_multiple_privileges_in_single_transaction(self, mock_lambda_client):
         """Test processing of transactions with multiple privileges in a single transaction."""
@@ -471,8 +481,11 @@ class TestGenerateTransactionReports(TstFunction):
         )
 
         # Calculate expected date range
-        end_time = datetime.fromisoformat('2025-04-03T00:00:00+00:00')  # Next day at midnight
-        start_time = end_time - timedelta(days=7)
+        # the end date should be the current day at 11:59:59.999999 UTC
+        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
+        # the start date should be 7 days ago at noon UTC
+        start_time_day = end_time - timedelta(days=7)
+        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
@@ -588,7 +601,8 @@ class TestGenerateTransactionReports(TstFunction):
                         content
                     )
 
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    # event bridge triggers the weekly report at noon UTC-4 timezone
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_with_large_number_of_transactions_and_providers(self, mock_lambda_client):
         """Test processing of a large number of transactions (>500) and providers (>100)."""
@@ -618,8 +632,11 @@ class TestGenerateTransactionReports(TstFunction):
             )
 
         # Calculate expected date range
-        end_time = datetime.fromisoformat('2025-04-03T00:00:00+00:00')  # Next day at midnight
-        start_time = end_time - timedelta(days=7)
+        # the end date should be the current day at 11:59:59.999999 UTC
+        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
+        # the start date should be 7 days ago at noon UTC
+        start_time_day = end_time - timedelta(days=7)
+        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
@@ -726,7 +743,8 @@ class TestGenerateTransactionReports(TstFunction):
 
         self.assertIn('Something went wrong', str(exc_info.exception.message))
 
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    # event bridge triggers the weekly report at noon UTC-4 timezone
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_handles_unknown_jurisdiction(self, mock_lambda_client):
         """Test handling of transactions with jurisdictions not in configuration.
@@ -738,8 +756,11 @@ class TestGenerateTransactionReports(TstFunction):
         _set_default_lambda_client_behavior(mock_lambda_client)
 
         # Calculate expected date range
-        end_time = datetime.fromisoformat('2025-04-03T00:00:00+00:00')  # Next day at midnight
-        start_time = end_time - timedelta(days=7)
+        # the end date should be the current day at 11:59:59.999999 UTC
+        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
+        # the start date should be 7 days ago at noon UTC
+        start_time_day = end_time - timedelta(days=7)
+        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -1,6 +1,8 @@
 # ruff: noqa: E501  line-too-long The lines displaying the csv file contents are long, but they are necessary for the test.
 import csv
 import json
+from io import BytesIO
+from zipfile import ZipFile
 from datetime import datetime, timedelta
 from decimal import Decimal
 from unittest.mock import patch
@@ -29,7 +31,7 @@ NEBRASKA_JURISDICTION = {'postalAbbreviation': 'ne', 'jurisdictionName': 'nebras
 
 
 def generate_mock_event():
-    return {'compact': TEST_COMPACT}
+    return {'compact': TEST_COMPACT, 'reportingCycle': 'weekly'}
 
 
 def _generate_mock_transaction(
@@ -190,29 +192,56 @@ class TestGenerateTransactionReports(TstFunction):
 
         self._add_compact_configuration_data()
 
+        # Set up mocked S3 bucket
+
+        # Get the expected date range
+        end_time = self.config.current_standard_datetime.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        start_time = end_time - timedelta(days=7)
+        date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
+
+        # Generate the reports
         generate_transaction_reports(generate_mock_event(), self.mock_context)
 
-        # assert that the email_notification_service_lambda_name was called with the correct payload
+        # Verify email notifications
         call_args = mock_lambda_client.invoke.call_args_list
+        
+        # Check compact report email
         compact_call = call_args[0][1]
         self.assertEqual(self.config.email_notification_service_lambda_name, compact_call['FunctionName'])
         self.assertEqual('RequestResponse', compact_call['InvocationType'])
+        
+        compact_payload = json.loads(compact_call['Payload'])
+        expected_compact_path = (
+            f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
+            f"{end_time.strftime('%Y/%m/%d')}/"
+            f"{TEST_COMPACT}-{date_range}-report.zip"
+        )
         self.assertEqual(
             {
                 'compact': TEST_COMPACT,
                 'recipientType': 'COMPACT_SUMMARY_REPORT',
                 'template': 'CompactTransactionReporting',
                 'templateVariables': {
-                    'compactFinancialSummaryReportCSV': 'Total Transactions,0\nTotal Compact Fees,$0.00\nState Fees (Ohio),$0.00\n',
-                    'compactTransactionReportCSV': 'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\nNo transactions for this period,,,,,,,\n',
+                    'reportS3Path': expected_compact_path,
+                    'reportingCycle': 'weekly',
+                    'startDate': start_time.strftime('%Y-%m-%d'),
+                    'endDate': end_time.strftime('%Y-%m-%d'),
                 },
             },
-            json.loads(compact_call['Payload']),
+            compact_payload,
         )
 
+        # Check jurisdiction report email
         ohio_call = call_args[1][1]
         self.assertEqual(self.config.email_notification_service_lambda_name, ohio_call['FunctionName'])
         self.assertEqual('RequestResponse', ohio_call['InvocationType'])
+        
+        ohio_payload = json.loads(ohio_call['Payload'])
+        expected_ohio_path = (
+            f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/oh/"
+            f"{end_time.strftime('%Y/%m/%d')}/"
+            f"oh-{date_range}-report.zip"
+        )
         self.assertEqual(
             {
                 'compact': TEST_COMPACT,
@@ -220,11 +249,58 @@ class TestGenerateTransactionReports(TstFunction):
                 'recipientType': 'JURISDICTION_SUMMARY_REPORT',
                 'template': 'JurisdictionTransactionReporting',
                 'templateVariables': {
-                    'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\nNo transactions for this period,,,,,,,\n,,,,,,,\nPrivileges Purchased,Total State Amount,,,,,,\n0,$0.00,,,,,,\n'
+                    'reportS3Path': expected_ohio_path,
+                    'reportingCycle': 'weekly',
+                    'startDate': start_time.strftime('%Y-%m-%d'),
+                    'endDate': end_time.strftime('%Y-%m-%d'),
                 },
             },
-            json.loads(ohio_call['Payload']),
+            ohio_payload,
         )
+
+        # Verify S3 stored files
+        # Check compact reports
+        compact_zip_obj = self.config.s3_client.get_object(
+            Bucket=self.config.transaction_reports_bucket_name,
+            Key=expected_compact_path
+        )
+        
+        
+        with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
+            # Check financial summary
+            with zip_file.open('financial-summary.csv') as f:
+                summary_content = f.read().decode('utf-8')
+                self.assertEqual(
+                    'Total Transactions,0\nTotal Compact Fees,$0.00\nState Fees (Ohio),$0.00\n',
+                    summary_content
+                )
+            
+            # Check transaction detail
+            with zip_file.open('transaction-detail.csv') as f:
+                detail_content = f.read().decode('utf-8')
+                self.assertEqual(
+                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\n'
+                    'No transactions for this period,,,,,,,\n',
+                    detail_content
+                )
+
+        # Check jurisdiction report
+        ohio_zip_obj = self.config.s3_client.get_object(
+            Bucket=self.config.transaction_reports_bucket_name,
+            Key=expected_ohio_path
+        )
+        
+        with ZipFile(BytesIO(ohio_zip_obj['Body'].read())) as zip_file:
+            with zip_file.open('transaction-detail.csv') as f:
+                ohio_content = f.read().decode('utf-8')
+                self.assertEqual(
+                    'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                    'No transactions for this period,,,,,,,\n'
+                    ',,,,,,,\n'
+                    'Privileges Purchased,Total State Amount,,,,,,\n'
+                    '0,$0.00,,,,,,\n',
+                    ohio_content
+                )
 
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
@@ -235,9 +311,11 @@ class TestGenerateTransactionReports(TstFunction):
         _set_default_lambda_client_behavior(mock_lambda_client)
 
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
-        # Add a transaction that will be in the previous month
+
+        # Add test transactions
         mock_user_1 = self._add_mock_provider_to_db('12345', 'John', 'Doe')
         mock_user_2 = self._add_mock_provider_to_db('5678', 'Jane', 'Johnson')
+        
         # in this case, there will be two transactions, one in march and the other in April
         # the lambda should pick up both transactions
         self._add_mock_transaction_to_db(
@@ -253,64 +331,122 @@ class TestGenerateTransactionReports(TstFunction):
             transaction_settlement_time_utc=datetime.fromisoformat('2025-04-01T12:00:00+00:00'),
         )
 
+        # Calculate expected date range
+        end_time = datetime.fromisoformat('2025-04-03T00:00:00+00:00')  # Next day at midnight
+        start_time = end_time - timedelta(days=7)
+        date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
+
         generate_transaction_reports(generate_mock_event(), self.mock_context)
 
-        # assert that the email_notification_service_lambda_name was called with the correct payload
+        # Verify email notifications
         calls_args = mock_lambda_client.invoke.call_args_list
-        compact_call_payload = json.loads(calls_args[0][1]['Payload'])
+        
+        # Check compact report email
+        compact_call = calls_args[0][1]
+        self.assertEqual(self.config.email_notification_service_lambda_name, compact_call['FunctionName'])
+        self.assertEqual('RequestResponse', compact_call['InvocationType'])
+        
+        expected_compact_path = (
+            f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
+            f"{end_time.strftime('%Y/%m/%d')}/"
+            f"{TEST_COMPACT}-{date_range}-report.zip"
+        )
+        compact_payload = json.loads(compact_call['Payload'])
         self.assertEqual(
             {
-                'compact': 'aslp',
+                'compact': TEST_COMPACT,
                 'recipientType': 'COMPACT_SUMMARY_REPORT',
                 'template': 'CompactTransactionReporting',
                 'templateVariables': {
-                    'compactFinancialSummaryReportCSV': 'Total Transactions,2\n'
+                    'reportS3Path': expected_compact_path,
+                    'reportingCycle': 'weekly',
+                    'startDate': start_time.strftime('%Y-%m-%d'),
+                    'endDate': end_time.strftime('%Y-%m-%d'),
+                },
+            },
+            compact_payload,
+        )
+
+        # Check jurisdiction report emails
+        for idx, jurisdiction in enumerate(['ky', 'oh']):
+            jurisdiction_call = calls_args[idx + 1][1]
+            self.assertEqual(self.config.email_notification_service_lambda_name, jurisdiction_call['FunctionName'])
+            self.assertEqual('RequestResponse', jurisdiction_call['InvocationType'])
+            
+            expected_jurisdiction_path = (
+                f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
+                f"{end_time.strftime('%Y/%m/%d')}/"
+                f"{jurisdiction}-{date_range}-report.zip"
+            )
+            jurisdiction_payload = json.loads(jurisdiction_call['Payload'])
+            self.assertEqual(
+                {
+                    'compact': TEST_COMPACT,
+                    'jurisdiction': jurisdiction,
+                    'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                    'template': 'JurisdictionTransactionReporting',
+                    'templateVariables': {
+                        'reportS3Path': expected_jurisdiction_path,
+                        'reportingCycle': 'weekly',
+                        'startDate': start_time.strftime('%Y-%m-%d'),
+                        'endDate': end_time.strftime('%Y-%m-%d'),
+                    },
+                },
+                jurisdiction_payload,
+            )
+
+        # Verify S3 stored files
+        # Check compact reports
+        compact_zip_obj = self.config.s3_client.get_object(
+            Bucket=self.config.transaction_reports_bucket_name,
+            Key=expected_compact_path
+        )
+        
+        with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
+            # Check financial summary
+            with zip_file.open('financial-summary.csv') as f:
+                summary_content = f.read().decode('utf-8')
+                self.assertEqual(
+                    'Total Transactions,2\n'
                     'Total Compact Fees,$21.00\n'
                     'State Fees (Kentucky),$100.00\n'
                     'State Fees (Ohio),$100.00\n',
-                    'compactTransactionReportCSV': f'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\n'
-                    f'{mock_user_1['givenName']},{mock_user_1['familyName']},{mock_user_1['providerId']},03-30-2025,OH,100,10.50,{MOCK_TRANSACTION_ID}\n'
-                    f'{mock_user_2['givenName']},{mock_user_2['familyName']},{mock_user_2['providerId']},04-01-2025,KY,100,10.50,{MOCK_TRANSACTION_ID}\n',
-                },
-            },
-            compact_call_payload,
-        )
+                    summary_content
+                )
+            
+            # Check transaction detail
+            with zip_file.open('transaction-detail.csv') as f:
+                detail_content = f.read().decode('utf-8')
+                self.assertEqual(
+                    f'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id\n'
+                    f'{mock_user_1["givenName"]},{mock_user_1["familyName"]},{mock_user_1["providerId"]},03-30-2025,OH,100,10.50,{MOCK_TRANSACTION_ID}\n'
+                    f'{mock_user_2["givenName"]},{mock_user_2["familyName"]},{mock_user_2["providerId"]},04-01-2025,KY,100,10.50,{MOCK_TRANSACTION_ID}\n',
+                    detail_content
+                )
 
-        kentucky_call_payload = json.loads(calls_args[1][1]['Payload'])
-        self.assertEqual(
-            {
-                'compact': 'aslp',
-                'jurisdiction': 'ky',
-                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
-                'template': 'JurisdictionTransactionReporting',
-                'templateVariables': {
-                    'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
-                    f'{mock_user_2['givenName']},{mock_user_2['familyName']},{mock_user_2['providerId']},04-01-2025,100,KY,10.50,{MOCK_TRANSACTION_ID}\n'
-                    ',,,,,,,\n'
-                    'Privileges Purchased,Total State Amount,,,,,,\n'
-                    '1,$100.00,,,,,,\n'
-                },
-            },
-            kentucky_call_payload,
-        )
-
-        ohio_call_payload = json.loads(calls_args[2][1]['Payload'])
-        self.assertEqual(
-            {
-                'compact': 'aslp',
-                'jurisdiction': 'oh',
-                'recipientType': 'JURISDICTION_SUMMARY_REPORT',
-                'template': 'JurisdictionTransactionReporting',
-                'templateVariables': {
-                    'jurisdictionTransactionReportCSV': 'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
-                    f'{mock_user_1['givenName']},{mock_user_1['familyName']},{mock_user_1['providerId']},03-30-2025,100,OH,10.50,{MOCK_TRANSACTION_ID}\n'
-                    ',,,,,,,\n'
-                    'Privileges Purchased,Total State Amount,,,,,,\n'
-                    '1,$100.00,,,,,,\n'
-                },
-            },
-            ohio_call_payload,
-        )
+        # Check jurisdiction reports
+        for jurisdiction, user in [('ky', mock_user_2), ('oh', mock_user_1)]:
+            jurisdiction_zip_obj = self.config.s3_client.get_object(
+                Bucket=self.config.transaction_reports_bucket_name,
+                Key=(
+                    f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
+                    f"{end_time.strftime('%Y/%m/%d')}/"
+                    f"{jurisdiction}-{date_range}-report.zip"
+                )
+            )
+            
+            with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
+                with zip_file.open('transaction-detail.csv') as f:
+                    content = f.read().decode('utf-8')
+                    transaction_date = '03-30-2025' if jurisdiction == 'oh' else '04-01-2025'
+                    self.assertEqual(
+                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                        f'{user["givenName"]},{user["familyName"]},{user["providerId"]},{transaction_date},100,{jurisdiction.upper()},10.50,{MOCK_TRANSACTION_ID}\n'
+                        ',,,,,,,\n'
+                        'Privileges Purchased,Total State Amount,,,,,,\n'
+                        '1,$100.00,,,,,,\n',
+                        content
+                    )
 
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
@@ -323,6 +459,7 @@ class TestGenerateTransactionReports(TstFunction):
         self._add_compact_configuration_data(
             jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION]
         )
+        
 
         mock_user = self._add_mock_provider_to_db('12345', 'John', 'Doe')
         # Create a transaction with privileges for multiple jurisdictions
@@ -333,40 +470,123 @@ class TestGenerateTransactionReports(TstFunction):
             transaction_settlement_time_utc=datetime.fromisoformat('2025-03-30T12:00:00+00:00'),
         )
 
+        # Calculate expected date range
+        end_time = datetime.fromisoformat('2025-04-03T00:00:00+00:00')  # Next day at midnight
+        start_time = end_time - timedelta(days=7)
+        date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
+
         generate_transaction_reports(generate_mock_event(), self.mock_context)
 
+        # Verify email notifications
         calls_args = mock_lambda_client.invoke.call_args_list
-        compact_call_payload = json.loads(calls_args[0][1]['Payload'])
-
-        # Verify compact summary shows correct totals
+        
+        # Check compact report email
+        compact_call = calls_args[0][1]
+        self.assertEqual(self.config.email_notification_service_lambda_name, compact_call['FunctionName'])
+        self.assertEqual('RequestResponse', compact_call['InvocationType'])
+        
+        expected_compact_path = (
+            f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
+            f"{end_time.strftime('%Y/%m/%d')}/"
+            f"{TEST_COMPACT}-{date_range}-report.zip"
+        )
+        compact_payload = json.loads(compact_call['Payload'])
         self.assertEqual(
-            'Total Transactions,1\n'
-            'Total Compact Fees,$31.50\n'  # $10.50 x 3 privileges
-            'State Fees (Kentucky),$100.00\n'
-            'State Fees (Nebraska),$100.00\n'
-            'State Fees (Ohio),$100.00\n',
-            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV'],
+            {
+                'compact': TEST_COMPACT,
+                'recipientType': 'COMPACT_SUMMARY_REPORT',
+                'template': 'CompactTransactionReporting',
+                'templateVariables': {
+                    'reportS3Path': expected_compact_path,
+                    'reportingCycle': 'weekly',
+                    'startDate': start_time.strftime('%Y-%m-%d'),
+                    'endDate': end_time.strftime('%Y-%m-%d'),
+                },
+            },
+            compact_payload,
         )
 
-        # Verify each jurisdiction report shows the correct privilege
+        # Check jurisdiction report emails
+        for idx, jurisdiction in enumerate(['ky', 'ne', 'oh']):
+            jurisdiction_call = calls_args[idx + 1][1]
+            self.assertEqual(self.config.email_notification_service_lambda_name, jurisdiction_call['FunctionName'])
+            self.assertEqual('RequestResponse', jurisdiction_call['InvocationType'])
+            
+            expected_jurisdiction_path = (
+                f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
+                f"{end_time.strftime('%Y/%m/%d')}/"
+                f"{jurisdiction}-{date_range}-report.zip"
+            )
+            jurisdiction_payload = json.loads(jurisdiction_call['Payload'])
+            self.assertEqual(
+                {
+                    'compact': TEST_COMPACT,
+                    'jurisdiction': jurisdiction,
+                    'recipientType': 'JURISDICTION_SUMMARY_REPORT',
+                    'template': 'JurisdictionTransactionReporting',
+                    'templateVariables': {
+                        'reportS3Path': expected_jurisdiction_path,
+                        'reportingCycle': 'weekly',
+                        'startDate': start_time.strftime('%Y-%m-%d'),
+                        'endDate': end_time.strftime('%Y-%m-%d'),
+                    },
+                },
+                jurisdiction_payload,
+            )
+
+        # Verify S3 stored files
+        # Check compact reports
+        compact_zip_obj = self.config.s3_client.get_object(
+            Bucket=self.config.transaction_reports_bucket_name,
+            Key=expected_compact_path
+        )
+        
+        with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
+            # Check financial summary
+            with zip_file.open('financial-summary.csv') as f:
+                summary_content = f.read().decode('utf-8')
+                self.assertEqual(
+                    'Total Transactions,1\n'
+                    'Total Compact Fees,$31.50\n'  # $10.50 x 3 privileges
+                    'State Fees (Kentucky),$100.00\n'
+                    'State Fees (Nebraska),$100.00\n'
+                    'State Fees (Ohio),$100.00\n',
+                    summary_content
+                )
+            
+            # Check transaction detail
+            with zip_file.open('transaction-detail.csv') as f:
+                detail_content = f.read().decode('utf-8')
+                expected_lines = [
+                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id']
+                for state in ['OH', 'KY', 'NE']:
+                    expected_lines.append(
+                        f'{mock_user["givenName"]},{mock_user["familyName"]},{mock_user["providerId"]},03-30-2025,{state},100,10.50,{MOCK_TRANSACTION_ID}'
+                    )
+                self.assertEqual('\n'.join(expected_lines) + '\n', detail_content)
+
+        # Check jurisdiction reports
         for jurisdiction in ['ky', 'ne', 'oh']:
-            jurisdiction_call = next(
-                call for call in calls_args[1:] if json.loads(call[1]['Payload'])['jurisdiction'] == jurisdiction
+            jurisdiction_zip_obj = self.config.s3_client.get_object(
+                Bucket=self.config.transaction_reports_bucket_name,
+                Key=(
+                    f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
+                    f"{end_time.strftime('%Y/%m/%d')}/"
+                    f"{jurisdiction}-{date_range}-report.zip"
+                )
             )
-            jurisdiction_payload = json.loads(jurisdiction_call[1]['Payload'])
-            self.assertIn(
-                f'{mock_user['givenName']},{mock_user['familyName']},{mock_user['providerId']},03-30-2025,100,{jurisdiction.upper()},10.50,{MOCK_TRANSACTION_ID}',
-                jurisdiction_payload['templateVariables']['jurisdictionTransactionReportCSV'],
-            )
-            # also verify that other jurisdictions are not included in the report
-            # convert csv string into a json object and verify that the jurisdiction is not in the object
-            report_json = csv.DictReader(
-                jurisdiction_payload['templateVariables']['jurisdictionTransactionReportCSV'].split('\n')
-            )
-            for other_jurisdiction in ['oh', 'ky', 'ne']:
-                if other_jurisdiction != jurisdiction:
-                    for row in report_json:
-                        self.assertNotIn(other_jurisdiction.upper(), row['State'])
+            
+            with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
+                with zip_file.open('transaction-detail.csv') as f:
+                    content = f.read().decode('utf-8')
+                    self.assertEqual(
+                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id\n'
+                        f'{mock_user["givenName"]},{mock_user["familyName"]},{mock_user["providerId"]},03-30-2025,100,{jurisdiction.upper()},10.50,{MOCK_TRANSACTION_ID}\n'
+                        ',,,,,,,\n'
+                        'Privileges Purchased,Total State Amount,,,,,,\n'
+                        '1,$100.00,,,,,,\n',
+                        content
+                    )
 
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
@@ -397,52 +617,89 @@ class TestGenerateTransactionReports(TstFunction):
                 transaction_id=f'tx_{i}',
             )
 
+        # Calculate expected date range
+        end_time = datetime.fromisoformat('2025-04-03T00:00:00+00:00')  # Next day at midnight
+        start_time = end_time - timedelta(days=7)
+        date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
+
         generate_transaction_reports(generate_mock_event(), self.mock_context)
 
-        calls_args = mock_lambda_client.invoke.call_args_list
-        compact_call_payload = json.loads(calls_args[0][1]['Payload'])
-
-        # Verify summary totals
-        self.assertEqual(
-            'Total Transactions,600\n'
-            'Total Compact Fees,$6300.00\n'  # $10.50 x 600
-            'State Fees (Kentucky),$30000.00\n'  # $100 x 300
-            'State Fees (Ohio),$30000.00\n',  # $100 x 300
-            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV'],
-        )
-
-        # Verify transaction reports
-        ohio_transactions_in_report = [
-            line
-            for line in compact_call_payload['templateVariables']['compactTransactionReportCSV'].split('\n')
-            if 'OH' in line
-        ]
-        kentucky_transactions_in_report = [
-            line
-            for line in compact_call_payload['templateVariables']['compactTransactionReportCSV'].split('\n')
-            if 'KY' in line
-        ]
-        self.assertEqual(300, len(ohio_transactions_in_report))
-        self.assertEqual(300, len(kentucky_transactions_in_report))
-        # make sure all expected user ids in report
-        for i in range(300):
-            self.assertIn(f'user_{i}', ohio_transactions_in_report[i])
-            self.assertIn(f'user_{i+300}', kentucky_transactions_in_report[i])
-
-        # Verify jurisdiction reports
-        for jurisdiction in ['oh', 'ky']:
-            jurisdiction_call = next(
-                call for call in calls_args[1:] if json.loads(call[1]['Payload'])['jurisdiction'] == jurisdiction
+        # Verify S3 stored files
+        # Check compact reports
+        compact_zip_obj = self.config.s3_client.get_object(
+            Bucket=self.config.transaction_reports_bucket_name,
+            Key=(
+                f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
+                f"{end_time.strftime('%Y/%m/%d')}/"
+                f"{TEST_COMPACT}-{date_range}-report.zip"
             )
-            jurisdiction_payload = json.loads(jurisdiction_call[1]['Payload'])
-            report_csv = jurisdiction_payload['templateVariables']['jurisdictionTransactionReportCSV']
+        )
+        
+        with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
+            # Check financial summary
+            with zip_file.open('financial-summary.csv') as f:
+                summary_content = f.read().decode('utf-8')
+                self.assertEqual(
+                    'Total Transactions,600\n'
+                    'Total Compact Fees,$6300.00\n'  # $10.50 x 600
+                    'State Fees (Kentucky),$30000.00\n'  # $100 x 300
+                    'State Fees (Ohio),$30000.00\n', # $100 x 300
+                    summary_content
+                )
+            
+            # Check transaction detail
+            with zip_file.open('transaction-detail.csv') as f:
+                detail_content = f.read().decode('utf-8').split('\n')
+                # Verify header
+                self.assertEqual(
+                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Date,State,State Fee,Compact Fee,Transaction Id',
+                    detail_content[0]
+                )
+                
+                # Count transactions by state
+                oh_transactions = [line for line in detail_content if ',OH,' in line]
+                ky_transactions = [line for line in detail_content if ',KY,' in line]
+                self.assertEqual(300, len(oh_transactions))
+                self.assertEqual(300, len(ky_transactions))
+                
+                # Verify all providers are included
+                for i in range(300):
+                    # Check Ohio transactions (first 300 providers)
+                    self.assertIn(f'First{i},Last{i},user_{i},', oh_transactions[i])
+                    self.assertIn('tx_' + str(i), oh_transactions[i])
+                    
+                    # Check Kentucky transactions (next 300 providers)
+                    ky_idx = i + 300
+                    self.assertIn(f'First{ky_idx},Last{ky_idx},user_{ky_idx},', ky_transactions[i])
+                    self.assertIn('tx_' + str(ky_idx), ky_transactions[i])
 
-            # 300 transactions + 5 extra lines for the header, spacing, summary headers, summary values, and line at EOF
-            expected_csv_line_count = 305
-            self.assertEqual(expected_csv_line_count, len(report_csv.split('\n')))
-            # Verify the summary totals are correct
-            self.assertIn('Privileges Purchased,Total State Amount,,,,,,', report_csv)
-            self.assertIn('300,$30000.00,,,,,,', report_csv)
+        # Check jurisdiction reports
+        for jurisdiction, start_idx in [('oh', 0), ('ky', 300)]:
+            jurisdiction_zip_obj = self.config.s3_client.get_object(
+                Bucket=self.config.transaction_reports_bucket_name,
+                Key=(
+                    f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
+                    f"{end_time.strftime('%Y/%m/%d')}/"
+                    f"{jurisdiction}-{date_range}-report.zip"
+                )
+            )
+            
+            with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
+                with zip_file.open('transaction-detail.csv') as f:
+                    content = f.read().decode('utf-8').split('\n')
+                    
+                    # Verify header
+                    self.assertEqual(
+                        'First Name,Last Name,Licensee Id,Transaction Date,State Fee,State,Compact Fee,Transaction Id',
+                        content[0]
+                    )
+
+                    # 300 transactions + 5 extra lines for the header, spacing, summary headers, summary values, and line at EOF
+                    expected_csv_line_count = 305
+                    self.assertEqual(expected_csv_line_count, len(content))
+                    # Verify summary totals
+                    self.assertEqual('Privileges Purchased,Total State Amount,,,,,,', content[-3])
+                    self.assertEqual('300,$30000.00,,,,,,', content[-2])
 
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
     def test_generate_report_raises_error_when_compact_not_found(self):
@@ -480,6 +737,11 @@ class TestGenerateTransactionReports(TstFunction):
 
         _set_default_lambda_client_behavior(mock_lambda_client)
 
+        # Calculate expected date range
+        end_time = datetime.fromisoformat('2025-04-03T00:00:00+00:00')  # Next day at midnight
+        start_time = end_time - timedelta(days=7)
+        date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
+
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
 
         mock_user = self._add_mock_provider_to_db('12345', 'John', 'Doe')
@@ -496,18 +758,32 @@ class TestGenerateTransactionReports(TstFunction):
 
         self.assertIn('Unknown jurisdiction', str(exc_info.exception.message))
 
-        calls_args = mock_lambda_client.invoke.call_args_list
-        compact_call_payload = json.loads(calls_args[0][1]['Payload'])
-
-        # Verify compact summary includes unknown jurisdiction
-        self.assertEqual(
-            'Total Transactions,1\n'
-            'Total Compact Fees,$31.50\n'  # $10.50 x 3 privileges
-            'State Fees (Kentucky),$100.00\n'
-            'State Fees (Ohio),$100.00\n'
-            'State Fees (UNKNOWN (xx)),$100.00\n',
-            compact_call_payload['templateVariables']['compactFinancialSummaryReportCSV'],
+        # Verify S3 stored files
+        # Check compact reports
+        compact_zip_obj = self.config.s3_client.get_object(
+            Bucket=self.config.transaction_reports_bucket_name,
+            Key=(
+                f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
+                f"{end_time.strftime('%Y/%m/%d')}/"
+                f"{TEST_COMPACT}-{date_range}-report.zip"
+            )
         )
+
+        with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
+            # Check financial summary
+            with zip_file.open('financial-summary.csv') as f:
+                summary_content = f.read().decode('utf-8')
+                # Verify compact summary includes unknown jurisdiction
+                self.assertEqual(
+                    'Total Transactions,1\n'
+                    'Total Compact Fees,$31.50\n'  # $10.50 x 3 privileges
+                    'State Fees (Kentucky),$100.00\n'
+                    'State Fees (Ohio),$100.00\n'
+                    'State Fees (UNKNOWN (xx)),$100.00\n',
+                    summary_content
+                )
+
+        calls_args = mock_lambda_client.invoke.call_args_list
 
         # Verify we only sent reports for known jurisdictions
         jurisdiction_calls = [

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -829,15 +829,13 @@ class TestGenerateTransactionReports(TstFunction):
             transaction_settlement_time_utc=datetime.fromisoformat('2024-02-01T00:00:00+00:00'),
         )
 
-        # Create a transaction with a priviliege which is settled at the end of the month
+        # Create a transaction with a privilege which is settled at the very end of the month
         # This transaction should be included in the monthly report
         self._add_mock_transaction_to_db(
             jurisdictions=['ky'],
             licensee_id=mock_user['providerId'],
             month_iso_string='2024-02',
-            # NOTE: the moto mock does not correctly mock the behavior of the BETWEEN condition, which according to AWS is inclusive
-            # so for the purposes of this test we use a time that is just before midnight UTC
-            transaction_settlement_time_utc=datetime.fromisoformat('2024-02-29T23:59:58+00:00'),
+            transaction_settlement_time_utc=datetime.fromisoformat('2024-02-29T23:59:59+00:00'),
         )
 
         # Create a transaction with a privilege which is settled the last day of the month at midnight UTC

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -818,7 +818,9 @@ class TestGenerateTransactionReports(TstFunction):
 
         _set_default_lambda_client_behavior(mock_lambda_client)
 
-        self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION])
+        self._add_compact_configuration_data(
+            jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION]
+        )
 
         mock_user = self._add_mock_provider_to_db('12345', 'John', 'Doe')
         # Create a transaction with a privilege which is settled the first day of the month at midnight UTC
@@ -917,13 +919,17 @@ class TestGenerateTransactionReports(TstFunction):
     # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-03-08T22:00:01+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
-    def test_generate_weekly_report_includes_expected_settled_transactions_for_full_week_range(self, mock_lambda_client):
+    def test_generate_weekly_report_includes_expected_settled_transactions_for_full_week_range(
+        self, mock_lambda_client
+    ):
         """Test processing weekly report with full week range for Mar 2024."""
         from handlers.transaction_reporting import generate_transaction_reports
 
         _set_default_lambda_client_behavior(mock_lambda_client)
 
-        self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION])
+        self._add_compact_configuration_data(
+            jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION]
+        )
 
         mock_user = self._add_mock_provider_to_db('12345', 'John', 'Doe')
 
@@ -953,7 +959,6 @@ class TestGenerateTransactionReports(TstFunction):
             transaction_settlement_time_utc=datetime.fromisoformat('2025-03-08T21:59:59+00:00'),
         )
 
-
         # Create a transaction with a privilege which is settled at the end of the week at 10:00 PM UTC
         # This transaction should NOT be included in the weekly report
         self._add_mock_transaction_to_db(
@@ -971,7 +976,6 @@ class TestGenerateTransactionReports(TstFunction):
             month_iso_string='2025-03',
             transaction_settlement_time_utc=datetime.fromisoformat('2025-03-08T22:00:01+00:00'),
         )
-
 
         # Calculate expected date range
         # the end time should be Friday at 10:00 PM UTC

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -1,10 +1,10 @@
 # ruff: noqa: E501  line-too-long The lines displaying the csv file contents are long, but they are necessary for the test.
 import json
-from io import BytesIO
-from zipfile import ZipFile
 from datetime import datetime, timedelta
 from decimal import Decimal
+from io import BytesIO
 from unittest.mock import patch
+from zipfile import ZipFile
 
 from cc_common.exceptions import CCInternalException, CCNotFoundException
 from moto import mock_aws
@@ -208,12 +208,12 @@ class TestGenerateTransactionReports(TstFunction):
 
         # Verify email notifications
         call_args = mock_lambda_client.invoke.call_args_list
-        
+
         # Check compact report email
         compact_call = call_args[0][1]
         self.assertEqual(self.config.email_notification_service_lambda_name, compact_call['FunctionName'])
         self.assertEqual('RequestResponse', compact_call['InvocationType'])
-        
+
         compact_payload = json.loads(compact_call['Payload'])
         expected_compact_path = (
             f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
@@ -239,7 +239,7 @@ class TestGenerateTransactionReports(TstFunction):
         ohio_call = call_args[1][1]
         self.assertEqual(self.config.email_notification_service_lambda_name, ohio_call['FunctionName'])
         self.assertEqual('RequestResponse', ohio_call['InvocationType'])
-        
+
         ohio_payload = json.loads(ohio_call['Payload'])
         expected_ohio_path = (
             f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/oh/"
@@ -265,35 +265,31 @@ class TestGenerateTransactionReports(TstFunction):
         # Verify S3 stored files
         # Check compact reports
         compact_zip_obj = self.config.s3_client.get_object(
-            Bucket=self.config.transaction_reports_bucket_name,
-            Key=expected_compact_path
+            Bucket=self.config.transaction_reports_bucket_name, Key=expected_compact_path
         )
-        
-        
+
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
             with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
                 summary_content = f.read().decode('utf-8')
                 self.assertEqual(
-                    'Total Transactions,0\nTotal Compact Fees,$0.00\nState Fees (Ohio),$0.00\n',
-                    summary_content
+                    'Total Transactions,0\nTotal Compact Fees,$0.00\nState Fees (Ohio),$0.00\n', summary_content
                 )
-            
+
             # Check transaction detail
             with zip_file.open(f'{TEST_COMPACT}-transaction-detail-{date_range}.csv') as f:
                 detail_content = f.read().decode('utf-8')
                 self.assertEqual(
                     'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id\n'
                     'No transactions for this period,,,,,,,\n',
-                    detail_content
+                    detail_content,
                 )
 
         # Check jurisdiction report
         ohio_zip_obj = self.config.s3_client.get_object(
-            Bucket=self.config.transaction_reports_bucket_name,
-            Key=expected_ohio_path
+            Bucket=self.config.transaction_reports_bucket_name, Key=expected_ohio_path
         )
-        
+
         with ZipFile(BytesIO(ohio_zip_obj['Body'].read())) as zip_file:
             with zip_file.open(f'oh-transaction-detail-{date_range}.csv') as f:
                 ohio_content = f.read().decode('utf-8')
@@ -303,7 +299,7 @@ class TestGenerateTransactionReports(TstFunction):
                     ',,,,,,,\n'
                     'Privileges Purchased,Total State Amount,,,,,,\n'
                     '0,$0.00,,,,,,\n',
-                    ohio_content
+                    ohio_content,
                 )
 
     # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
@@ -320,7 +316,7 @@ class TestGenerateTransactionReports(TstFunction):
         # Add test transactions
         mock_user_1 = self._add_mock_provider_to_db('12345', 'John', 'Doe')
         mock_user_2 = self._add_mock_provider_to_db('5678', 'Jane', 'Johnson')
-        
+
         # in this case, there will be two transactions, one in march and the other in April
         # the lambda should pick up both transactions
         self._add_mock_transaction_to_db(
@@ -347,12 +343,12 @@ class TestGenerateTransactionReports(TstFunction):
 
         # Verify email notifications
         calls_args = mock_lambda_client.invoke.call_args_list
-        
+
         # Check compact report email
         compact_call = calls_args[0][1]
         self.assertEqual(self.config.email_notification_service_lambda_name, compact_call['FunctionName'])
         self.assertEqual('RequestResponse', compact_call['InvocationType'])
-        
+
         expected_compact_path = (
             f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
             f"{end_time.strftime('%Y/%m/%d')}/"
@@ -379,7 +375,7 @@ class TestGenerateTransactionReports(TstFunction):
             jurisdiction_call = calls_args[idx + 1][1]
             self.assertEqual(self.config.email_notification_service_lambda_name, jurisdiction_call['FunctionName'])
             self.assertEqual('RequestResponse', jurisdiction_call['InvocationType'])
-            
+
             expected_jurisdiction_path = (
                 f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
                 f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
@@ -405,10 +401,9 @@ class TestGenerateTransactionReports(TstFunction):
         # Verify S3 stored files
         # Check compact reports
         compact_zip_obj = self.config.s3_client.get_object(
-            Bucket=self.config.transaction_reports_bucket_name,
-            Key=expected_compact_path
+            Bucket=self.config.transaction_reports_bucket_name, Key=expected_compact_path
         )
-        
+
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
             with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
@@ -418,9 +413,9 @@ class TestGenerateTransactionReports(TstFunction):
                     'Total Compact Fees,$21.00\n'
                     'State Fees (Kentucky),$100.00\n'
                     'State Fees (Ohio),$100.00\n',
-                    summary_content
+                    summary_content,
                 )
-            
+
             # Check transaction detail
             with zip_file.open(f'{TEST_COMPACT}-transaction-detail-{date_range}.csv') as f:
                 detail_content = f.read().decode('utf-8')
@@ -428,7 +423,7 @@ class TestGenerateTransactionReports(TstFunction):
                     f'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id\n'
                     f'{mock_user_1["givenName"]},{mock_user_1["familyName"]},{mock_user_1["providerId"]},03-30-2025,OH,100,10.50,{MOCK_TRANSACTION_ID}\n'
                     f'{mock_user_2["givenName"]},{mock_user_2["familyName"]},{mock_user_2["providerId"]},04-01-2025,KY,100,10.50,{MOCK_TRANSACTION_ID}\n',
-                    detail_content
+                    detail_content,
                 )
 
         # Check jurisdiction reports
@@ -439,9 +434,9 @@ class TestGenerateTransactionReports(TstFunction):
                     f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
                     f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
                     f"{jurisdiction}-{date_range}-report.zip"
-                )
+                ),
             )
-            
+
             with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
                 with zip_file.open(f'{jurisdiction}-transaction-detail-{date_range}.csv') as f:
                     content = f.read().decode('utf-8')
@@ -452,7 +447,7 @@ class TestGenerateTransactionReports(TstFunction):
                         ',,,,,,,\n'
                         'Privileges Purchased,Total State Amount,,,,,,\n'
                         '1,$100.00,,,,,,\n',
-                        content
+                        content,
                     )
 
     # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
@@ -467,7 +462,6 @@ class TestGenerateTransactionReports(TstFunction):
         self._add_compact_configuration_data(
             jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION, NEBRASKA_JURISDICTION]
         )
-        
 
         mock_user = self._add_mock_provider_to_db('12345', 'John', 'Doe')
         # Create a transaction with privileges for multiple jurisdictions
@@ -489,12 +483,12 @@ class TestGenerateTransactionReports(TstFunction):
 
         # Verify email notifications
         calls_args = mock_lambda_client.invoke.call_args_list
-        
+
         # Check compact report email
         compact_call = calls_args[0][1]
         self.assertEqual(self.config.email_notification_service_lambda_name, compact_call['FunctionName'])
         self.assertEqual('RequestResponse', compact_call['InvocationType'])
-        
+
         expected_compact_path = (
             f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
             f"{end_time.strftime('%Y/%m/%d')}/"
@@ -521,7 +515,7 @@ class TestGenerateTransactionReports(TstFunction):
             jurisdiction_call = calls_args[idx + 1][1]
             self.assertEqual(self.config.email_notification_service_lambda_name, jurisdiction_call['FunctionName'])
             self.assertEqual('RequestResponse', jurisdiction_call['InvocationType'])
-            
+
             expected_jurisdiction_path = (
                 f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
                 f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
@@ -547,10 +541,9 @@ class TestGenerateTransactionReports(TstFunction):
         # Verify S3 stored files
         # Check compact reports
         compact_zip_obj = self.config.s3_client.get_object(
-            Bucket=self.config.transaction_reports_bucket_name,
-            Key=expected_compact_path
+            Bucket=self.config.transaction_reports_bucket_name, Key=expected_compact_path
         )
-        
+
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
             with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
@@ -561,14 +554,15 @@ class TestGenerateTransactionReports(TstFunction):
                     'State Fees (Kentucky),$100.00\n'
                     'State Fees (Nebraska),$100.00\n'
                     'State Fees (Ohio),$100.00\n',
-                    summary_content
+                    summary_content,
                 )
-            
+
             # Check transaction detail
             with zip_file.open(f'{TEST_COMPACT}-transaction-detail-{date_range}.csv') as f:
                 detail_content = f.read().decode('utf-8')
                 expected_lines = [
-                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id']
+                    'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id'
+                ]
                 for state in ['OH', 'KY', 'NE']:
                     expected_lines.append(
                         f'{mock_user["givenName"]},{mock_user["familyName"]},{mock_user["providerId"]},03-30-2025,{state},100,10.50,{MOCK_TRANSACTION_ID}'
@@ -583,9 +577,9 @@ class TestGenerateTransactionReports(TstFunction):
                     f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
                     f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
                     f"{jurisdiction}-{date_range}-report.zip"
-                )
+                ),
             )
-            
+
             with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
                 with zip_file.open(f'{jurisdiction}-transaction-detail-{date_range}.csv') as f:
                     content = f.read().decode('utf-8')
@@ -595,7 +589,7 @@ class TestGenerateTransactionReports(TstFunction):
                         ',,,,,,,\n'
                         'Privileges Purchased,Total State Amount,,,,,,\n'
                         '1,$100.00,,,,,,\n',
-                        content
+                        content,
                     )
 
     # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
@@ -645,9 +639,9 @@ class TestGenerateTransactionReports(TstFunction):
                 f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
                 f"{end_time.strftime('%Y/%m/%d')}/"
                 f"{TEST_COMPACT}-{date_range}-report.zip"
-            )
+            ),
         )
-        
+
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
             # Check financial summary
             with zip_file.open(f'{TEST_COMPACT}-financial-summary-{date_range}.csv') as f:
@@ -656,55 +650,55 @@ class TestGenerateTransactionReports(TstFunction):
                     'Total Transactions,600\n'
                     'Total Compact Fees,$6300.00\n'  # $10.50 x 600
                     'State Fees (Kentucky),$30000.00\n'  # $100 x 300
-                    'State Fees (Ohio),$30000.00\n', # $100 x 300
-                    summary_content
+                    'State Fees (Ohio),$30000.00\n',  # $100 x 300
+                    summary_content,
                 )
-            
+
             # Check transaction detail
             with zip_file.open(f'{TEST_COMPACT}-transaction-detail-{date_range}.csv') as f:
                 detail_content = f.read().decode('utf-8').split('\n')
                 # Verify header
                 self.assertEqual(
                     'Licensee First Name,Licensee Last Name,Licensee Id,Transaction Settlement Date,State,State Fee,Compact Fee,Transaction Id',
-                    detail_content[0]
+                    detail_content[0],
                 )
-                
+
                 # Count transactions by state
                 oh_transactions = [line for line in detail_content if ',OH,' in line]
                 ky_transactions = [line for line in detail_content if ',KY,' in line]
                 self.assertEqual(300, len(oh_transactions))
                 self.assertEqual(300, len(ky_transactions))
-                
+
                 # Verify all providers are included
                 for i in range(300):
                     # Check Ohio transactions (first 300 providers)
                     self.assertIn(f'First{i},Last{i},user_{i},', oh_transactions[i])
                     self.assertIn('tx_' + str(i), oh_transactions[i])
-                    
+
                     # Check Kentucky transactions (next 300 providers)
                     ky_idx = i + 300
                     self.assertIn(f'First{ky_idx},Last{ky_idx},user_{ky_idx},', ky_transactions[i])
                     self.assertIn('tx_' + str(ky_idx), ky_transactions[i])
 
         # Check jurisdiction reports
-        for jurisdiction, start_idx in [('oh', 0), ('ky', 300)]:
+        for jurisdiction, _start_idx in [('oh', 0), ('ky', 300)]:
             jurisdiction_zip_obj = self.config.s3_client.get_object(
                 Bucket=self.config.transaction_reports_bucket_name,
                 Key=(
                     f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
                     f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
                     f"{jurisdiction}-{date_range}-report.zip"
-                )
+                ),
             )
-            
+
             with ZipFile(BytesIO(jurisdiction_zip_obj['Body'].read())) as zip_file:
                 with zip_file.open(f'{jurisdiction}-transaction-detail-{date_range}.csv') as f:
                     content = f.read().decode('utf-8').split('\n')
-                    
+
                     # Verify header
                     self.assertEqual(
                         'First Name,Last Name,Licensee Id,Transaction Settlement Date,State Fee,State,Compact Fee,Transaction Id',
-                        content[0]
+                        content[0],
                     )
 
                     # 300 transactions + 5 extra lines for the header, spacing, summary headers, summary values, and line at EOF
@@ -782,7 +776,7 @@ class TestGenerateTransactionReports(TstFunction):
                 f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/weekly/"
                 f"{end_time.strftime('%Y/%m/%d')}/"
                 f"{TEST_COMPACT}-{date_range}-report.zip"
-            )
+            ),
         )
 
         with ZipFile(BytesIO(compact_zip_obj['Body'].read())) as zip_file:
@@ -796,7 +790,7 @@ class TestGenerateTransactionReports(TstFunction):
                     'State Fees (Kentucky),$100.00\n'
                     'State Fees (Ohio),$100.00\n'
                     'State Fees (UNKNOWN (xx)),$100.00\n',
-                    summary_content
+                    summary_content,
                 )
 
         calls_args = mock_lambda_client.invoke.call_args_list

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -239,7 +239,7 @@ class TestGenerateTransactionReports(TstFunction):
         ohio_payload = json.loads(ohio_call['Payload'])
         expected_ohio_path = (
             f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/oh/"
-            f"{end_time.strftime('%Y/%m/%d')}/"
+            f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
             f"oh-{date_range}-report.zip"
         )
         self.assertEqual(
@@ -375,7 +375,7 @@ class TestGenerateTransactionReports(TstFunction):
             
             expected_jurisdiction_path = (
                 f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
-                f"{end_time.strftime('%Y/%m/%d')}/"
+                f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
                 f"{jurisdiction}-{date_range}-report.zip"
             )
             jurisdiction_payload = json.loads(jurisdiction_call['Payload'])
@@ -430,7 +430,7 @@ class TestGenerateTransactionReports(TstFunction):
                 Bucket=self.config.transaction_reports_bucket_name,
                 Key=(
                     f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
-                    f"{end_time.strftime('%Y/%m/%d')}/"
+                    f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
                     f"{jurisdiction}-{date_range}-report.zip"
                 )
             )
@@ -514,7 +514,7 @@ class TestGenerateTransactionReports(TstFunction):
             
             expected_jurisdiction_path = (
                 f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
-                f"{end_time.strftime('%Y/%m/%d')}/"
+                f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
                 f"{jurisdiction}-{date_range}-report.zip"
             )
             jurisdiction_payload = json.loads(jurisdiction_call['Payload'])
@@ -571,7 +571,7 @@ class TestGenerateTransactionReports(TstFunction):
                 Bucket=self.config.transaction_reports_bucket_name,
                 Key=(
                     f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
-                    f"{end_time.strftime('%Y/%m/%d')}/"
+                    f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
                     f"{jurisdiction}-{date_range}-report.zip"
                 )
             )
@@ -679,7 +679,7 @@ class TestGenerateTransactionReports(TstFunction):
                 Bucket=self.config.transaction_reports_bucket_name,
                 Key=(
                     f"compact/{TEST_COMPACT}/reports/jurisdiction-transactions/jurisdiction/{jurisdiction}/"
-                    f"{end_time.strftime('%Y/%m/%d')}/"
+                    f"reporting-cycle/weekly/{end_time.strftime('%Y/%m/%d')}/"
                     f"{jurisdiction}-{date_range}-report.zip"
                 )
             )

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -58,7 +58,8 @@ def _generate_mock_transaction(
             'description': f'Compact Privilege for {jurisdiction.upper()}',
             'itemId': f'{TEST_COMPACT}-{jurisdiction}',
             'name': f'{jurisdiction.upper()} Compact Privilege',
-            'quantity': '1',
+            # setting this as '1.0' to simulate behavior we've seen returned from authorize.net
+            'quantity': '1.0',
             'taxable': False,
             'unitPrice': MOCK_JURISDICTION_FEE,
         }

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -810,15 +810,15 @@ class TestGenerateTransactionReports(TstFunction):
     # event bridge triggers the monthly report at the first day of the month 5 mins after midnight UTC
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-03-01T00:05:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
-    def test_generate_monthly_report_includes_expected_settled_transactions_for_full_month_range(self, mock_lambda_client):
+    def test_generate_monthly_report_includes_expected_settled_transactions_for_full_month_range(
+        self, mock_lambda_client
+    ):
         """Test processing monthly report with full month range for Feb 2024 (leap year)."""
         from handlers.transaction_reporting import generate_transaction_reports
 
         _set_default_lambda_client_behavior(mock_lambda_client)
 
-        self._add_compact_configuration_data(
-            jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION]
-        )
+        self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])
 
         mock_user = self._add_mock_provider_to_db('12345', 'John', 'Doe')
         # Create a transaction with a privilege which is settled the first day of the month at midnight UTC

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -183,8 +183,8 @@ class TestGenerateTransactionReports(TstFunction):
                 record.update(jurisdiction)
                 self._compact_configuration_table.put_item(Item=record)
 
-    # event bridge triggers the weekly report at noon UTC-4 timezone
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
+    # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-05T22:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_transaction_reports_sends_csv_with_zero_values_when_no_transactions(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
@@ -197,11 +197,10 @@ class TestGenerateTransactionReports(TstFunction):
         # Set up mocked S3 bucket
 
         # Calculate expected date range
-        # the end date should be the current day at 11:59:59.999999 UTC
-        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
-        # the start date should be 7 days ago at noon UTC
-        start_time_day = end_time - timedelta(days=7)
-        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
+        # the end time should be Friday at 10:00 PM UTC
+        end_time = datetime.fromisoformat('2025-04-05T22:00:00+00:00')
+        # the start time should be 7 days ago at 10:00 PM UTC
+        start_time = end_time - timedelta(days=7)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         # Generate the reports
@@ -307,8 +306,8 @@ class TestGenerateTransactionReports(TstFunction):
                     ohio_content
                 )
 
-    # event bridge triggers the weekly report at noon UTC-4 timezone
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
+    # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-05T22:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_collects_transactions_across_two_months(self, mock_lambda_client):
         """Test successful processing of settled transactions."""
@@ -338,11 +337,10 @@ class TestGenerateTransactionReports(TstFunction):
         )
 
         # Calculate expected date range
-        # the end date should be the current day at 11:59:59.999999 UTC
-        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
-        # the start date should be 7 days ago at noon UTC
-        start_time_day = end_time - timedelta(days=7)
-        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
+        # the end time should be Friday at 10:00 PM UTC
+        end_time = datetime.fromisoformat('2025-04-05T22:00:00+00:00')
+        # the start time should be 7 days ago at 10:00 PM UTC
+        start_time = end_time - timedelta(days=7)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
@@ -457,8 +455,8 @@ class TestGenerateTransactionReports(TstFunction):
                         content
                     )
 
-    # event bridge triggers the weekly report at noon UTC-4 timezone
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
+    # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-05T22:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_with_multiple_privileges_in_single_transaction(self, mock_lambda_client):
         """Test processing of transactions with multiple privileges in a single transaction."""
@@ -481,11 +479,10 @@ class TestGenerateTransactionReports(TstFunction):
         )
 
         # Calculate expected date range
-        # the end date should be the current day at 11:59:59.999999 UTC
-        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
-        # the start date should be 7 days ago at noon UTC
-        start_time_day = end_time - timedelta(days=7)
-        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
+        # the end time should be Friday at 10:00 PM UTC
+        end_time = datetime.fromisoformat('2025-04-05T22:00:00+00:00')
+        # the start time should be 7 days ago at 10:00 PM UTC
+        start_time = end_time - timedelta(days=7)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
@@ -601,8 +598,8 @@ class TestGenerateTransactionReports(TstFunction):
                         content
                     )
 
-    # event bridge triggers the weekly report at noon UTC-4 timezone
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
+    # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-05T22:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_with_large_number_of_transactions_and_providers(self, mock_lambda_client):
         """Test processing of a large number of transactions (>500) and providers (>100)."""
@@ -632,11 +629,10 @@ class TestGenerateTransactionReports(TstFunction):
             )
 
         # Calculate expected date range
-        # the end date should be the current day at 11:59:59.999999 UTC
-        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
-        # the start date should be 7 days ago at noon UTC
-        start_time_day = end_time - timedelta(days=7)
-        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
+        # the end time should be Friday at 10:00 PM UTC
+        end_time = datetime.fromisoformat('2025-04-05T22:00:00+00:00')
+        # the start time should be 7 days ago at 10:00 PM UTC
+        start_time = end_time - timedelta(days=7)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         generate_transaction_reports(generate_mock_event(), self.mock_context)
@@ -718,7 +714,7 @@ class TestGenerateTransactionReports(TstFunction):
                     self.assertEqual('Privileges Purchased,Total State Amount,,,,,,', content[-3])
                     self.assertEqual('300,$30000.00,,,,,,', content[-2])
 
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-05T22:00:00+00:00'))
     def test_generate_report_raises_error_when_compact_not_found(self):
         """Test error handling when compact configuration is not found."""
         from handlers.transaction_reporting import generate_transaction_reports
@@ -729,7 +725,7 @@ class TestGenerateTransactionReports(TstFunction):
 
         self.assertIn('Compact configuration not found', str(exc_info.exception.message))
 
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T23:59:59+00:00'))
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-05T22:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_raises_error_when_lambda_returns_function_error(self, mock_lambda_client):
         """Test error handling when compact configuration is not found."""
@@ -743,8 +739,8 @@ class TestGenerateTransactionReports(TstFunction):
 
         self.assertIn('Something went wrong', str(exc_info.exception.message))
 
-    # event bridge triggers the weekly report at noon UTC-4 timezone
-    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-02T16:00:00+00:00'))
+    # event bridge triggers the weekly report at Friday 10:00 PM UTC (5:00 PM EST)
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2025-04-05T22:00:00+00:00'))
     @patch('handlers.transaction_reporting.config.lambda_client')
     def test_generate_report_handles_unknown_jurisdiction(self, mock_lambda_client):
         """Test handling of transactions with jurisdictions not in configuration.
@@ -756,11 +752,10 @@ class TestGenerateTransactionReports(TstFunction):
         _set_default_lambda_client_behavior(mock_lambda_client)
 
         # Calculate expected date range
-        # the end date should be the current day at 11:59:59.999999 UTC
-        end_time = datetime.fromisoformat('2025-04-02T11:59:59+00:00')
-        # the start date should be 7 days ago at noon UTC
-        start_time_day = end_time - timedelta(days=7)
-        start_time = start_time_day.replace(hour=12, minute=0, second=0, microsecond=0)
+        # the end time should be Friday at 10:00 PM UTC
+        end_time = datetime.fromisoformat('2025-04-05T22:00:00+00:00')
+        # the start time should be 7 days ago at 10:00 PM UTC
+        start_time = end_time - timedelta(days=7)
         date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
 
         self._add_compact_configuration_data(jurisdictions=[OHIO_JURISDICTION, KENTUCKY_JURISDICTION])

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -860,11 +860,11 @@ class TestGenerateTransactionReports(TstFunction):
         )
 
         # Calculate expected date range
-        # the end time should be the last day of the month
-        end_time = datetime.fromisoformat('2024-02-29T23:59:59:9999+00:00')
+        # the display end time should be the last day of the month
+        display_end_time = '2024-02-29'
         # the start time should be the first day of the month
-        start_time = datetime.fromisoformat('2024-02-01T00:00:00+00:00')
-        date_range = f"{start_time.strftime('%Y-%m-%d')}--{end_time.strftime('%Y-%m-%d')}"
+        display_start_time = '2024-02-01'
+        date_range = f'{display_start_time}--{display_end_time}'
 
         generate_transaction_reports(generate_mock_event(reporting_cycle='monthly'), self.mock_context)
 
@@ -877,9 +877,8 @@ class TestGenerateTransactionReports(TstFunction):
         self.assertEqual('RequestResponse', compact_call['InvocationType'])
 
         expected_compact_path = (
-            f"compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/monthly/"
-            f"{end_time.strftime('%Y/%m/%d')}/"
-            f"{TEST_COMPACT}-{date_range}-report.zip"
+            f'compact/{TEST_COMPACT}/reports/compact-transactions/reporting-cycle/monthly/2024/02/29/'
+            f'{TEST_COMPACT}-{date_range}-report.zip'
         )
         compact_payload = json.loads(compact_call['Payload'])
         self.assertEqual(
@@ -890,8 +889,8 @@ class TestGenerateTransactionReports(TstFunction):
                 'templateVariables': {
                     'reportS3Path': expected_compact_path,
                     'reportingCycle': 'monthly',
-                    'startDate': start_time.strftime('%Y-%m-%d'),
-                    'endDate': end_time.strftime('%Y-%m-%d'),
+                    'startDate': display_start_time,
+                    'endDate': display_end_time,
                 },
             },
             compact_payload,

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -27,6 +27,7 @@ from stacks.persistent_stack.rate_limiting_table import RateLimitingTable
 from stacks.persistent_stack.ssn_table import SSNTable
 from stacks.persistent_stack.staff_users import StaffUsers
 from stacks.persistent_stack.transaction_history_table import TransactionHistoryTable
+from stacks.persistent_stack.transaction_reports_bucket import TransactionReportsBucket
 from stacks.persistent_stack.user_email_notifications import UserEmailNotifications
 
 
@@ -182,6 +183,14 @@ class PersistentStack(AppStack):
             event_bus=self.data_event_bus,
         )
 
+        self.transaction_reports_bucket = TransactionReportsBucket(
+            self,
+            'TransactionReportsBucket',
+            access_logs_bucket=self.access_logs_bucket,
+            encryption_key=self.shared_encryption_key,
+            removal_policy=removal_policy,
+        )
+
         self.rate_limiting_table = RateLimitingTable(
             self,
             'RateLimitingTable',
@@ -252,6 +261,7 @@ class PersistentStack(AppStack):
             environment={
                 'FROM_ADDRESS': from_address,
                 'COMPACT_CONFIGURATION_TABLE_NAME': self.compact_configuration_table.table_name,
+                'TRANSACTION_REPORTS_BUCKET_NAME': self.transaction_reports_bucket.bucket_name,
                 'UI_BASE_PATH_URL': self._get_ui_base_path_url(),
                 'ENVIRONMENT_NAME': environment_name,
                 **self.common_env_vars,
@@ -260,6 +270,8 @@ class PersistentStack(AppStack):
 
         # Grant permissions to read compact configurations
         self.compact_configuration_table.grant_read_data(self.email_notification_service_lambda)
+        # Grant permissions to get report files for emailing reports
+        self.transaction_reports_bucket.grant_read(self.email_notification_service_lambda)
         # if there is no domain name, we can't set up SES permissions
         # in this case the lambda will perform a no-op when invoked.
         if self.hosted_zone:
@@ -273,7 +285,8 @@ class PersistentStack(AppStack):
                     'id': 'AwsSolutions-IAM5',
                     'reason': """
                               This policy contains wild-carded actions and resources but they are scoped to the
-                              specific actions, Table, and Email Identity that this lambda specifically needs access to.
+                              specific actions, reporting Bucket, Table, and Email Identity that this lambda
+                              specifically needs access to.
                               """,
                 },
             ],

--- a/backend/compact-connect/stacks/persistent_stack/transaction_reports_bucket.py
+++ b/backend/compact-connect/stacks/persistent_stack/transaction_reports_bucket.py
@@ -20,6 +20,11 @@ class TransactionReportsBucket(Bucket):
         encryption_key: IKey,
         **kwargs,
     ):
+        # TODO - we currently don't set a lifecycle policy on this buckets objects  # noqa: FIX002
+        #   as this will be included when we start supporting archival of old data in the system.
+        #   See https://github.com/csg-org/CompactConnect/issues/187
+        #   As part of that work, we will need to create a lifecycle policy to delete old reports
+        #   after a certain period of time so the storage size does not grow indefinitely.
         super().__init__(
             scope,
             construct_id,

--- a/backend/compact-connect/stacks/persistent_stack/transaction_reports_bucket.py
+++ b/backend/compact-connect/stacks/persistent_stack/transaction_reports_bucket.py
@@ -7,7 +7,6 @@ from common_constructs.access_logs_bucket import AccessLogsBucket
 from common_constructs.bucket import Bucket
 from constructs import Construct
 
-import stacks.persistent_stack as ps
 
 class TransactionReportsBucket(Bucket):
     """S3 bucket to store transaction report files."""

--- a/backend/compact-connect/stacks/persistent_stack/transaction_reports_bucket.py
+++ b/backend/compact-connect/stacks/persistent_stack/transaction_reports_bucket.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from aws_cdk.aws_kms import IKey
+from aws_cdk.aws_s3 import BucketEncryption, CorsRule, HttpMethods
+from cdk_nag import NagSuppressions
+from common_constructs.access_logs_bucket import AccessLogsBucket
+from common_constructs.bucket import Bucket
+from constructs import Construct
+
+import stacks.persistent_stack as ps
+
+class TransactionReportsBucket(Bucket):
+    """S3 bucket to store transaction report files."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        access_logs_bucket: AccessLogsBucket,
+        encryption_key: IKey,
+        **kwargs,
+    ):
+        super().__init__(
+            scope,
+            construct_id,
+            encryption=BucketEncryption.KMS,
+            encryption_key=encryption_key,
+            server_access_logs_bucket=access_logs_bucket,
+            versioned=True,
+            cors=[
+                CorsRule(
+                    allowed_methods=[HttpMethods.GET, HttpMethods.POST],
+                    allowed_origins=['*'],
+                    allowed_headers=['*'],
+                ),
+            ],
+            **kwargs,
+        )
+
+        NagSuppressions.add_resource_suppressions(
+            self,
+            suppressions=[
+                {
+                    'id': 'HIPAA.Security-S3BucketReplicationEnabled',
+                    'reason': 'This bucket is used to store read-only reports that can be regenerated as needed.',
+                },
+            ],
+        )

--- a/backend/compact-connect/stacks/persistent_stack/transaction_reports_bucket.py
+++ b/backend/compact-connect/stacks/persistent_stack/transaction_reports_bucket.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from aws_cdk.aws_kms import IKey
-from aws_cdk.aws_s3 import BucketEncryption, CorsRule, HttpMethods
+from aws_cdk.aws_s3 import BucketEncryption
 from cdk_nag import NagSuppressions
 from common_constructs.access_logs_bucket import AccessLogsBucket
 from common_constructs.bucket import Bucket
@@ -27,13 +27,6 @@ class TransactionReportsBucket(Bucket):
             encryption_key=encryption_key,
             server_access_logs_bucket=access_logs_bucket,
             versioned=True,
-            cors=[
-                CorsRule(
-                    allowed_methods=[HttpMethods.GET, HttpMethods.POST],
-                    allowed_origins=['*'],
-                    allowed_headers=['*'],
-                ),
-            ],
             **kwargs,
         )
 

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -178,7 +178,8 @@ class ReportingStack(AppStack):
             Rule(
                 self,
                 f'{compact.capitalize()}-WeeklyTransactionReportRule',
-                schedule=Schedule.cron(week_day='7', hour='1', minute='0', month='*', year='*'),
+                # Send weekly reports every Friday at 5:00 pm EST, which is 10:00 pm UTC
+                schedule=Schedule.cron(week_day='5', hour='22', minute='0', month='*', year='*'),
                 targets=[
                     LambdaFunction(
                         handler=self.transaction_reporter,
@@ -190,11 +191,12 @@ class ReportingStack(AppStack):
                 ],
             )
 
-            # Add monthly report rule to run every month on the first day of the month at midnight
+            # Monthly reports run every month on the first day of the month shortly after midnight UTC
+            # This helps ensure that our time range is the full month
             Rule(
                 self,
                 f'{compact.capitalize()}-MonthlyTransactionReportRule',
-                schedule=Schedule.cron(day='1', hour='0', minute='0', month='*', year='*'),
+                schedule=Schedule.cron(day='1', hour='0', minute='5', month='*', year='*'),
                 targets=[
                     LambdaFunction(
                         handler=self.transaction_reporter,

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -166,7 +166,7 @@ class ReportingStack(AppStack):
                     'id': 'AwsSolutions-IAM5',
                     'reason': """
                             This policy contains wild-carded actions and resources but they are scoped to the
-                            specific actions, KMS key, reporting bucket, and Tables that this lambda specifically 
+                            specific actions, KMS key, reporting bucket, and Tables that this lambda specifically
                             needs access to.
                             """,
                 },
@@ -183,10 +183,7 @@ class ReportingStack(AppStack):
                 targets=[
                     LambdaFunction(
                         handler=self.transaction_reporter,
-                        event=RuleTargetInput.from_object({
-                            'compact': compact.lower(),
-                            'reportingCycle': 'weekly'
-                        }),
+                        event=RuleTargetInput.from_object({'compact': compact.lower(), 'reportingCycle': 'weekly'}),
                     )
                 ],
             )
@@ -200,10 +197,7 @@ class ReportingStack(AppStack):
                 targets=[
                     LambdaFunction(
                         handler=self.transaction_reporter,
-                        event=RuleTargetInput.from_object({
-                            'compact': compact.lower(),
-                            'reportingCycle': 'monthly'
-                        }),
+                        event=RuleTargetInput.from_object({'compact': compact.lower(), 'reportingCycle': 'monthly'}),
                     )
                 ],
             )

--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -178,8 +178,8 @@ class ReportingStack(AppStack):
             Rule(
                 self,
                 f'{compact.capitalize()}-WeeklyTransactionReportRule',
-                # Send weekly reports every Friday at 5:00 pm EST, which is 10:00 pm UTC
-                schedule=Schedule.cron(week_day='5', hour='22', minute='0', month='*', year='*'),
+                # Send weekly reports every Friday at 10:00 PM UTC
+                schedule=Schedule.cron(week_day='FRI', hour='22', minute='0', month='*', year='*'),
                 targets=[
                     LambdaFunction(
                         handler=self.transaction_reporter,


### PR DESCRIPTION
CSG has requested that we implement automated monthly transaction reporting. This required several updates to increase the number of transactions that could be handled within a single report. Previously we were passing in the full csv report string to the email-service lambda payload, which was prone to a 6MB file size limit, now we are storing these reports in a compressed zip format in S3, and passing in the S3 key to the email service so it can pull down the file and attach the zip file to the email directly. This adds the needed infrastructure to support monthly reporting in a scaleable manner.

### Requirements List
- No new requirements, this change is backwards compatible with the current system

### Description List
- Added event bridge rule to trigger transaction reporter lambda on the first day of every month
- Added transaction reporting S3 bucket to store compiled csv report files in a compressed format
- Update email-notification-service node lambda to pull down report files from S3
- Fix formatting for reporting email body text to support markdown

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
-  Python tests added for monthly reporting code verification
- Verification of monthly report generation for over 100k transactions in sandbox environment.

Closes #493 
