### PR TITLE
Set explicit export of SSN key arn to address CDK cross-stack dep

### DIFF
--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -203,6 +203,9 @@ class PersistentStack(AppStack):
             license_preprocessing_queue=self.ssn_table.preprocessor_queue.queue,
             license_upload_role=self.ssn_table.license_upload_role,
         )
+        # TODO - This dummy export is required until the api stack has been deployed # noqa: FIX002
+        #  to stop referencing this bucket arn
+        self.export_value(self.bulk_uploads_bucket.bucket_arn)
 
         self.transaction_reports_bucket = TransactionReportsBucket(
             self,

--- a/backend/compact-connect/stacks/persistent_stack/ssn_table.py
+++ b/backend/compact-connect/stacks/persistent_stack/ssn_table.py
@@ -130,9 +130,11 @@ class SSNTable(Table):
         )
         self.grant_read_write_data(self.ingest_role)
         self._role_suppressions(self.ingest_role)
-        # TODO - This dummy export is required until the ingest stack has been deployed # noqa: FIX002
-        #  to stop consuming this role
+        # TODO - These dummy exports are required until the ingest stack has been deployed # noqa: FIX002
+        #  to stop consuming this role and key
         Stack.of(self.ingest_role).export_value(self.ingest_role.role_arn)
+        Stack.of(self.key).export_value(self.key.key_arn)
+
 
         self.license_upload_role = Role(
             self,


### PR DESCRIPTION
We removed reference to this KMS key in the ingest stack, but due to CDK's handling of cross-stack deps we need to explicitly export the key arn until the change has gone through all envs of the system