### PR TITLE
Feat/support licensee transaction fees

### DIFF
--- a/backend/compact-connect/compact-config/aslp.yml
+++ b/backend/compact-connect/compact-config/aslp.yml
@@ -4,9 +4,6 @@ compactCommissionFee:
     feeType: "FLAT_RATE"
     feeAmount: 3.50
 transactionFeeConfiguration:
-    processorFees: 
-        percentageRate: 2.9  
-        fixedRatePerTransaction: 0.30
     licenseeCharges:
         active: true
         chargeType: "FLAT_FEE_PER_PRIVILEGE"

--- a/backend/compact-connect/compact-config/aslp.yml
+++ b/backend/compact-connect/compact-config/aslp.yml
@@ -3,6 +3,14 @@ compactName: "aslp"
 compactCommissionFee:
     feeType: "FLAT_RATE"
     feeAmount: 3.50
+transactionFeeConfiguration:
+    processorFees: 
+        percentageRate: 2.9  
+        fixedRatePerTransaction: 0.30
+    licenseeCharges:
+        active: true
+        chargeType: "FLAT_FEE_PER_PRIVILEGE"
+        chargeAmount: 3.00
 compactOperationsTeamEmails: []
 compactAdverseActionsNotificationEmails: []
 compactSummaryReportNotificationEmails: []

--- a/backend/compact-connect/compact-config/coun.yml
+++ b/backend/compact-connect/compact-config/coun.yml
@@ -3,6 +3,10 @@ compactName: "coun"
 compactCommissionFee:
     feeType: "FLAT_RATE"
     feeAmount: 3.50
+transactionFeeConfiguration:
+    processorFees: 
+        percentageRate: 2.9  
+        fixedRatePerTransaction: 0.30
 compactOperationsTeamEmails: []
 compactAdverseActionsNotificationEmails: []
 compactSummaryReportNotificationEmails: []

--- a/backend/compact-connect/compact-config/coun.yml
+++ b/backend/compact-connect/compact-config/coun.yml
@@ -3,10 +3,6 @@ compactName: "coun"
 compactCommissionFee:
     feeType: "FLAT_RATE"
     feeAmount: 3.50
-transactionFeeConfiguration:
-    processorFees: 
-        percentageRate: 2.9  
-        fixedRatePerTransaction: 0.30
 compactOperationsTeamEmails: []
 compactAdverseActionsNotificationEmails: []
 compactSummaryReportNotificationEmails: []

--- a/backend/compact-connect/compact-config/octp.yml
+++ b/backend/compact-connect/compact-config/octp.yml
@@ -4,9 +4,6 @@ compactCommissionFee:
     feeType: "FLAT_RATE"
     feeAmount: 3.50
 transactionFeeConfiguration:
-    processorFees: 
-        percentageRate: 2.9  
-        fixedRatePerTransaction: 0.30
     licenseeCharges:
         active: true
         chargeType: "FLAT_FEE_PER_PRIVILEGE"

--- a/backend/compact-connect/compact-config/octp.yml
+++ b/backend/compact-connect/compact-config/octp.yml
@@ -3,6 +3,14 @@ compactName: "octp"
 compactCommissionFee:
     feeType: "FLAT_RATE"
     feeAmount: 3.50
+transactionFeeConfiguration:
+    processorFees: 
+        percentageRate: 2.9  
+        fixedRatePerTransaction: 0.30
+    licenseeCharges:
+        active: true
+        chargeType: "FLAT_FEE_PER_PRIVILEGE"
+        chargeAmount: 3.00
 compactOperationsTeamEmails: []
 compactAdverseActionsNotificationEmails: []
 compactSummaryReportNotificationEmails: []

--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "LicenseApi",
-    "version": "2025-02-05T21:10:07Z"
+    "version": "2025-02-06T16:08:27Z"
   },
   "servers": [
     {
@@ -44,7 +44,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenJwkX1M19iehD"
+                  "$ref": "#/components/schemas/SandboLicenxwmHa2Q438IJ"
                 }
               }
             }
@@ -81,7 +81,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenQmuWrxvHrNne"
+                "$ref": "#/components/schemas/SandboLicenM3v1DQsiYo0I"
               }
             }
           },
@@ -93,7 +93,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenCKI8MYY04rNP"
+                  "$ref": "#/components/schemas/SandboLicennsxzW9stMafI"
                 }
               }
             }
@@ -142,7 +142,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicensqVdeqIDiTUV"
+                "$ref": "#/components/schemas/SandboLicenOBKe66xJrnUY"
               }
             }
           },
@@ -154,7 +154,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenBHELNobWpOAZ"
+                  "$ref": "#/components/schemas/SandboLicenZpJMDau4cDdN"
                 }
               }
             }
@@ -205,7 +205,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenkelmvshNMdxq"
+                  "$ref": "#/components/schemas/SandboLicenC0IHjjHMelH4"
                 }
               }
             }
@@ -246,7 +246,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenkzXEuzbeBMcD"
+                "$ref": "#/components/schemas/SandboLicenZtKJxTXXg5UL"
               }
             }
           },
@@ -258,7 +258,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenk4wMidJp4tSI"
+                  "$ref": "#/components/schemas/SandboLicenWHrz3Lh8eYZP"
                 }
               }
             }
@@ -309,7 +309,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenPWICF4WAig5B"
+                  "$ref": "#/components/schemas/SandboLicenDdBuFYJj4W5C"
                 }
               }
             }
@@ -351,7 +351,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennisEwvBxWQhC"
+                  "$ref": "#/components/schemas/SandboLicenAYFFIt5ce2HI"
                 }
               }
             }
@@ -382,7 +382,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenDIQiicBLz4mm"
+                "$ref": "#/components/schemas/SandboLicenzMeGyfqdYCbr"
               }
             }
           },
@@ -401,7 +401,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -444,7 +444,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -461,7 +461,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -502,7 +502,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -512,7 +512,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -551,7 +551,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenNYOXdr8q1V6F"
+                "$ref": "#/components/schemas/SandboLiceneEbMkNNP0wku"
               }
             }
           },
@@ -563,7 +563,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -580,7 +580,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -623,7 +623,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -633,7 +633,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -668,7 +668,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenPWICF4WAig5B"
+                  "$ref": "#/components/schemas/SandboLicenDdBuFYJj4W5C"
                 }
               }
             }
@@ -697,7 +697,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenVl4LxvKwNI3S"
+                "$ref": "#/components/schemas/SandboLicencgqVAvZnWkMG"
               }
             }
           },
@@ -709,7 +709,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenXS5uvP2iI0Bd"
+                  "$ref": "#/components/schemas/SandboLicenKugXONwl77RZ"
                 }
               }
             }
@@ -736,7 +736,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicen3bd9q60ck5Mk"
+                "$ref": "#/components/schemas/SandboLicenvclXpdeW3Y28"
               }
             }
           },
@@ -748,7 +748,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -767,7 +767,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenUEBOJMrsNHnm"
+                "$ref": "#/components/schemas/SandboLicennCBAWSBaWj85"
               }
             }
           },
@@ -779,7 +779,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -803,7 +803,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicendmj7qfw2x1tR"
+                "$ref": "#/components/schemas/SandboLicenGA3a6Jf5sr6W"
               }
             }
           },
@@ -815,7 +815,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenTrpoUes4Xu35"
+                  "$ref": "#/components/schemas/SandboLicen2gYLvhizuSaW"
                 }
               }
             }
@@ -846,7 +846,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenicEElMwlVowu"
+                  "$ref": "#/components/schemas/SandboLicenIlcgezTgAmMg"
                 }
               }
             }
@@ -867,7 +867,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -884,7 +884,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -903,7 +903,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicencwCJNumn5Our"
+                "$ref": "#/components/schemas/SandboLicenj65itQcZP12q"
               }
             }
           },
@@ -915,7 +915,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenyYKFQAIjlFCn"
+                  "$ref": "#/components/schemas/SandboLicenYgKyaZjnxxpR"
                 }
               }
             }
@@ -932,7 +932,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenq0WHjwuOL0r5"
+                  "$ref": "#/components/schemas/SandboLicenUL01PEWATEUT"
                 }
               }
             }
@@ -950,305 +950,7 @@
   },
   "components": {
     "schemas": {
-      "SandboLicenBHELNobWpOAZ": {
-        "required": [
-          "message"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenkzXEuzbeBMcD": {
-        "required": [
-          "query"
-        ],
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "string"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            },
-            "additionalProperties": false
-          },
-          "query": {
-            "type": "object",
-            "properties": {
-              "providerId": {
-                "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
-                "type": "string",
-                "description": "Internal UUID for the provider"
-              },
-              "jurisdiction": {
-                "type": "string",
-                "description": "Filter for providers with privilege/license in a jurisdiction",
-                "enum": [
-                  "al",
-                  "ak",
-                  "az",
-                  "ar",
-                  "ca",
-                  "co",
-                  "ct",
-                  "de",
-                  "dc",
-                  "fl",
-                  "ga",
-                  "hi",
-                  "id",
-                  "il",
-                  "in",
-                  "ia",
-                  "ks",
-                  "ky",
-                  "la",
-                  "me",
-                  "md",
-                  "ma",
-                  "mi",
-                  "mn",
-                  "ms",
-                  "mo",
-                  "mt",
-                  "ne",
-                  "nv",
-                  "nh",
-                  "nj",
-                  "nm",
-                  "ny",
-                  "nc",
-                  "nd",
-                  "oh",
-                  "ok",
-                  "or",
-                  "pa",
-                  "pr",
-                  "ri",
-                  "sc",
-                  "sd",
-                  "tn",
-                  "tx",
-                  "ut",
-                  "vt",
-                  "va",
-                  "vi",
-                  "wa",
-                  "wv",
-                  "wi",
-                  "wy"
-                ]
-              },
-              "ssn": {
-                "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-                "type": "string",
-                "description": "Social security number to look up"
-              }
-            },
-            "description": "The query parameters"
-          },
-          "sorting": {
-            "required": [
-              "key"
-            ],
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "description": "The key to sort results by",
-                "enum": [
-                  "dateOfUpdate",
-                  "familyName"
-                ]
-              },
-              "direction": {
-                "type": "string",
-                "description": "Direction to sort results by",
-                "enum": [
-                  "ascending",
-                  "descending"
-                ]
-              }
-            },
-            "description": "How to sort results"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenVl4LxvKwNI3S": {
-        "required": [
-          "affiliationType",
-          "fileNames"
-        ],
-        "type": "object",
-        "properties": {
-          "affiliationType": {
-            "type": "string",
-            "description": "The type of military affiliation",
-            "enum": [
-              "militaryMember",
-              "militaryMemberSpouse"
-            ]
-          },
-          "fileNames": {
-            "type": "array",
-            "description": "List of military affiliation file names",
-            "items": {
-              "maxLength": 150,
-              "type": "string",
-              "description": "The name of the file being uploaded"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenkelmvshNMdxq": {
-        "required": [
-          "fields"
-        ],
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "url": {
-            "type": "string"
-          }
-        }
-      },
-      "SandboLicenUEBOJMrsNHnm": {
-        "required": [
-          "compact",
-          "dob",
-          "email",
-          "familyName",
-          "givenName",
-          "jurisdiction",
-          "licenseType",
-          "partialSocial",
-          "token"
-        ],
-        "type": "object",
-        "properties": {
-          "licenseType": {
-            "maxLength": 500,
-            "type": "string",
-            "description": "Type of license"
-          },
-          "compact": {
-            "maxLength": 100,
-            "type": "string",
-            "description": "Compact name"
-          },
-          "dob": {
-            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-            "type": "string",
-            "description": "Date of birth in YYYY-MM-DD format"
-          },
-          "givenName": {
-            "maxLength": 200,
-            "type": "string",
-            "description": "Provider's given name"
-          },
-          "familyName": {
-            "maxLength": 200,
-            "type": "string",
-            "description": "Provider's family name"
-          },
-          "jurisdiction": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "Two-letter jurisdiction code",
-            "enum": [
-              "al",
-              "ak",
-              "az",
-              "ar",
-              "ca",
-              "co",
-              "ct",
-              "de",
-              "dc",
-              "fl",
-              "ga",
-              "hi",
-              "id",
-              "il",
-              "in",
-              "ia",
-              "ks",
-              "ky",
-              "la",
-              "me",
-              "md",
-              "ma",
-              "mi",
-              "mn",
-              "ms",
-              "mo",
-              "mt",
-              "ne",
-              "nv",
-              "nh",
-              "nj",
-              "nm",
-              "ny",
-              "nc",
-              "nd",
-              "oh",
-              "ok",
-              "or",
-              "pa",
-              "pr",
-              "ri",
-              "sc",
-              "sd",
-              "tn",
-              "tx",
-              "ut",
-              "vt",
-              "va",
-              "vi",
-              "wa",
-              "wv",
-              "wi",
-              "wy"
-            ]
-          },
-          "partialSocial": {
-            "maxLength": 4,
-            "minLength": 4,
-            "type": "string",
-            "description": "Last 4 digits of SSN"
-          },
-          "email": {
-            "maxLength": 100,
-            "type": "string",
-            "description": "Provider's email address"
-          },
-          "token": {
-            "type": "string",
-            "description": "ReCAPTCHA token"
-          }
-        }
-      },
-      "SandboLicenk4wMidJp4tSI": {
+      "SandboLicenWHrz3Lh8eYZP": {
         "required": [
           "pagination"
         ],
@@ -1567,7 +1269,345 @@
           }
         }
       },
-      "SandboLicennisEwvBxWQhC": {
+      "SandboLiceneEbMkNNP0wku": {
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "readPrivate": {
+                      "type": "boolean"
+                    },
+                    "read": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jurisdictions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "readPrivate": {
+                            "type": "boolean"
+                          },
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "write": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicennsxzW9stMafI": {
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the request"
+          }
+        }
+      },
+      "SandboLicenC0IHjjHMelH4": {
+        "required": [
+          "fields"
+        ],
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "SandboLicenOBKe66xJrnUY": {
+        "maxLength": 100,
+        "type": "array",
+        "items": {
+          "required": [
+            "dateOfBirth",
+            "dateOfExpiration",
+            "dateOfIssuance",
+            "dateOfRenewal",
+            "familyName",
+            "givenName",
+            "homeAddressCity",
+            "homeAddressPostalCode",
+            "homeAddressState",
+            "homeAddressStreet1",
+            "licenseType",
+            "ssn",
+            "status"
+          ],
+          "type": "object",
+          "properties": {
+            "homeAddressStreet2": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "npi": {
+              "pattern": "^[0-9]{10}$",
+              "type": "string"
+            },
+            "homeAddressPostalCode": {
+              "maxLength": 7,
+              "minLength": 5,
+              "type": "string"
+            },
+            "givenName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeAddressStreet1": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "militaryWaiver": {
+              "type": "boolean"
+            },
+            "dateOfBirth": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfIssuance": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "ssn": {
+              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+              "type": "string"
+            },
+            "licenseType": {
+              "type": "string",
+              "enum": [
+                "audiologist",
+                "speech-language pathologist",
+                "occupational therapist",
+                "occupational therapy assistant",
+                "licensed professional counselor"
+              ]
+            },
+            "dateOfExpiration": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "homeAddressState": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "dateOfRenewal": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "familyName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeAddressCity": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "licenseNumber": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "middleName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "active",
+                "inactive"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "SandboLicennCBAWSBaWj85": {
+        "required": [
+          "compact",
+          "dob",
+          "email",
+          "familyName",
+          "givenName",
+          "jurisdiction",
+          "licenseType",
+          "partialSocial",
+          "token"
+        ],
+        "type": "object",
+        "properties": {
+          "licenseType": {
+            "maxLength": 500,
+            "type": "string",
+            "description": "Type of license"
+          },
+          "compact": {
+            "maxLength": 100,
+            "type": "string",
+            "description": "Compact name"
+          },
+          "dob": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "type": "string",
+            "description": "Date of birth in YYYY-MM-DD format"
+          },
+          "givenName": {
+            "maxLength": 200,
+            "type": "string",
+            "description": "Provider's given name"
+          },
+          "familyName": {
+            "maxLength": 200,
+            "type": "string",
+            "description": "Provider's family name"
+          },
+          "jurisdiction": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "Two-letter jurisdiction code",
+            "enum": [
+              "al",
+              "ak",
+              "az",
+              "ar",
+              "ca",
+              "co",
+              "ct",
+              "de",
+              "dc",
+              "fl",
+              "ga",
+              "hi",
+              "id",
+              "il",
+              "in",
+              "ia",
+              "ks",
+              "ky",
+              "la",
+              "me",
+              "md",
+              "ma",
+              "mi",
+              "mn",
+              "ms",
+              "mo",
+              "mt",
+              "ne",
+              "nv",
+              "nh",
+              "nj",
+              "nm",
+              "ny",
+              "nc",
+              "nd",
+              "oh",
+              "ok",
+              "or",
+              "pa",
+              "pr",
+              "ri",
+              "sc",
+              "sd",
+              "tn",
+              "tx",
+              "ut",
+              "vt",
+              "va",
+              "vi",
+              "wa",
+              "wv",
+              "wi",
+              "wy"
+            ]
+          },
+          "partialSocial": {
+            "maxLength": 4,
+            "minLength": 4,
+            "type": "string",
+            "description": "Last 4 digits of SSN"
+          },
+          "email": {
+            "maxLength": 100,
+            "type": "string",
+            "description": "Provider's email address"
+          },
+          "token": {
+            "type": "string",
+            "description": "ReCAPTCHA token"
+          }
+        }
+      },
+      "SandboLicenj65itQcZP12q": {
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenAYFFIt5ce2HI": {
         "type": "object",
         "properties": {
           "pagination": {
@@ -1690,199 +1730,393 @@
         },
         "additionalProperties": false
       },
-      "SandboLicendmj7qfw2x1tR": {
+      "SandboLicenzMeGyfqdYCbr": {
         "required": [
-          "orderInformation",
-          "selectedJurisdictions"
+          "attributes",
+          "permissions"
         ],
         "type": "object",
         "properties": {
-          "attestations": {
-            "type": "array",
-            "description": "List of attestations that the user has agreed to",
-            "items": {
-              "required": [
-                "attestationId",
-                "version"
-              ],
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
               "type": "object",
               "properties": {
-                "attestationId": {
-                  "maxLength": 100,
-                  "type": "string",
-                  "description": "The ID of the attestation"
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "readPrivate": {
+                      "type": "boolean"
+                    },
+                    "read": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    }
+                  }
                 },
-                "version": {
-                  "maxLength": 10,
-                  "pattern": "^\\d+$",
-                  "type": "string",
-                  "description": "The version of the attestation"
-                }
-              }
-            }
-          },
-          "orderInformation": {
-            "required": [
-              "billing",
-              "card"
-            ],
-            "type": "object",
-            "properties": {
-              "card": {
-                "required": [
-                  "cvv",
-                  "expiration",
-                  "number"
-                ],
-                "type": "object",
-                "properties": {
-                  "number": {
-                    "maxLength": 19,
-                    "minLength": 13,
-                    "type": "string",
-                    "description": "The card number"
-                  },
-                  "cvv": {
-                    "maxLength": 4,
-                    "minLength": 3,
-                    "type": "string",
-                    "description": "The card cvv"
-                  },
-                  "expiration": {
-                    "maxLength": 7,
-                    "minLength": 7,
-                    "type": "string",
-                    "description": "The card expiration date"
+                "jurisdictions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "readPrivate": {
+                            "type": "boolean"
+                          },
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "write": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
                   }
                 }
               },
-              "billing": {
-                "required": [
-                  "firstName",
-                  "lastName",
-                  "state",
-                  "streetAddress",
-                  "zip"
-                ],
-                "type": "object",
-                "properties": {
-                  "zip": {
-                    "maxLength": 10,
-                    "minLength": 5,
-                    "type": "string",
-                    "description": "The zip code for the card"
-                  },
-                  "firstName": {
-                    "maxLength": 100,
-                    "minLength": 1,
-                    "type": "string",
-                    "description": "The first name on the card"
-                  },
-                  "lastName": {
-                    "maxLength": 100,
-                    "minLength": 1,
-                    "type": "string",
-                    "description": "The last name on the card"
-                  },
-                  "streetAddress": {
-                    "maxLength": 150,
-                    "minLength": 2,
-                    "type": "string",
-                    "description": "The street address for the card"
-                  },
-                  "streetAddress2": {
-                    "maxLength": 150,
-                    "type": "string",
-                    "description": "The second street address for the card"
-                  },
-                  "state": {
-                    "maxLength": 2,
-                    "minLength": 2,
-                    "type": "string",
-                    "description": "The state postal abbreviation for the card"
-                  }
-                }
+              "additionalProperties": false
+            }
+          },
+          "attributes": {
+            "required": [
+              "email",
+              "familyName",
+              "givenName"
+            ],
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "email": {
+                "maxLength": 100,
+                "minLength": 5,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenIlcgezTgAmMg": {
+        "required": [
+          "items",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "lastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
               }
             }
           },
-          "selectedJurisdictions": {
+          "items": {
             "maxLength": 100,
             "type": "array",
             "items": {
-              "type": "string",
-              "description": "Jurisdictions a provider has selected to purchase privileges in.",
-              "enum": [
-                "al",
-                "ak",
-                "az",
-                "ar",
-                "ca",
-                "co",
-                "ct",
-                "de",
-                "dc",
-                "fl",
-                "ga",
-                "hi",
-                "id",
-                "il",
-                "in",
-                "ia",
-                "ks",
-                "ky",
-                "la",
-                "me",
-                "md",
-                "ma",
-                "mi",
-                "mn",
-                "ms",
-                "mo",
-                "mt",
-                "ne",
-                "nv",
-                "nh",
-                "nj",
-                "nm",
-                "ny",
-                "nc",
-                "nd",
-                "oh",
-                "ok",
-                "or",
-                "pa",
-                "pr",
-                "ri",
-                "sc",
-                "sd",
-                "tn",
-                "tx",
-                "ut",
-                "vt",
-                "va",
-                "vi",
-                "wa",
-                "wv",
-                "wi",
-                "wy"
+              "type": "object",
+              "oneOf": [
+                {
+                  "required": [
+                    "compactCommissionFee",
+                    "compactName",
+                    "transactionFeeConfiguration",
+                    "type"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "compactCommissionFee": {
+                      "required": [
+                        "feeAmount",
+                        "feeType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "feeAmount": {
+                          "type": "number"
+                        },
+                        "feeType": {
+                          "type": "string",
+                          "enum": [
+                            "FLAT_RATE"
+                          ]
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "compact"
+                      ]
+                    },
+                    "transactionFeeConfiguration": {
+                      "required": [
+                        "licenseeCharges"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "licenseeCharges": {
+                          "required": [
+                            "active",
+                            "chargeAmount",
+                            "chargeType"
+                          ],
+                          "type": "object",
+                          "properties": {
+                            "chargeType": {
+                              "type": "string",
+                              "description": "The type of transaction fee charge",
+                              "enum": [
+                                "FLAT_FEE_PER_PRIVILEGE"
+                              ]
+                            },
+                            "active": {
+                              "type": "boolean",
+                              "description": "Whether the compact is charging licensees transaction fees"
+                            },
+                            "chargeAmount": {
+                              "type": "number",
+                              "description": "The amount to charge per privilege purchased"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "compactName": {
+                      "type": "string",
+                      "description": "The name of the compact"
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "jurisdictionFee",
+                    "jurisdictionName",
+                    "jurisprudenceRequirements",
+                    "postalAbbreviation",
+                    "type"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "militaryDiscount": {
+                      "required": [
+                        "active",
+                        "discountAmount",
+                        "discountType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the military discount is active"
+                        },
+                        "discountAmount": {
+                          "type": "number",
+                          "description": "The amount of the discount"
+                        },
+                        "discountType": {
+                          "type": "string",
+                          "description": "The type of discount",
+                          "enum": [
+                            "FLAT_RATE"
+                          ]
+                        }
+                      }
+                    },
+                    "postalAbbreviation": {
+                      "type": "string",
+                      "description": "The postal abbreviation of the jurisdiction"
+                    },
+                    "jurisprudenceRequirements": {
+                      "required": [
+                        "required"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether jurisprudence requirements exist"
+                        }
+                      }
+                    },
+                    "jurisdictionName": {
+                      "type": "string",
+                      "description": "The name of the jurisdiction"
+                    },
+                    "jurisdictionFee": {
+                      "type": "number",
+                      "description": "The fee for the jurisdiction"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "jurisdiction"
+                      ]
+                    }
+                  }
+                }
               ]
             }
           }
         }
       },
-      "SandboLicenCKI8MYY04rNP": {
+      "SandboLicenKugXONwl77RZ": {
         "required": [
-          "message"
+          "affiliationType",
+          "dateOfUpdate",
+          "dateOfUpload",
+          "documentUploadFields",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfUpload": {
+            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+            "type": "string",
+            "description": "The date the document was uploaded",
+            "format": "date"
+          },
+          "affiliationType": {
+            "type": "string",
+            "description": "The type of military affiliation",
+            "enum": [
+              "militaryMember",
+              "militaryMemberSpouse"
+            ]
+          },
+          "fileNames": {
+            "type": "array",
+            "description": "List of military affiliation file names",
+            "items": {
+              "type": "string",
+              "description": "The name of the file being uploaded"
+            }
+          },
+          "dateOfUpdate": {
+            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+            "type": "string",
+            "description": "The date the document was last updated",
+            "format": "date"
+          },
+          "status": {
+            "type": "string",
+            "description": "The status of the military affiliation"
+          },
+          "documentUploadFields": {
+            "type": "array",
+            "description": "The fields used to upload documents",
+            "items": {
+              "type": "object",
+              "properties": {
+                "fields": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "The form fields used to upload the document"
+                },
+                "url": {
+                  "type": "string",
+                  "description": "The url to upload the document to"
+                }
+              },
+              "description": "The fields used to upload a specific document"
+            }
+          }
+        }
+      },
+      "SandboLicen2gYLvhizuSaW": {
+        "required": [
+          "transactionId"
         ],
         "type": "object",
         "properties": {
           "message": {
             "type": "string",
-            "description": "A message about the request"
+            "description": "A message about the transaction"
+          },
+          "transactionId": {
+            "type": "string",
+            "description": "The transaction id for the purchase"
           }
         }
       },
-      "SandboLicenq0WHjwuOL0r5": {
+      "SandboLicenM3v1DQsiYo0I": {
+        "required": [
+          "apiLoginId",
+          "processor",
+          "transactionKey"
+        ],
+        "type": "object",
+        "properties": {
+          "apiLoginId": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string",
+            "description": "The api login id for the payment processor"
+          },
+          "transactionKey": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string",
+            "description": "The transaction key for the payment processor"
+          },
+          "processor": {
+            "type": "string",
+            "description": "The type of payment processor",
+            "enum": [
+              "authorize.net"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenvclXpdeW3Y28": {
+        "required": [
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The status to set the military affiliation to.",
+            "enum": [
+              "inactive"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenUL01PEWATEUT": {
         "required": [
           "attributes",
           "permissions",
@@ -1976,485 +2210,13 @@
         },
         "additionalProperties": false
       },
-      "SandboLicenTrpoUes4Xu35": {
-        "required": [
-          "transactionId"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string",
-            "description": "A message about the transaction"
-          },
-          "transactionId": {
-            "type": "string",
-            "description": "The transaction id for the purchase"
-          }
-        }
-      },
-      "SandboLicensqVdeqIDiTUV": {
-        "maxLength": 100,
-        "type": "array",
-        "items": {
-          "required": [
-            "dateOfBirth",
-            "dateOfExpiration",
-            "dateOfIssuance",
-            "dateOfRenewal",
-            "familyName",
-            "givenName",
-            "homeAddressCity",
-            "homeAddressPostalCode",
-            "homeAddressState",
-            "homeAddressStreet1",
-            "licenseType",
-            "ssn",
-            "status"
-          ],
-          "type": "object",
-          "properties": {
-            "homeAddressStreet2": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "npi": {
-              "pattern": "^[0-9]{10}$",
-              "type": "string"
-            },
-            "homeAddressPostalCode": {
-              "maxLength": 7,
-              "minLength": 5,
-              "type": "string"
-            },
-            "givenName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeAddressStreet1": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "militaryWaiver": {
-              "type": "boolean"
-            },
-            "dateOfBirth": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfIssuance": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "ssn": {
-              "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-              "type": "string"
-            },
-            "licenseType": {
-              "type": "string",
-              "enum": [
-                "audiologist",
-                "speech-language pathologist",
-                "occupational therapist",
-                "occupational therapy assistant",
-                "licensed professional counselor"
-              ]
-            },
-            "dateOfExpiration": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "homeAddressState": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "dateOfRenewal": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "familyName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeAddressCity": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "licenseNumber": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "middleName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "active",
-                "inactive"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "SandboLicencwCJNumn5Our": {
-        "type": "object",
-        "properties": {
-          "attributes": {
-            "type": "object",
-            "properties": {
-              "givenName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "familyName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenNYOXdr8q1V6F": {
-        "type": "object",
-        "properties": {
-          "permissions": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "actions": {
-                  "type": "object",
-                  "properties": {
-                    "readPrivate": {
-                      "type": "boolean"
-                    },
-                    "read": {
-                      "type": "boolean"
-                    },
-                    "admin": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "jurisdictions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "readPrivate": {
-                            "type": "boolean"
-                          },
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenDIQiicBLz4mm": {
-        "required": [
-          "attributes",
-          "permissions"
-        ],
-        "type": "object",
-        "properties": {
-          "permissions": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "actions": {
-                  "type": "object",
-                  "properties": {
-                    "readPrivate": {
-                      "type": "boolean"
-                    },
-                    "read": {
-                      "type": "boolean"
-                    },
-                    "admin": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "jurisdictions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "readPrivate": {
-                            "type": "boolean"
-                          },
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "attributes": {
-            "required": [
-              "email",
-              "familyName",
-              "givenName"
-            ],
-            "type": "object",
-            "properties": {
-              "givenName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "familyName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              },
-              "email": {
-                "maxLength": 100,
-                "minLength": 5,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenicEElMwlVowu": {
-        "required": [
-          "items",
-          "pagination"
-        ],
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "items": {
-            "maxLength": 100,
-            "type": "array",
-            "items": {
-              "type": "object",
-              "oneOf": [
-                {
-                  "required": [
-                    "compactCommissionFee",
-                    "compactName",
-                    "type"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "compactCommissionFee": {
-                      "required": [
-                        "feeAmount",
-                        "feeType"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "feeAmount": {
-                          "type": "number"
-                        },
-                        "feeType": {
-                          "type": "string",
-                          "enum": [
-                            "FLAT_RATE"
-                          ]
-                        }
-                      }
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "compact"
-                      ]
-                    },
-                    "compactName": {
-                      "type": "string",
-                      "description": "The name of the compact"
-                    }
-                  }
-                },
-                {
-                  "required": [
-                    "jurisdictionFee",
-                    "jurisdictionName",
-                    "jurisprudenceRequirements",
-                    "postalAbbreviation",
-                    "type"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "militaryDiscount": {
-                      "required": [
-                        "active",
-                        "discountAmount",
-                        "discountType"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "active": {
-                          "type": "boolean",
-                          "description": "Whether the military discount is active"
-                        },
-                        "discountAmount": {
-                          "type": "number",
-                          "description": "The amount of the discount"
-                        },
-                        "discountType": {
-                          "type": "string",
-                          "description": "The type of discount",
-                          "enum": [
-                            "FLAT_RATE"
-                          ]
-                        }
-                      }
-                    },
-                    "postalAbbreviation": {
-                      "type": "string",
-                      "description": "The postal abbreviation of the jurisdiction"
-                    },
-                    "jurisprudenceRequirements": {
-                      "required": [
-                        "required"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "required": {
-                          "type": "boolean",
-                          "description": "Whether jurisprudence requirements exist"
-                        }
-                      }
-                    },
-                    "jurisdictionName": {
-                      "type": "string",
-                      "description": "The name of the jurisdiction"
-                    },
-                    "jurisdictionFee": {
-                      "type": "number",
-                      "description": "The fee for the jurisdiction"
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "jurisdiction"
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "SandboLicenQmuWrxvHrNne": {
-        "required": [
-          "apiLoginId",
-          "processor",
-          "transactionKey"
-        ],
-        "type": "object",
-        "properties": {
-          "apiLoginId": {
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string",
-            "description": "The api login id for the payment processor"
-          },
-          "transactionKey": {
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string",
-            "description": "The transaction key for the payment processor"
-          },
-          "processor": {
-            "type": "string",
-            "description": "The type of payment processor",
-            "enum": [
-              "authorize.net"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenXS5uvP2iI0Bd": {
+      "SandboLicencgqVAvZnWkMG": {
         "required": [
           "affiliationType",
-          "dateOfUpdate",
-          "dateOfUpload",
-          "documentUploadFields",
-          "status"
+          "fileNames"
         ],
         "type": "object",
         "properties": {
-          "dateOfUpload": {
-            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-            "type": "string",
-            "description": "The date the document was uploaded",
-            "format": "date"
-          },
           "affiliationType": {
             "type": "string",
             "description": "The type of military affiliation",
@@ -2467,110 +2229,15 @@
             "type": "array",
             "description": "List of military affiliation file names",
             "items": {
+              "maxLength": 150,
               "type": "string",
               "description": "The name of the file being uploaded"
             }
-          },
-          "dateOfUpdate": {
-            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-            "type": "string",
-            "description": "The date the document was last updated",
-            "format": "date"
-          },
-          "status": {
-            "type": "string",
-            "description": "The status of the military affiliation"
-          },
-          "documentUploadFields": {
-            "type": "array",
-            "description": "The fields used to upload documents",
-            "items": {
-              "type": "object",
-              "properties": {
-                "fields": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "The form fields used to upload the document"
-                },
-                "url": {
-                  "type": "string",
-                  "description": "The url to upload the document to"
-                }
-              },
-              "description": "The fields used to upload a specific document"
-            }
-          }
-        }
-      },
-      "SandboLicenJwkX1M19iehD": {
-        "type": "object",
-        "properties": {
-          "dateCreated": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "compact": {
-            "type": "string",
-            "enum": [
-              "aslp",
-              "octp",
-              "coun"
-            ]
-          },
-          "attestationType": {
-            "type": "string"
-          },
-          "text": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "attestation"
-            ]
-          },
-          "locale": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "required": {
-            "type": "boolean"
-          }
-        }
-      },
-      "SandboLicen3bd9q60ck5Mk": {
-        "required": [
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "The status to set the military affiliation to.",
-            "enum": [
-              "inactive"
-            ]
           }
         },
         "additionalProperties": false
       },
-      "SandboLicenyYKFQAIjlFCn": {
-        "required": [
-          "message"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string",
-            "description": "A message about the request"
-          }
-        }
-      },
-      "SandboLicenPWICF4WAig5B": {
+      "SandboLicenDdBuFYJj4W5C": {
         "required": [
           "birthMonthDay",
           "compact",
@@ -3973,6 +3640,373 @@
               "active",
               "inactive"
             ]
+          }
+        }
+      },
+      "SandboLicenxwmHa2Q438IJ": {
+        "type": "object",
+        "properties": {
+          "dateCreated": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "compact": {
+            "type": "string",
+            "enum": [
+              "aslp",
+              "octp",
+              "coun"
+            ]
+          },
+          "attestationType": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "attestation"
+            ]
+          },
+          "locale": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SandboLicenZpJMDau4cDdN": {
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenZtKJxTXXg5UL": {
+        "required": [
+          "query"
+        ],
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "lastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "string"
+              },
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "query": {
+            "type": "object",
+            "properties": {
+              "providerId": {
+                "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
+                "type": "string",
+                "description": "Internal UUID for the provider"
+              },
+              "jurisdiction": {
+                "type": "string",
+                "description": "Filter for providers with privilege/license in a jurisdiction",
+                "enum": [
+                  "al",
+                  "ak",
+                  "az",
+                  "ar",
+                  "ca",
+                  "co",
+                  "ct",
+                  "de",
+                  "dc",
+                  "fl",
+                  "ga",
+                  "hi",
+                  "id",
+                  "il",
+                  "in",
+                  "ia",
+                  "ks",
+                  "ky",
+                  "la",
+                  "me",
+                  "md",
+                  "ma",
+                  "mi",
+                  "mn",
+                  "ms",
+                  "mo",
+                  "mt",
+                  "ne",
+                  "nv",
+                  "nh",
+                  "nj",
+                  "nm",
+                  "ny",
+                  "nc",
+                  "nd",
+                  "oh",
+                  "ok",
+                  "or",
+                  "pa",
+                  "pr",
+                  "ri",
+                  "sc",
+                  "sd",
+                  "tn",
+                  "tx",
+                  "ut",
+                  "vt",
+                  "va",
+                  "vi",
+                  "wa",
+                  "wv",
+                  "wi",
+                  "wy"
+                ]
+              },
+              "ssn": {
+                "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+                "type": "string",
+                "description": "Social security number to look up"
+              }
+            },
+            "description": "The query parameters"
+          },
+          "sorting": {
+            "required": [
+              "key"
+            ],
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key to sort results by",
+                "enum": [
+                  "dateOfUpdate",
+                  "familyName"
+                ]
+              },
+              "direction": {
+                "type": "string",
+                "description": "Direction to sort results by",
+                "enum": [
+                  "ascending",
+                  "descending"
+                ]
+              }
+            },
+            "description": "How to sort results"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenYgKyaZjnxxpR": {
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the request"
+          }
+        }
+      },
+      "SandboLicenGA3a6Jf5sr6W": {
+        "required": [
+          "orderInformation",
+          "selectedJurisdictions"
+        ],
+        "type": "object",
+        "properties": {
+          "attestations": {
+            "type": "array",
+            "description": "List of attestations that the user has agreed to",
+            "items": {
+              "required": [
+                "attestationId",
+                "version"
+              ],
+              "type": "object",
+              "properties": {
+                "attestationId": {
+                  "maxLength": 100,
+                  "type": "string",
+                  "description": "The ID of the attestation"
+                },
+                "version": {
+                  "maxLength": 10,
+                  "pattern": "^\\d+$",
+                  "type": "string",
+                  "description": "The version of the attestation"
+                }
+              }
+            }
+          },
+          "orderInformation": {
+            "required": [
+              "billing",
+              "card"
+            ],
+            "type": "object",
+            "properties": {
+              "card": {
+                "required": [
+                  "cvv",
+                  "expiration",
+                  "number"
+                ],
+                "type": "object",
+                "properties": {
+                  "number": {
+                    "maxLength": 19,
+                    "minLength": 13,
+                    "type": "string",
+                    "description": "The card number"
+                  },
+                  "cvv": {
+                    "maxLength": 4,
+                    "minLength": 3,
+                    "type": "string",
+                    "description": "The card cvv"
+                  },
+                  "expiration": {
+                    "maxLength": 7,
+                    "minLength": 7,
+                    "type": "string",
+                    "description": "The card expiration date"
+                  }
+                }
+              },
+              "billing": {
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "state",
+                  "streetAddress",
+                  "zip"
+                ],
+                "type": "object",
+                "properties": {
+                  "zip": {
+                    "maxLength": 10,
+                    "minLength": 5,
+                    "type": "string",
+                    "description": "The zip code for the card"
+                  },
+                  "firstName": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "The first name on the card"
+                  },
+                  "lastName": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "The last name on the card"
+                  },
+                  "streetAddress": {
+                    "maxLength": 150,
+                    "minLength": 2,
+                    "type": "string",
+                    "description": "The street address for the card"
+                  },
+                  "streetAddress2": {
+                    "maxLength": 150,
+                    "type": "string",
+                    "description": "The second street address for the card"
+                  },
+                  "state": {
+                    "maxLength": 2,
+                    "minLength": 2,
+                    "type": "string",
+                    "description": "The state postal abbreviation for the card"
+                  }
+                }
+              }
+            }
+          },
+          "selectedJurisdictions": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Jurisdictions a provider has selected to purchase privileges in.",
+              "enum": [
+                "al",
+                "ak",
+                "az",
+                "ar",
+                "ca",
+                "co",
+                "ct",
+                "de",
+                "dc",
+                "fl",
+                "ga",
+                "hi",
+                "id",
+                "il",
+                "in",
+                "ia",
+                "ks",
+                "ky",
+                "la",
+                "me",
+                "md",
+                "ma",
+                "mi",
+                "mn",
+                "ms",
+                "mo",
+                "mt",
+                "ne",
+                "nv",
+                "nh",
+                "nj",
+                "nm",
+                "ny",
+                "nc",
+                "nd",
+                "oh",
+                "ok",
+                "or",
+                "pa",
+                "pr",
+                "ri",
+                "sc",
+                "sd",
+                "tn",
+                "tx",
+                "ut",
+                "vt",
+                "va",
+                "vi",
+                "wa",
+                "wv",
+                "wi",
+                "wy"
+              ]
+            }
           }
         }
       }

--- a/backend/compact-connect/docs/onboarding/JURISDICTION_COMPACT_ONBOARDING.md
+++ b/backend/compact-connect/docs/onboarding/JURISDICTION_COMPACT_ONBOARDING.md
@@ -169,10 +169,7 @@ compactName: "<compact name>"
 compactCommissionFee:
     feeType: "FLAT_RATE"                            # Currently only "FLAT_RATE" type is supported.
     feeAmount: <number>                             # This value will be added to the jurisdiciton fee.
-transactionFeeConfiguration:                        # Required configuration for payment processor fees
-    processorFees:                                  # Required. The fees being charged to the compact by the payment processor
-        percentageRate: <number>                    # Optional: The percentage rate charged by the processor
-        fixedRatePerTransaction: <number>           # Optional: The fixed rate per transaction charged by the processor
+transactionFeeConfiguration:                        # Optional: configuration for payment processor fees
     licenseeCharges:                               # Optional: How the compact wants to charge licensees to cover these fees
         active: true|false                         # Whether the compact is charging licensees for transaction fees
         chargeType: "FLAT_FEE_PER_PRIVILEGE"       # Currently only supporting FLAT_FEE_PER_PRIVILEGE
@@ -193,13 +190,9 @@ At deploy time, if the environment name matches one of the files in the `activeE
 files will be written to the database and accessible by the system.
 
 ### Configure Transaction Fee Settings
-Each compact must decide if they want to charge licensees to absorb payment processor transaction fees. There are two aspects to this configuration:
+Each compact must decide if they want to charge licensees to absorb payment processor transaction fees. This includes the following fields:
 
-1. **Processor Fees Tracking** - For reporting purposes, compacts can estimate the transaction fees charged by their payment processor:
-   - `percentageRate`: The percentage fee charged per transaction (e.g., 2.9%)
-   - `fixedRatePerTransaction`: The fixed fee charged per transaction (e.g., $0.30)
-
-2. **Licensee Charges** - Compacts can choose to charge licensees a fee to help cover transaction costs:
+1. **Licensee Charges** - Compacts can choose to charge licensees a fee to help cover transaction costs:
    - `active`: Whether to charge licensees a transaction fee
    - `chargeType`: Currently only supports "FLAT_FEE_PER_PRIVILEGE"
    - `chargeAmount`: The fixed amount to charge per privilege purchase
@@ -207,9 +200,6 @@ Each compact must decide if they want to charge licensees to absorb payment proc
 Example configuration:
 ```yaml
 transactionFeeConfiguration:
-    processorFees:
-        percentageRate: 2.9
-        fixedRatePerTransaction: 0.30
     licenseeCharges:
         active: true
         chargeType: "FLAT_FEE_PER_PRIVILEGE"

--- a/backend/compact-connect/docs/onboarding/JURISDICTION_COMPACT_ONBOARDING.md
+++ b/backend/compact-connect/docs/onboarding/JURISDICTION_COMPACT_ONBOARDING.md
@@ -169,7 +169,7 @@ compactName: "<compact name>"
 compactCommissionFee:
     feeType: "FLAT_RATE"                            # Currently only "FLAT_RATE" type is supported.
     feeAmount: <number>                             # This value will be added to the jurisdiciton fee.
-transactionFeeConfiguration:                        # Optional: configuration for payment processor fees
+transactionFeeConfiguration:                        # Optional: configuration for transaction fees
     licenseeCharges:                               # Optional: How the compact wants to charge licensees to cover these fees
         active: true|false                         # Whether the compact is charging licensees for transaction fees
         chargeType: "FLAT_FEE_PER_PRIVILEGE"       # Currently only supporting FLAT_FEE_PER_PRIVILEGE
@@ -207,10 +207,7 @@ transactionFeeConfiguration:
 ```
 
 In this example:
-- The payment processor charges 2.9% plus $0.30 per transaction (the standard rate for Authorize.net)
-- The compact charges licensees a flat fee of $3.00 per privilege to help cover these costs
-- The processor fee information is used for reporting purposes only
-- The licensee charge amount will be added to each privilege purchase
+- The compact charges licensees a flat fee of $3.00 per privilege to help cover transaction fees
 
 Note: The `licenseeCharges` section is optional. If omitted, no transaction fees will be charged to licensees.
 

--- a/backend/compact-connect/docs/onboarding/JURISDICTION_COMPACT_ONBOARDING.md
+++ b/backend/compact-connect/docs/onboarding/JURISDICTION_COMPACT_ONBOARDING.md
@@ -169,6 +169,14 @@ compactName: "<compact name>"
 compactCommissionFee:
     feeType: "FLAT_RATE"                            # Currently only "FLAT_RATE" type is supported.
     feeAmount: <number>                             # This value will be added to the jurisdiciton fee.
+transactionFeeConfiguration:                        # Required configuration for payment processor fees
+    processorFees:                                  # Required. The fees being charged to the compact by the payment processor
+        percentageRate: <number>                    # Optional: The percentage rate charged by the processor
+        fixedRatePerTransaction: <number>           # Optional: The fixed rate per transaction charged by the processor
+    licenseeCharges:                               # Optional: How the compact wants to charge licensees to cover these fees
+        active: true|false                         # Whether the compact is charging licensees for transaction fees
+        chargeType: "FLAT_FEE_PER_PRIVILEGE"       # Currently only supporting FLAT_FEE_PER_PRIVILEGE
+        chargeAmount: <number>                     # The amount to charge per privilege purchased
 compactOperationsTeamEmails: ["<email address>"]
 compactAdverseActionsNotificationEmails: ["<email address>"]
 compactSummaryReportNotificationEmails: ["<email address>"]
@@ -183,6 +191,38 @@ attestations:                                       # Required attestations for 
 ```
 At deploy time, if the environment name matches one of the files in the `activeEnvironments` list, these configuration
 files will be written to the database and accessible by the system.
+
+### Configure Transaction Fee Settings
+Each compact must decide if they want to charge licensees to absorb payment processor transaction fees. There are two aspects to this configuration:
+
+1. **Processor Fees Tracking** - For reporting purposes, compacts can estimate the transaction fees charged by their payment processor:
+   - `percentageRate`: The percentage fee charged per transaction (e.g., 2.9%)
+   - `fixedRatePerTransaction`: The fixed fee charged per transaction (e.g., $0.30)
+
+2. **Licensee Charges** - Compacts can choose to charge licensees a fee to help cover transaction costs:
+   - `active`: Whether to charge licensees a transaction fee
+   - `chargeType`: Currently only supports "FLAT_FEE_PER_PRIVILEGE"
+   - `chargeAmount`: The fixed amount to charge per privilege purchase
+
+Example configuration:
+```yaml
+transactionFeeConfiguration:
+    processorFees:
+        percentageRate: 2.9
+        fixedRatePerTransaction: 0.30
+    licenseeCharges:
+        active: true
+        chargeType: "FLAT_FEE_PER_PRIVILEGE"
+        chargeAmount: 3.00
+```
+
+In this example:
+- The payment processor charges 2.9% plus $0.30 per transaction (the standard rate for Authorize.net)
+- The compact charges licensees a flat fee of $3.00 per privilege to help cover these costs
+- The processor fee information is used for reporting purposes only
+- The licensee charge amount will be added to each privilege purchase
+
+Note: The `licenseeCharges` section is optional. If omitted, no transaction fees will be charged to licensees.
 
 ### Configure Compact Attestations
 Each compact must define a set of attestations that providers must accept when purchasing privileges. Attestations are legally binding statements that providers must agree to, and they are versioned to ensure providers always see and accept the most current version. The attestations must be defined in the compact configuration file under the `attestations` field.

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/__init__.py
@@ -14,9 +14,27 @@ class CompactFeeType(CCEnum):
     FLAT_RATE = 'FLAT_RATE'
 
 
+class TransactionFeeChargeType(CCEnum):
+    FLAT_FEE_PER_PRIVILEGE = 'FLAT_FEE_PER_PRIVILEGE'
+
+
 class CompactCommissionFeeSchema(Schema):
     feeType = String(required=True, allow_none=False, validate=OneOf([e.value for e in CompactFeeType]))
-    feeAmount = Decimal(required=True, allow_none=False)
+    feeAmount = Decimal(required=True, allow_none=False, places=2)
+
+
+class LicenseeChargesSchema(Schema):
+    """Schema for licensee transaction fee charges configuration"""
+
+    active = Boolean(required=True, allow_none=False)
+    chargeType = String(required=True, allow_none=False, validate=OneOf([e.value for e in TransactionFeeChargeType]))
+    chargeAmount = Decimal(required=True, allow_none=False, places=2)
+
+
+class TransactionFeeConfigurationSchema(Schema):
+    """Schema for the transaction fee configuration"""
+
+    licenseeCharges = Nested(LicenseeChargesSchema(), required=False, allow_none=True)
 
 
 class CompactCommissionFee(UserDict):
@@ -29,30 +47,28 @@ class CompactCommissionFee(UserDict):
         return CompactFeeType.from_str(self['feeType'])
 
     @property
-    def fee_amount(self) -> float:
-        return float(self['feeAmount'])
+    def fee_amount(self) -> Decimal:
+        return self['feeAmount']
 
 
-class ProcessorFeesSchema(Schema):
-    """Schema for payment processor fees configuration"""
+class LicenseeCharges(UserDict):
+    @property
+    def active(self) -> bool:
+        return self['active']
 
-    percentageRate = Decimal(required=False, allow_none=True)
-    fixedRatePerTransaction = Decimal(required=False, allow_none=True)
+    @property
+    def charge_type(self) -> TransactionFeeChargeType:
+        return TransactionFeeChargeType.from_str(self['chargeType'])
+
+    @property
+    def charge_amount(self) -> Decimal:
+        return self['chargeAmount']
 
 
-class LicenseeChargesSchema(Schema):
-    """Schema for licensee transaction fee charges configuration"""
-
-    active = Boolean(required=True, allow_none=False)
-    chargeType = String(required=True, allow_none=False, validate=OneOf(['FLAT_FEE_PER_PRIVILEGE']))
-    chargeAmount = Decimal(required=True, allow_none=False)
-
-
-class TransactionFeeConfigurationSchema(Schema):
-    """Schema for the complete transaction fee configuration"""
-
-    processorFees = Nested(ProcessorFeesSchema(), required=True, allow_none=False)
-    licenseeCharges = Nested(LicenseeChargesSchema(), required=False, allow_none=True)
+class TransactionFeeConfiguration(UserDict):
+    @property
+    def licensee_charges(self) -> LicenseeCharges:
+        return LicenseeCharges(self['licenseeCharges']) if self.get('licenseeCharges') else None
 
 
 class Compact(UserDict):
@@ -69,16 +85,12 @@ class Compact(UserDict):
         return CompactCommissionFee(self['compactCommissionFee'])
 
     @property
-    def transaction_fee_configuration(self) -> dict:
-        return self['transactionFeeConfiguration']
-
-    @property
-    def processor_fees(self) -> dict | None:
-        return self.transaction_fee_configuration['processorFees']
-
-    @property
-    def licensee_charges(self) -> dict | None:
-        return self.transaction_fee_configuration.get('licenseeCharges')
+    def transaction_fee_configuration(self) -> TransactionFeeConfiguration:
+        return (
+            TransactionFeeConfiguration(self['transactionFeeConfiguration'])
+            if self.get('transactionFeeConfiguration')
+            else None
+        )
 
     @property
     def compact_operations_team_emails(self) -> list[str] | None:

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/api.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/api.py
@@ -4,7 +4,17 @@ from marshmallow.validate import OneOf
 
 from cc_common.config import config
 from cc_common.data_model.schema.base_record import ForgivingSchema
-from cc_common.data_model.schema.compact import COMPACT_TYPE, CompactCommissionFeeSchema
+from cc_common.data_model.schema.compact import (
+    COMPACT_TYPE,
+    CompactCommissionFeeSchema,
+    LicenseeChargesSchema,
+)
+
+
+class TransactionFeeConfigurationResponseSchema(ForgivingSchema):
+    """Schema for transaction fee configuration in API responses - excludes processor fees"""
+
+    licenseeCharges = Nested(LicenseeChargesSchema(), required=False, allow_none=True)
 
 
 class CompactOptionsResponseSchema(ForgivingSchema):
@@ -12,4 +22,5 @@ class CompactOptionsResponseSchema(ForgivingSchema):
 
     compactName = String(required=True, allow_none=False, validate=OneOf(config.compacts))
     compactCommissionFee = Nested(CompactCommissionFeeSchema(), required=True, allow_none=False)
+    transactionFeeConfiguration = Nested(TransactionFeeConfigurationResponseSchema(), required=True, allow_none=False)
     type = String(required=True, allow_none=False, validate=OneOf([COMPACT_TYPE]))

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/record.py
@@ -21,7 +21,7 @@ class CompactRecordSchema(BaseRecordSchema):
     # Provided fields
     compactName = String(required=True, allow_none=False, validate=OneOf(config.compacts))
     compactCommissionFee = Nested(CompactCommissionFeeSchema(), required=True, allow_none=False)
-    transactionFeeConfiguration = Nested(TransactionFeeConfigurationSchema(), required=True, allow_none=False)
+    transactionFeeConfiguration = Nested(TransactionFeeConfigurationSchema(), required=False, allow_none=False)
     compactOperationsTeamEmails = List(String(required=True, allow_none=False), required=True, allow_none=False)
     compactAdverseActionsNotificationEmails = List(
         String(required=True, allow_none=False),

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/record.py
@@ -5,7 +5,11 @@ from marshmallow.validate import Length, OneOf
 
 from cc_common.config import config
 from cc_common.data_model.schema.base_record import BaseRecordSchema
-from cc_common.data_model.schema.compact import COMPACT_TYPE, CompactCommissionFeeSchema
+from cc_common.data_model.schema.compact import (
+    COMPACT_TYPE,
+    CompactCommissionFeeSchema,
+    TransactionFeeConfigurationSchema,
+)
 
 
 @BaseRecordSchema.register_schema(COMPACT_TYPE)
@@ -17,6 +21,7 @@ class CompactRecordSchema(BaseRecordSchema):
     # Provided fields
     compactName = String(required=True, allow_none=False, validate=OneOf(config.compacts))
     compactCommissionFee = Nested(CompactCommissionFeeSchema(), required=True, allow_none=False)
+    transactionFeeConfiguration = Nested(TransactionFeeConfigurationSchema(), required=True, allow_none=False)
     compactOperationsTeamEmails = List(String(required=True, allow_none=False), required=True, allow_none=False)
     compactAdverseActionsNotificationEmails = List(
         String(required=True, allow_none=False),

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/__init__.py
@@ -1,5 +1,6 @@
 # ruff: noqa: N801, N815, ARG002 invalid-name unused-kwargs
 from collections import UserDict
+from decimal import Decimal
 
 from cc_common.data_model.schema.common import CCEnum
 
@@ -25,8 +26,8 @@ class JurisdictionMilitaryDiscount(UserDict):
         return JurisdictionMilitaryDiscountType.from_str(self['discountType'])
 
     @property
-    def discount_amount(self) -> float:
-        return float(self['discountAmount'])
+    def discount_amount(self) -> Decimal:
+        return self['discountAmount']
 
 
 class JurisdictionJurisprudenceRequirements(UserDict):
@@ -59,8 +60,8 @@ class Jurisdiction(UserDict):
         return self['compact']
 
     @property
-    def jurisdiction_fee(self) -> float:
-        return float(self['jurisdictionFee'])
+    def jurisdiction_fee(self) -> Decimal:
+        return self['jurisdictionFee']
 
     @property
     def military_discount(self) -> JurisdictionMilitaryDiscount | None:

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
@@ -13,7 +13,7 @@ class JurisdictionMilitaryDiscountRecordSchema(Schema):
     discountType = String(
         required=True, allow_none=False, validate=OneOf([e.value for e in JurisdictionMilitaryDiscountType])
     )
-    discountAmount = Decimal(required=True, allow_none=False)
+    discountAmount = Decimal(required=True, allow_none=False, places=2)
 
 
 class JurisdictionJurisprudenceRequirementsRecordSchema(Schema):
@@ -30,7 +30,7 @@ class JurisdictionRecordSchema(BaseRecordSchema):
     jurisdictionName = String(required=True, allow_none=False)
     postalAbbreviation = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
     compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
-    jurisdictionFee = Decimal(required=True, allow_none=False)
+    jurisdictionFee = Decimal(required=True, allow_none=False, places=2)
     militaryDiscount = Nested(JurisdictionMilitaryDiscountRecordSchema(), required=False, allow_none=False)
     jurisdictionOperationsTeamEmails = List(
         Email(required=True, allow_none=False), required=True, allow_none=False, validate=Length(min=1)

--- a/backend/compact-connect/lambdas/python/common/tests/resources/api/compact-configuration-response.json
+++ b/backend/compact-connect/lambdas/python/common/tests/resources/api/compact-configuration-response.json
@@ -1,0 +1,15 @@
+{
+  "type": "compact",
+  "compactName": "aslp",
+  "compactCommissionFee": {
+    "feeType": "FLAT_RATE",
+    "feeAmount": 3.50
+  },
+  "transactionFeeConfiguration": {
+    "licenseeCharges": {
+      "active": true,
+      "chargeType": "FLAT_FEE_PER_PRIVILEGE",
+      "chargeAmount": 3.00
+    }
+  }
+}

--- a/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/compact.json
+++ b/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/compact.json
@@ -7,6 +7,17 @@
     "feeType": "FLAT_RATE",
     "feeAmount": 3.50
   },
+  "transactionFeeConfiguration": {
+    "processorFees": {
+      "percentageRate": 2.9,
+      "fixedRatePerTransaction": 0.30
+    },
+    "licenseeCharges": {
+      "active": true,
+      "chargeType": "FLAT_FEE_PER_PRIVILEGE",
+      "chargeAmount": 3.00
+    }
+  },
   "compactOperationsTeamEmails": ["<email address>"],
   "compactAdverseActionsNotificationEmails": ["<email address>"],
   "compactSummaryReportNotificationEmails": ["<email address>"],

--- a/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/compact.json
+++ b/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/compact.json
@@ -8,10 +8,6 @@
     "feeAmount": 3.50
   },
   "transactionFeeConfiguration": {
-    "processorFees": {
-      "percentageRate": 2.9,
-      "fixedRatePerTransaction": 0.30
-    },
     "licenseeCharges": {
       "active": true,
       "chargeType": "FLAT_FEE_PER_PRIVILEGE",

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_privilege_options.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_privilege_options.py
@@ -58,16 +58,8 @@ class TestGetPurchasePrivilegeOptions(TstFunction):
         self.assertEqual(200, resp['statusCode'])
         privilege_options = json.loads(resp['body'])
 
-        with open('../common/tests/resources/dynamo/compact.json') as f:
+        with open('../common/tests/resources/api/compact-configuration-response.json') as f:
             expected_compact_option = json.load(f)
-            expected_compact_option.pop('pk')
-            expected_compact_option.pop('sk')
-            # we should not be returning email information in the response
-            expected_compact_option.pop('compactOperationsTeamEmails')
-            expected_compact_option.pop('compactAdverseActionsNotificationEmails')
-            expected_compact_option.pop('compactSummaryReportNotificationEmails')
-            # remove date fields as they are not needed in the response
-            expected_compact_option.pop('dateOfUpdate')
 
         # the compact configuration is stored in the dynamo db as part of the
         # parent TstFunction setup, so we can compare the response directly

--- a/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
@@ -100,17 +100,17 @@ def _generate_aslp_compact_configuration(include_licensee_charges: bool = False)
         return Compact(compact)
 
 
-def _generate_selected_jurisdictions(jursidction_items: list[dict] = None):
+def _generate_selected_jurisdictions(jurisdiction_items: list[dict] = None):
     from cc_common.data_model.schema.jurisdiction import Jurisdiction
 
-    if jursidction_items is None:
-        jursidction_items = [
+    if jurisdiction_items is None:
+        jurisdiction_items = [
             {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'jurisdictionFee': 100.00},
         ]
 
     jurisdiction_configurations = []
 
-    for jurisdiction_test_item in jursidction_items:
+    for jurisdiction_test_item in jurisdiction_items:
         with open('../common/tests/resources/dynamo/jurisdiction.json') as f:
             jurisdiction = json.load(f)
             jurisdiction['jurisdictionFee'] = Decimal(jurisdiction_test_item['jurisdictionFee'])

--- a/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
@@ -20,7 +20,7 @@ MOCK_TRANSACTION_ID = '123456'
 
 MOCK_LICENSEE_ID = '89a6377e-c3a5-40e5-bca5-317ec854c570'
 
-EXPECTED_TOTAL_FEE_AMOUNT = 150.50
+MOCK_LICENSEE_TRANSACTION_FEE_AMOUNT = 5
 
 # Test constants for transaction history tests
 MOCK_BATCH_ID = '12345'
@@ -81,7 +81,7 @@ def _generate_default_order_information():
     }
 
 
-def _generate_aslp_compact_configuration():
+def _generate_aslp_compact_configuration(include_licensee_charges: bool = False):
     from cc_common.data_model.schema.compact import Compact
 
     with open('../common/tests/resources/dynamo/compact.json') as f:
@@ -89,22 +89,40 @@ def _generate_aslp_compact_configuration():
         compact = json.load(f)
         # DynamoDB loads this as a Decimal
         compact['compactCommissionFee']['feeAmount'] = Decimal(50.50)
-
+        # the compact.json file includes licensee charges by default,
+        # so we need to set this to False if we don't want them
+        if not include_licensee_charges:
+            compact['transactionFeeConfiguration']['licenseeCharges']['active'] = False
+        # setting the fee amount explicitly here to make calculation easy to check
+        compact['transactionFeeConfiguration']['licenseeCharges']['chargeAmount'] = Decimal(
+            MOCK_LICENSEE_TRANSACTION_FEE_AMOUNT
+        )
         return Compact(compact)
 
 
-def _generate_selected_jurisdictions():
+def _generate_selected_jurisdictions(jursidction_items: list[dict] = None):
     from cc_common.data_model.schema.jurisdiction import Jurisdiction
 
-    with open('../common/tests/resources/dynamo/jurisdiction.json') as f:
-        jurisdiction = json.load(f)
-        jurisdiction['jurisdictionFee'] = Decimal(100.00)
-        # set military discount to fixed amount for tests
-        jurisdiction['militaryDiscount']['discountAmount'] = Decimal(25.00)
-        jurisdiction['militaryDiscount']['active'] = True
-        jurisdiction['militaryDiscount']['discountType'] = 'FLAT_RATE'
+    if jursidction_items is None:
+        jursidction_items = [
+            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'jurisdictionFee': 100.00},
+        ]
 
-        return [Jurisdiction(jurisdiction)]
+    jurisdiction_configurations = []
+
+    for jurisdiction_test_item in jursidction_items:
+        with open('../common/tests/resources/dynamo/jurisdiction.json') as f:
+            jurisdiction = json.load(f)
+            jurisdiction['jurisdictionFee'] = Decimal(jurisdiction_test_item['jurisdictionFee'])
+            # set military discount to fixed amount for tests
+            jurisdiction['militaryDiscount']['discountAmount'] = Decimal(25.00)
+            jurisdiction['militaryDiscount']['active'] = True
+            jurisdiction['militaryDiscount']['discountType'] = 'FLAT_RATE'
+            jurisdiction['postalAbbreviation'] = jurisdiction_test_item['postalCode']
+            jurisdiction['jurisdictionName'] = jurisdiction_test_item['jurisdictionName']
+            jurisdiction_configurations.append(Jurisdiction(jurisdiction))
+
+    return jurisdiction_configurations
 
 
 class TestAuthorizeDotNetPurchaseClient(TstLambdas):
@@ -241,7 +259,8 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         self.assertEqual('2035-10', api_contract_v1_obj.transactionRequest.payment.creditCard.expirationDate)
         self.assertEqual('125', api_contract_v1_obj.transactionRequest.payment.creditCard.cardCode)
         # transaction billing fields
-        self.assertEqual(EXPECTED_TOTAL_FEE_AMOUNT, api_contract_v1_obj.transactionRequest.amount)
+        expected_total_fee_amount = 150.50
+        self.assertEqual(expected_total_fee_amount, api_contract_v1_obj.transactionRequest.amount)
         self.assertEqual('USD', api_contract_v1_obj.transactionRequest.currencyCode)
         self.assertEqual('OH', api_contract_v1_obj.transactionRequest.billTo.state)
         self.assertEqual('12345', api_contract_v1_obj.transactionRequest.billTo.zip)
@@ -302,6 +321,79 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
 
         # ensure the total amount is the sum of the two line items
         self.assertEqual(150.50, api_contract_v1_obj.transactionRequest.amount)
+
+    @patch('purchase_client.createTransactionController')
+    def test_purchase_client_sends_expected_line_items_when_licensee_charges_are_active(
+        self, mock_create_transaction_controller
+    ):
+        from purchase_client import PurchaseClient
+
+        mock_secrets_manager_client = self._generate_mock_secrets_manager_client()
+        self._when_authorize_dot_net_transaction_is_successful(
+            mock_create_transaction_controller=mock_create_transaction_controller
+        )
+
+        test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
+
+        test_jurisdictions = [
+            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'jurisdictionFee': 50.00},
+            {'postalCode': 'ky', 'jurisdictionName': 'kentucky', 'jurisdictionFee': 200.00},
+        ]
+
+        test_purchase_client.process_charge_for_licensee_privileges(
+            licensee_id=MOCK_LICENSEE_ID,
+            order_information=_generate_default_order_information(),
+            compact_configuration=_generate_aslp_compact_configuration(include_licensee_charges=True),
+            selected_jurisdictions=_generate_selected_jurisdictions(test_jurisdictions),
+            user_active_military=False,
+        )
+
+        call_args = mock_create_transaction_controller.call_args.args
+        api_contract_v1_obj = call_args[0]
+
+        # we check every line item of the object to ensure that the correct values are being set
+        self.assertEqual(4, len(api_contract_v1_obj.transactionRequest.lineItems.lineItem))
+        # first line item is the jurisdiction fee
+        self.assertEqual('aslp-oh', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].itemId)
+        self.assertEqual('Ohio Compact Privilege', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].name)
+        self.assertEqual(50.00, api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].unitPrice)
+        self.assertEqual(1, api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].quantity)
+        self.assertEqual(
+            'Compact Privilege for Ohio', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].description
+        )
+        # the second line item is the jurisdiction fee for kentucky
+        self.assertEqual('aslp-ky', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].itemId)
+        self.assertEqual(
+            'Kentucky Compact Privilege', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].name
+        )
+        self.assertEqual(200.00, api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].unitPrice)
+        self.assertEqual(1, api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].quantity)
+        self.assertEqual(
+            'Compact Privilege for Kentucky', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].description
+        )
+
+        # third line item is the compact fee
+        self.assertEqual('aslp-compact-fee', api_contract_v1_obj.transactionRequest.lineItems.lineItem[2].itemId)
+        self.assertEqual(2, api_contract_v1_obj.transactionRequest.lineItems.lineItem[2].quantity)
+        self.assertEqual(50.50, api_contract_v1_obj.transactionRequest.lineItems.lineItem[2].unitPrice)
+        # fourth line item is the licensee charge
+        self.assertEqual(
+            'credit-card-transaction-fee', api_contract_v1_obj.transactionRequest.lineItems.lineItem[3].itemId
+        )
+        self.assertEqual(2, api_contract_v1_obj.transactionRequest.lineItems.lineItem[3].quantity)
+        self.assertEqual(
+            'Credit Card Transaction Fee', api_contract_v1_obj.transactionRequest.lineItems.lineItem[3].name
+        )
+        self.assertEqual(
+            'Transaction fee for credit card processing',
+            api_contract_v1_obj.transactionRequest.lineItems.lineItem[3].description,
+        )
+        self.assertEqual(
+            MOCK_LICENSEE_TRANSACTION_FEE_AMOUNT, api_contract_v1_obj.transactionRequest.lineItems.lineItem[3].unitPrice
+        )
+
+        # ensure the total amount is the sum of the four line items
+        self.assertEqual(361.00, api_contract_v1_obj.transactionRequest.amount)
 
     @patch('purchase_client.createTransactionController')
     def test_purchase_client_sets_licensee_id_in_order_description(self, mock_create_transaction_controller):

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -715,7 +715,7 @@ class ApiModel:
             one_of=[
                 JsonSchema(
                     type=JsonSchemaType.OBJECT,
-                    required=['type', 'compactName', 'compactCommissionFee'],
+                    required=['type', 'compactName', 'compactCommissionFee', 'transactionFeeConfiguration'],
                     properties={
                         'type': JsonSchema(type=JsonSchemaType.STRING, enum=['compact']),
                         'compactName': JsonSchema(type=JsonSchemaType.STRING, description='The name of the compact'),
@@ -725,6 +725,31 @@ class ApiModel:
                             properties={
                                 'feeType': JsonSchema(type=JsonSchemaType.STRING, enum=['FLAT_RATE']),
                                 'feeAmount': JsonSchema(type=JsonSchemaType.NUMBER),
+                            },
+                        ),
+                        'transactionFeeConfiguration': JsonSchema(
+                            type=JsonSchemaType.OBJECT,
+                            required=['licenseeCharges'],
+                            properties={
+                                'licenseeCharges': JsonSchema(
+                                    type=JsonSchemaType.OBJECT,
+                                    required=['active', 'chargeType', 'chargeAmount'],
+                                    properties={
+                                        'active': JsonSchema(
+                                            type=JsonSchemaType.BOOLEAN,
+                                            description='Whether the compact is charging licensees transaction fees',
+                                        ),
+                                        'chargeType': JsonSchema(
+                                            type=JsonSchemaType.STRING,
+                                            enum=['FLAT_FEE_PER_PRIVILEGE'],
+                                            description='The type of transaction fee charge',
+                                        ),
+                                        'chargeAmount': JsonSchema(
+                                            type=JsonSchemaType.NUMBER,
+                                            description='The amount to charge per privilege purchased',
+                                        ),
+                                    },
+                                ),
                             },
                         ),
                     },

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_INPUT.json
@@ -7,10 +7,6 @@
         "feeAmount": 3.5
       },
       "transactionFeeConfiguration": {
-        "processorFees": {
-          "percentageRate": 2.9,
-          "fixedRatePerTransaction": 0.3
-        },
         "licenseeCharges": {
           "active": true,
           "chargeType": "FLAT_FEE_PER_PRIVILEGE",
@@ -113,10 +109,6 @@
         "feeAmount": 3.5
       },
       "transactionFeeConfiguration": {
-        "processorFees": {
-          "percentageRate": 2.9,
-          "fixedRatePerTransaction": 0.3
-        },
         "licenseeCharges": {
           "active": true,
           "chargeType": "FLAT_FEE_PER_PRIVILEGE",

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_INPUT.json
@@ -6,6 +6,17 @@
         "feeType": "FLAT_RATE",
         "feeAmount": 3.5
       },
+      "transactionFeeConfiguration": {
+        "processorFees": {
+          "percentageRate": 2.9,
+          "fixedRatePerTransaction": 0.3
+        },
+        "licenseeCharges": {
+          "active": true,
+          "chargeType": "FLAT_FEE_PER_PRIVILEGE",
+          "chargeAmount": 3.0
+        }
+      },
       "compactOperationsTeamEmails": [],
       "compactAdverseActionsNotificationEmails": [],
       "compactSummaryReportNotificationEmails": [],
@@ -100,6 +111,17 @@
       "compactCommissionFee": {
         "feeType": "FLAT_RATE",
         "feeAmount": 3.5
+      },
+      "transactionFeeConfiguration": {
+        "processorFees": {
+          "percentageRate": 2.9,
+          "fixedRatePerTransaction": 0.3
+        },
+        "licenseeCharges": {
+          "active": true,
+          "chargeType": "FLAT_FEE_PER_PRIVILEGE",
+          "chargeAmount": 3.0
+        }
       },
       "compactOperationsTeamEmails": [],
       "compactAdverseActionsNotificationEmails": [],

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_OPTIONS_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_OPTIONS_RESPONSE_SCHEMA.json
@@ -32,12 +32,46 @@
                   "feeAmount"
                 ],
                 "type": "object"
+              },
+              "transactionFeeConfiguration": {
+                "properties": {
+                  "licenseeCharges": {
+                    "properties": {
+                      "active": {
+                        "description": "Whether the compact is charging licensees transaction fees",
+                        "type": "boolean"
+                      },
+                      "chargeType": {
+                        "description": "The type of transaction fee charge",
+                        "enum": [
+                          "FLAT_FEE_PER_PRIVILEGE"
+                        ],
+                        "type": "string"
+                      },
+                      "chargeAmount": {
+                        "description": "The amount to charge per privilege purchased",
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "active",
+                      "chargeType",
+                      "chargeAmount"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "licenseeCharges"
+                ],
+                "type": "object"
               }
             },
             "required": [
               "type",
               "compactName",
-              "compactCommissionFee"
+              "compactCommissionFee",
+              "transactionFeeConfiguration"
             ],
             "type": "object"
           },

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -2,7 +2,6 @@
 import json
 import time
 from datetime import UTC, datetime
-from decimal import Decimal
 
 import requests
 from config import config, logger
@@ -69,8 +68,8 @@ def test_purchase_privilege_options():
 
     if ky_jurisdiction_data != expected_ky_jurisdiction_data:
         raise SmokeTestFailureException(
-            f'KY jurisdiction data does not match expected values.\nExpected:\n {json.dumps(expected_ky_jurisdiction_data)}\nActual:\n '
-            f'{json.dumps(ky_jurisdiction_data)}'
+            f'KY jurisdiction data does not match expected values.\nExpected:\n '
+            f'{json.dumps(expected_ky_jurisdiction_data)}\nActual:\n {json.dumps(ky_jurisdiction_data)}'
         )
 
     logger.info('Successfully verified purchase privilege options')

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+import json
 import time
 from datetime import UTC, datetime
+from decimal import Decimal
 
 import requests
 from config import config, logger
@@ -14,6 +16,64 @@ from smoke_common import (
 # of the Compact Connect API.
 # To run this script, create a smoke_tests_env.json file in the same directory as this script using the
 # 'smoke_tests_env_example.json' file as a template.
+
+
+def test_purchase_privilege_options():
+    """Test the GET /v1/purchases/privileges/options endpoint."""
+    headers = get_provider_user_auth_headers_cached()
+    response = requests.get(
+        url=f'{config.api_base_url}/v1/purchases/privileges/options',
+        headers=headers,
+        timeout=10,
+    )
+
+    if response.status_code != 200:
+        raise SmokeTestFailureException(f'Failed to get purchase privilege options. Response: {response.json()}')
+
+    response_body = response.json()
+    logger.info('Received purchase privilege options response:', data=response_body)
+
+    compact_data = next((item for item in response_body['items'] if item.get('type') == 'compact'), None)
+
+    # Verify compact data matches expected values
+    expected_compact_data = {
+        'type': 'compact',
+        'compactName': 'aslp',
+        'compactCommissionFee': {'feeType': 'FLAT_RATE', 'feeAmount': 3.50},
+        'transactionFeeConfiguration': {
+            'licenseeCharges': {'active': True, 'chargeType': 'FLAT_FEE_PER_PRIVILEGE', 'chargeAmount': 3.00}
+        },
+    }
+
+    if compact_data != expected_compact_data:
+        raise SmokeTestFailureException(
+            f'Compact data does not match expected values.\nExpected:\n {json.dumps(expected_compact_data)}\nActual:\n '
+            f'{json.dumps(compact_data)}'
+        )
+
+    # now we verify the ky jurisdiction data
+    # we only verify this one for brevity, since the other jurisdictions are loaded as configured in the yaml files
+    ky_jurisdiction_data = next(
+        (item for item in response_body['items'] if item.get('postalAbbreviation') == 'ky'), None
+    )
+
+    expected_ky_jurisdiction_data = {
+        'type': 'jurisdiction',
+        'jurisdictionName': 'Kentucky',
+        'postalAbbreviation': 'ky',
+        'compact': 'aslp',
+        'jurisdictionFee': 100,
+        'militaryDiscount': {'active': True, 'discountType': 'FLAT_RATE', 'discountAmount': 10},
+        'jurisprudenceRequirements': {'required': True},
+    }
+
+    if ky_jurisdiction_data != expected_ky_jurisdiction_data:
+        raise SmokeTestFailureException(
+            f'KY jurisdiction data does not match expected values.\nExpected:\n {json.dumps(expected_ky_jurisdiction_data)}\nActual:\n '
+            f'{json.dumps(ky_jurisdiction_data)}'
+        )
+
+    logger.info('Successfully verified purchase privilege options')
 
 
 def test_purchasing_privilege():
@@ -152,4 +212,5 @@ def test_purchasing_privilege():
 
 
 if __name__ == '__main__':
+    test_purchase_privilege_options()
     test_purchasing_privilege()


### PR DESCRIPTION
Several compacts have determined to charge credit card transaction fees to licensees, in order to absorb the costs of the fees charged by their Merchant Service Providers. This adds the needed compact configuration fields which compacts will need to specify when they onboard into the compact connect system.

### Requirements List
- This change is backwards compatible, as these are optional fields that a compact may or may not choose to specify.

### Description List
- Added a `transactionFeeConfiguration` field to the compact configuration schema, which includes config for licensee transaction fees.
- Returning these values in the API when the frontend gets the list of compact configuration. 
- Updated the privilege purchase flow to include these transaction fee charges in a separate line item.

### Testing List
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- uint tests to verify licensee transaction fees are added
- Code review

Closes #502 
