### PR TITLE
Make attestations field required when purchasing privileges

### DIFF
--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/privilege/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/privilege/record.py
@@ -48,6 +48,7 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
     attestations = List(Nested(AttestationVersionRecordSchema()), required=True, allow_none=False)
     # the human-friendly identifier for this privilege
     privilegeId = String(required=True, allow_none=False)
+
     @pre_dump
     def generate_pk_sk(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
         in_data['pk'] = f'{in_data["compact"]}#PROVIDER#{in_data["providerId"]}'

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/privilege/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/privilege/record.py
@@ -45,10 +45,9 @@ class PrivilegeRecordSchema(CalculatedStatusRecordSchema):
     # the id of the transaction that was made when the user purchased the privilege
     compactTransactionId = String(required=False, allow_none=False)
     # list of attestations that were accepted when purchasing this privilege
-    attestations = List(Nested(AttestationVersionRecordSchema()), required=False, allow_none=False)
+    attestations = List(Nested(AttestationVersionRecordSchema()), required=True, allow_none=False)
     # the human-friendly identifier for this privilege
     privilegeId = String(required=True, allow_none=False)
-
     @pre_dump
     def generate_pk_sk(self, in_data, **kwargs):  # noqa: ARG001 unused-argument
         in_data['pk'] = f'{in_data["compact"]}#PROVIDER#{in_data["providerId"]}'

--- a/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
@@ -1,5 +1,4 @@
 import json
-import os
 from datetime import date
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -125,35 +124,30 @@ def _validate_attestations(compact: str, attestations: list[dict], has_active_mi
     # Get all latest attestations for this compact
     latest_attestations = config.compact_configuration_client.get_attestations_by_locale(compact=compact)
 
-    # TODO: We were asked not to enforce attestations until the frontend is updated # noqa: FIX002
-    #       to pass them in the request body. For now, we will simply check whatever
-    #       attestation is passed in to make sure it is the latest version. This conditional
-    #       should be removed once the frontend is updated to pass in all required attestations.
-    if os.environ.get('ENFORCE_ATTESTATIONS') == 'true':
-        # Build list of required attestations
-        required_ids = REQUIRED_ATTESTATION_IDS.copy()
-        if has_active_military_affiliation:
-            required_ids.append(MILITARY_ATTESTATION_ID)
+    # Build list of required attestations
+    required_ids = REQUIRED_ATTESTATION_IDS.copy()
+    if has_active_military_affiliation:
+        required_ids.append(MILITARY_ATTESTATION_ID)
 
-        # Validate investigation attestations - exactly one must be provided
-        investigation_attestations = [a for a in attestations if a['attestationId'] in INVESTIGATION_ATTESTATION_IDS]
-        if len(investigation_attestations) != 1:
-            raise CCInvalidRequestException(
-                'Exactly one investigation attestation must be provided '
-                f'(either {INVESTIGATION_ATTESTATION_IDS[0]} or {INVESTIGATION_ATTESTATION_IDS[1]})'
-            )
-        required_ids.append(investigation_attestations[0]['attestationId'])
+    # Validate investigation attestations - exactly one must be provided
+    investigation_attestations = [a for a in attestations if a['attestationId'] in INVESTIGATION_ATTESTATION_IDS]
+    if len(investigation_attestations) != 1:
+        raise CCInvalidRequestException(
+            'Exactly one investigation attestation must be provided '
+            f'(either {INVESTIGATION_ATTESTATION_IDS[0]} or {INVESTIGATION_ATTESTATION_IDS[1]})'
+        )
+    required_ids.append(investigation_attestations[0]['attestationId'])
 
-        # Check that all required attestations are present
-        provided_ids = {a['attestationId'] for a in attestations}
-        missing_ids = set(required_ids) - provided_ids
-        if missing_ids:
-            raise CCInvalidRequestException(f'Missing required attestations: {", ".join(missing_ids)}')
+    # Check that all required attestations are present
+    provided_ids = {a['attestationId'] for a in attestations}
+    missing_ids = set(required_ids) - provided_ids
+    if missing_ids:
+        raise CCInvalidRequestException(f'Missing required attestations: {", ".join(missing_ids)}')
 
-        # Check for any invalid attestation IDs
-        invalid_ids = provided_ids - set(required_ids)
-        if invalid_ids:
-            raise CCInvalidRequestException(f'Invalid attestations provided: {", ".join(invalid_ids)}')
+    # Check for any invalid attestation IDs
+    invalid_ids = provided_ids - set(required_ids)
+    if invalid_ids:
+        raise CCInvalidRequestException(f'Invalid attestations provided: {", ".join(invalid_ids)}')
 
     # Verify all provided attestations are the latest version
     for attestation in attestations:

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -83,9 +83,6 @@ class TestPostPurchasePrivileges(TstFunction):
         from cc_common.data_model.schema.attestation import AttestationRecordSchema
 
         super().setUp()
-        # set the feature flag to enable the attestation validation feature
-        # this should be removed when the feature is enabled by default
-        os.environ.update({'ENFORCE_ATTESTATIONS': 'true'})
         # Load test attestation data
         with open('../common/tests/resources/dynamo/attestation.json') as f:
             test_attestation = json.load(f)
@@ -612,25 +609,6 @@ class TestPostPurchasePrivileges(TstFunction):
             {'attestationId': 'military-affiliation-confirmation-attestation', 'version': '1'}
         )
         event['body'] = json.dumps(event_body)
-
-        resp = post_purchase_privileges(event, self.mock_context)
-        self.assertEqual(200, resp['statusCode'], resp['body'])
-
-    # TODO - remove this test once the feature flag is removed # noqa: FIX002
-    @patch('handlers.privileges.PurchaseClient')
-    def test_post_purchase_privileges_should_not_validate_attestations_if_flag_not_set(
-        self, mock_purchase_client_constructor
-    ):
-        """Test that military attestation is required when user has active military affiliation."""
-        from handlers.privileges import post_purchase_privileges
-
-        os.environ.update({'ENFORCE_ATTESTATIONS': 'false'})
-
-        self._when_purchase_client_successfully_processes_request(mock_purchase_client_constructor)
-        self._load_military_affiliation_record_data(status='active')
-
-        event = self._when_testing_provider_user_event_with_custom_claims()
-        event['body'] = _generate_test_request_body(attestations=[])
 
         resp = post_purchase_privileges(event, self.mock_context)
         self.assertEqual(200, resp['statusCode'], resp['body'])

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -1,5 +1,4 @@
 import json
-import os
 from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, patch
 

--- a/backend/compact-connect/migration_scripts/attestations_required.py
+++ b/backend/compact-connect/migration_scripts/attestations_required.py
@@ -13,9 +13,8 @@ def update_privileges_missing_attestations(table_name: str, dry_run: bool = Fals
     Scans the provider table for privilege records missing the attestations field
     and adds an empty attestations list to them.
 
-    Args:
-        table_name: The name of the DynamoDB table to update
-        dry_run: If True, only print what would be updated without making changes
+    :param table_name: The name of the DynamoDB table to update
+    :param dry_run: If True, only print what would be updated without making changes
     """
     dynamodb = boto3.resource('dynamodb')
     table = dynamodb.Table(table_name)

--- a/backend/compact-connect/migration_scripts/attestations_required.py
+++ b/backend/compact-connect/migration_scripts/attestations_required.py
@@ -1,0 +1,74 @@
+# ruff: noqa: T201  we use print statements for migration scripts
+#!/usr/bin/env python3
+import argparse
+
+import boto3
+
+# This migration script updates privilege records that don't have an attestations field
+# by adding an empty attestations list to them.
+
+
+def update_privileges_missing_attestations(table_name: str, dry_run: bool = False) -> None:
+    """
+    Scans the provider table for privilege records missing the attestations field
+    and adds an empty attestations list to them.
+
+    Args:
+        table_name: The name of the DynamoDB table to update
+        dry_run: If True, only print what would be updated without making changes
+    """
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table(table_name)
+
+    # Get all privilege records
+    scan_kwargs = {
+        'FilterExpression': 'contains(#type_attr, :type_value)',
+        'ExpressionAttributeNames': {'#type_attr': 'type'},
+        'ExpressionAttributeValues': {':type_value': 'privilege'},
+    }
+
+    updated_count = 0
+    try:
+        done = False
+        start_key = None
+        while not done:
+            if start_key:
+                scan_kwargs['ExclusiveStartKey'] = start_key
+            response = table.scan(**scan_kwargs)
+            items = response.get('Items', [])
+
+            for item in items:
+                # Check if attestations field is missing
+                if 'attestations' not in item:
+                    print(f"{'Would update' if dry_run else 'Updating'} record with pk={item['pk']}, sk={item['sk']}")
+
+                    if not dry_run:
+                        # Update the item with an empty attestations list
+                        table.update_item(
+                            Key={'pk': item['pk'], 'sk': item['sk']},
+                            UpdateExpression='SET attestations = :empty_list',
+                            ExpressionAttributeValues={':empty_list': []},
+                        )
+                    updated_count += 1
+
+            start_key = response.get('LastEvaluatedKey')
+            done = start_key is None
+
+        print(f"{'Would have updated' if dry_run else 'Successfully updated'} {updated_count} privilege records")
+
+    except Exception as e:
+        print(f'Error updating privileges: {str(e)}')
+        raise
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Update privilege records to include empty attestations list if missing'
+    )
+    parser.add_argument('table_name', help='The name of the DynamoDB table to update')
+    parser.add_argument('-d', '--dry-run', action='store_true', help='Perform a dry run without making any changes')
+
+    args = parser.parse_args()
+
+    print(f"Starting migration on table: {args.table_name} {'(DRY RUN)' if args.dry_run else ''}")
+    update_privileges_missing_attestations(args.table_name, args.dry_run)

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -480,7 +480,7 @@ class ApiModel:
             description='Post purchase privileges request model',
             schema=JsonSchema(
                 type=JsonSchemaType.OBJECT,
-                required=['selectedJurisdictions', 'orderInformation'],
+                required=['selectedJurisdictions', 'orderInformation', 'attestations'],
                 properties={
                     'selectedJurisdictions': JsonSchema(
                         type=JsonSchemaType.ARRAY,

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
@@ -174,7 +174,8 @@
   },
   "required": [
     "selectedJurisdictions",
-    "orderInformation"
+    "orderInformation",
+    "attestations"
   ],
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#"


### PR DESCRIPTION
Now that the frontend has been updated to pass in attestations when purchasing privileges, we are making the field required both on the API endpoint as well as the privilege schema.

### Requirements List
- 🚨🚨**BREAKING CHANGE**🚨🚨This change is incompatible with old privilege records that do not have a list of attestations, any invalid privilege records will need to be deleted or updated to include an 'attestations' field. A migration script has been added as part of this PR which devs can run to fix their environments.

### Description List
- Update privilege schema to make attestations field required
- Update POST purchase API endpoint request schema to make attestations required
- Remove flag gating enforcement of attestation versions

### Testing List
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- Code review

Closes #425 
