### PR TITLE
Feat/Support license type selection when purchasing privileges

### DIFF
--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/data_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/data_client.py
@@ -320,7 +320,7 @@ class DataClient:
         license_expiration_date: date,
         compact_transaction_id: str,
         provider_record: dict,
-        existing_privileges: list[dict],
+        existing_privileges_for_license: list[dict],
         attestations: list[dict],
         license_type: str,
     ):
@@ -337,8 +337,8 @@ class DataClient:
         :param license_expiration_date: The license expiration date
         :param compact_transaction_id: The compact transaction id
         :param provider_record: The original provider record
-        :param existing_privileges: The list of existing privileges for this user. Used to track the original issuance
-        date of the privilege.
+        :param existing_privileges_for_license: The list of existing privileges for the specified license.
+        Used to track the original issuance date of the privilege.
         :param attestations: List of attestations that were accepted when purchasing the privileges
         :param license_type: The type of license (e.g. audiologist, speech-language-pathologist)
         """
@@ -360,8 +360,9 @@ class DataClient:
                 original_privilege = next(
                     (
                         record
-                        for record in existing_privileges
+                        for record in existing_privileges_for_license
                         if record['jurisdiction'].lower() == postal_abbreviation.lower()
+                        and record['licenseType'] == license_type
                     ),
                     None,
                 )
@@ -469,7 +470,8 @@ class DataClient:
             self._rollback_privilege_transactions(
                 processed_transactions=processed_transactions,
                 provider_record=provider_record,
-                existing_privileges=existing_privileges,
+                license_type=license_type,
+                existing_privileges_for_license_type=existing_privileges_for_license,
             )
             raise CCAwsServiceException(message) from e
 
@@ -477,14 +479,18 @@ class DataClient:
         self,
         processed_transactions: list[dict],
         provider_record: dict,
-        existing_privileges: list[dict],
+        license_type: str,
+        existing_privileges_for_license_type: list[dict],
     ):
         """Roll back successful privilege transactions after a failure."""
         rollback_transactions = []
 
         # Create a lookup of existing privileges by jurisdiction
+        # as a safety precaution, we must ensure that every privilege in the list matches the license type that we
+        # attempted to change privilege for
         existing_privileges_by_jurisdiction = {
-            privilege['jurisdiction']: privilege for privilege in existing_privileges
+            privilege['jurisdiction']: privilege for privilege in existing_privileges_for_license_type
+            if privilege['licenseType'] == license_type
         }
 
         # Delete all privilege update records and handle privilege records appropriately

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/__init__.py
@@ -288,7 +288,7 @@ class TstFunction(TstLambdas):
                     jurisdiction_postal_abbreviations=[privilege_jurisdiction],
                     license_expiration_date=date(2050, 6, 6),
                     compact_transaction_id='1234567890',
-                    existing_privileges=[],
+                    existing_privileges_for_license=[],
                     license_type='speech-language pathologist',
                     # This attestation id/version pair is defined in the 'privilege.json' file under the
                     # common/tests/resources/dynamo directory

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_data_model/test_provider_transformations.py
@@ -112,7 +112,7 @@ class TestTransformations(TstFunction):
             jurisdiction_postal_abbreviations=['ne'],
             license_expiration_date=date(2025, 4, 4),
             compact_transaction_id='1234567890',
-            existing_privileges=[],
+            existing_privileges_for_license=[],
             license_type='speech-language pathologist',
             attestations=[{'attestationId': 'jurisprudence-confirmation', 'version': '1'}],
         )

--- a/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
@@ -142,9 +142,10 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
     """
     This endpoint allows a provider to purchase privileges.
 
-    The request body should include the selected jurisdiction privileges to purchase, billing information,
+    The request body should include the license type, selected jurisdiction privileges to purchase, billing information,
     and attestations in the following format:
     {
+        "licenseType": "<license type>", # must match one of the license types from the provider's home state licenses
         "selectedJurisdictions": ["<jurisdiction postal abbreviations>"],
         "orderInformation": {
             "card": {
@@ -211,21 +212,23 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
     provider_id = _get_caller_provider_id_custom_attribute(event)
     user_provider_data = config.data_client.get_provider(compact=compact_abbr, provider_id=provider_id)
 
+    home_state_selection = ProviderRecordUtility.get_provider_home_state_selection(user_provider_data['items'])
+    if home_state_selection is None:
+        raise CCInternalException('No home state selection found for this user')
+
     license_records = ProviderRecordUtility.get_records_of_type(
         user_provider_data['items'],
         ProviderRecordType.LICENSE,
     )
 
-    home_state_selection = ProviderRecordUtility.get_provider_home_state_selection(user_provider_data['items'])
-    if home_state_selection is None:
-        raise CCInternalException('No home state selection found for this user')
+    # we now validate that the license type matches one of the license types from the home state license records
+    matching_license_record = next((record for record in license_records if record['licenseType'] == body['licenseType']
+                                    and record['jurisdiction'] == home_state_selection), None)
 
-    home_state_license_record = ProviderRecordUtility.find_best_license(
-        license_records=license_records,
-        home_jurisdiction=home_state_selection,
-    )
+    if matching_license_record is None:
+        raise CCInvalidRequestException('Specified license type does not match any home state license type.')
 
-    if home_state_license_record['status'] == ProviderEligibilityStatus.INACTIVE:
+    if matching_license_record['status'] == ProviderEligibilityStatus.INACTIVE:
         raise CCInvalidRequestException('No active license found in selected home state for this user')
 
     provider_records = ProviderRecordUtility.get_records_of_type(
@@ -237,7 +240,7 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
         raise CCNotFoundException('Provider not found')
     provider_record = provider_records[0]
 
-    license_jurisdiction = home_state_license_record['jurisdiction']
+    license_jurisdiction = matching_license_record['jurisdiction']
     if license_jurisdiction.lower() in selected_jurisdictions_postal_abbreviations:
         raise CCInvalidRequestException(
             f"Selected privilege jurisdiction '{license_jurisdiction}' matches license jurisdiction"
@@ -253,15 +256,15 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
             privilege['jurisdiction'].lower() in selected_jurisdictions_postal_abbreviations
             # if their latest privilege expiration date matches the license expiration date they will not
             # receive any benefit from purchasing the same privilege, since the expiration date will not change
-            and privilege['dateOfExpiration'] == home_state_license_record['dateOfExpiration']
-            and privilege['persistedStatus'] == 'active'
+            and privilege['dateOfExpiration'] == matching_license_record['dateOfExpiration']
+                and privilege['persistedStatus'] == 'active'
         ):
             raise CCInvalidRequestException(
                 f"Selected privilege jurisdiction '{privilege['jurisdiction'].lower()}'"
                 f' matches existing privilege jurisdiction'
             )
 
-    license_expiration_date: date = home_state_license_record['dateOfExpiration']
+    license_expiration_date: date = matching_license_record['dateOfExpiration']
     user_active_military = ProviderRecordUtility.determine_military_affiliation_status(user_provider_data['items'])
 
     # Validate attestations are the latest versions before proceeding with the purchase
@@ -287,7 +290,7 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
             compact_transaction_id=transaction_response['transactionId'],
             provider_record=provider_record,
             existing_privileges=existing_privileges,
-            license_type=home_state_license_record['licenseType'],
+            license_type=matching_license_record['licenseType'],
             attestations=body['attestations'],
         )
 

--- a/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
@@ -280,12 +280,14 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
     purchase_client = PurchaseClient()
     transaction_response = None
     try:
+        license_type_abbr = config.license_type_abbreviations[compact_abbr][matching_license_record['licenseType']]
         transaction_response = purchase_client.process_charge_for_licensee_privileges(
             licensee_id=provider_id,
             order_information=body['orderInformation'],
             compact_configuration=compact,
             selected_jurisdictions=selected_jurisdictions,
-            user_active_military=user_active_military,
+            license_type_abbreviation=license_type_abbr,
+            user_active_military=user_active_military
         )
 
         # transaction was successful, now we create privilege records for the selected jurisdictions

--- a/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
@@ -222,8 +222,14 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
     )
 
     # we now validate that the license type matches one of the license types from the home state license records
-    matching_license_record = next((record for record in license_records if record['licenseType'] == body['licenseType']
-                                    and record['jurisdiction'] == home_state_selection), None)
+    matching_license_record = next(
+        (
+            record
+            for record in license_records
+            if record['licenseType'] == body['licenseType'] and record['jurisdiction'] == home_state_selection
+        ),
+        None,
+    )
 
     if matching_license_record is None:
         raise CCInvalidRequestException('Specified license type does not match any home state license type.')

--- a/backend/compact-connect/lambdas/python/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/purchase_client.py
@@ -133,6 +133,7 @@ class PaymentProcessorClient(ABC):
         order_information: dict,
         compact_configuration: Compact,
         selected_jurisdictions: list[Jurisdiction],
+        license_type_abbreviation: str,
         user_active_military: bool,
     ) -> dict:
         """
@@ -142,6 +143,7 @@ class PaymentProcessorClient(ABC):
         :param order_information: A dictionary containing the order information (billing, card, etc.)
         :param compact_configuration: The compact configuration.
         :param selected_jurisdictions: A list of selected jurisdictions to purchase privileges for.
+        :param license_type_abbreviation: The license type abbreviation used to generate line item id.
         :param user_active_military: Whether the user is active military.
         """
 
@@ -277,6 +279,7 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
         order_information: dict,
         compact_configuration: Compact,
         selected_jurisdictions: list[Jurisdiction],
+        license_type_abbreviation: str,
         user_active_military: bool,
     ) -> dict:
         # Create a merchantAuthenticationType object with authentication details
@@ -307,7 +310,8 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
         for jurisdiction in selected_jurisdictions:
             jurisdiction_name_title_case = jurisdiction.jurisdiction_name.title()
             privilege_line_item = apicontractsv1.lineItemType()
-            privilege_line_item.itemId = f'priv:{compact_configuration.compact_abbr}-{jurisdiction.postal_abbreviation}'
+            privilege_line_item.itemId = \
+                f'priv:{compact_configuration.compact_abbr}-{jurisdiction.postal_abbreviation}-{license_type_abbreviation}'
             privilege_line_item.name = f'{jurisdiction_name_title_case} Compact Privilege'
             privilege_line_item.quantity = '1'
             privilege_line_item.unitPrice = _calculate_jurisdiction_fee(jurisdiction, user_active_military)
@@ -837,7 +841,8 @@ class PurchaseClient:
         order_information: dict,
         compact_configuration: Compact,
         selected_jurisdictions: list[Jurisdiction],
-        user_active_military: bool,
+        license_type_abbreviation: str,
+        user_active_military: bool
     ) -> dict:
         """
         Process a charge on a credit card for a list of privileges within a compact.
@@ -846,6 +851,7 @@ class PurchaseClient:
         :param order_information: A dictionary containing the order information (billing, card, etc.)
         :param compact_configuration: The compact configuration.
         :param selected_jurisdictions: A list of selected jurisdictions to purchase privileges for.
+        :param license_type_abbreviation: The license type abbreviation used to generate line item id.
         :param user_active_military: Whether the user is active military.
         """
         if not self.payment_processor_client:
@@ -859,6 +865,7 @@ class PurchaseClient:
             order_information=order_information,
             compact_configuration=compact_configuration,
             selected_jurisdictions=selected_jurisdictions,
+            license_type_abbreviation=license_type_abbreviation,
             user_active_military=user_active_military,
         )
 

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/__init__.py
@@ -148,7 +148,7 @@ class TstFunction(TstLambdas):
             logger.debug('Loading resource, %s: %s', resource, str(record))
             self._provider_table.put_item(Item=record)
 
-    def _load_license_data(self, status: str = 'active', expiration_date: str = None):
+    def _load_license_data(self, status: str = 'active', expiration_date: str = None, license_type: str = None):
         """Use the canned test resources to load a basic provider to the DB"""
         license_test_resources = ['../common/tests/resources/dynamo/license.json']
 
@@ -158,6 +158,11 @@ class TstFunction(TstLambdas):
                 record['jurisdictionStatus'] = status
                 if expiration_date:
                     record['dateOfExpiration'] = expiration_date
+                if license_type:
+                    # add the abbreviation to the sk
+                    license_type_abbr = self.config.license_type_abbreviations['aslp'][license_type]
+                    record['sk'] = f'aslp#PROVIDER#license/oh/{license_type_abbr}#'
+                    record['licenseType'] = license_type
 
             logger.debug('Loading resource, %s: %s', resource, str(record))
             self._provider_table.put_item(Item=record)

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -353,9 +353,9 @@ class TestPostPurchasePrivileges(TstFunction):
         This test checks for a rare edge case where a user has two licenses which happen to have the *exact* same
         expiration date, and the user has a privilege for the first license.
 
-        If the user attempts to buy a privilege for the other license in the same jurisdiction as the first license,
-        the handler should allow the purchase, ensuring that we are only checking the existing privileges specific
-        to the license type which the user has selected.
+        If the user attempts to buy a privilege for the other license in the same jurisdiction as the privilege of the
+        first license, the handler should allow the purchase, ensuring that we are only checking the existing privileges
+        specific to the license type which the user has selected.
         """
         from handlers.privileges import post_purchase_privileges
 

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -339,7 +339,8 @@ class TestPostPurchasePrivileges(TstFunction):
 
         self.assertEqual(
             {
-                'message': "Selected privilege jurisdiction 'ky' matches existing privilege jurisdiction for license type"
+                'message': "Selected privilege jurisdiction 'ky' matches existing privilege "
+                           "jurisdiction for license type"
             },
             response_body,
         )

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -177,6 +177,7 @@ class TestPostPurchasePrivileges(TstFunction):
                 for jurisdiction in purchase_client_call_kwargs['selected_jurisdictions']
             ],
         )
+        self.assertEqual('slp', purchase_client_call_kwargs['license_type_abbreviation'])
         # in this test, the user had an empty list of military affiliations, so this should be false
         self.assertEqual(False, purchase_client_call_kwargs['user_active_military'])
 

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -29,6 +29,8 @@ ALL_ATTESTATION_IDS = [
 TEST_EMAIL = 'testRegisteredEmail@example.com'
 TEST_COGNITO_SUB = '1234567890'
 
+TEST_LICENSE_TYPE = 'speech-language pathologist'
+
 
 def generate_default_attestation_list():
     return [
@@ -46,6 +48,7 @@ def generate_default_attestation_list():
 def _generate_test_request_body(
     selected_jurisdictions: list[str] = None,
     attestations: list[dict] = None,
+    license_type: str = TEST_LICENSE_TYPE
 ):
     if not selected_jurisdictions:
         selected_jurisdictions = ['ky']
@@ -54,6 +57,7 @@ def _generate_test_request_body(
 
     return json.dumps(
         {
+            'licenseType': license_type,
             'selectedJurisdictions': selected_jurisdictions,
             'orderInformation': {
                 'card': {'number': '<card number>', 'expiration': '<expiration date>', 'cvv': '<cvv>'},
@@ -473,6 +477,23 @@ class TestPostPurchasePrivileges(TstFunction):
         self.assertEqual({'message': 'No active license found in selected home state for this user'}, response_body)
 
     @patch('handlers.privileges.PurchaseClient')
+    def test_post_purchase_privileges_returns_400_if_license_type_does_not_match_any_home_state_license(
+            self, mock_purchase_client_constructor):
+        from handlers.privileges import post_purchase_privileges
+
+        self._when_purchase_client_successfully_processes_request(mock_purchase_client_constructor)
+
+        event = self._when_testing_provider_user_event_with_custom_claims(license_status='active')
+        event['body'] = _generate_test_request_body(license_type='some-bogus-license-type')
+
+        resp = post_purchase_privileges(event, self.mock_context)
+        self.assertEqual(400, resp['statusCode'])
+        response_body = json.loads(resp['body'])
+
+        self.assertEqual({'message': 'Specified license type does not match any home state license type.'},
+                         response_body)
+
+    @patch('handlers.privileges.PurchaseClient')
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-11-08T23:59:59+00:00'))
     def test_post_purchase_privileges_adds_privilege_record_if_transaction_successful(
         self, mock_purchase_client_constructor
@@ -607,6 +628,26 @@ class TestPostPurchasePrivileges(TstFunction):
         privilege_record = next(record for record in provider_records['items'] if record['type'] == 'privilege')
 
         self.assertEqual(generate_default_attestation_list(), privilege_record['attestations'])
+
+    @patch('handlers.privileges.PurchaseClient')
+    @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-11-08T23:59:59+00:00'))
+    def test_post_purchase_privileges_stores_license_type_in_privilege_record(self, mock_purchase_client_constructor):
+        """Test that attestations are stored in the privilege record."""
+        from handlers.privileges import post_purchase_privileges
+
+        self._when_purchase_client_successfully_processes_request(mock_purchase_client_constructor)
+
+        event = self._when_testing_provider_user_event_with_custom_claims(license_expiration_date='2050-01-01')
+        event['body'] = _generate_test_request_body()
+
+        resp = post_purchase_privileges(event, self.mock_context)
+        self.assertEqual(200, resp['statusCode'], resp['body'])
+
+        # check that the privilege record for ky was created with attestations
+        provider_records = self.config.data_client.get_provider(compact=TEST_COMPACT, provider_id=TEST_PROVIDER_ID)
+        privilege_record = next(record for record in provider_records['items'] if record['type'] == 'privilege')
+
+        self.assertEqual(TEST_LICENSE_TYPE, privilege_record['licenseType'])
 
     @patch('handlers.privileges.PurchaseClient')
     def test_post_purchase_privileges_validates_investigation_attestations(self, mock_purchase_client_constructor):

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -46,9 +46,7 @@ def generate_default_attestation_list():
 
 
 def _generate_test_request_body(
-    selected_jurisdictions: list[str] = None,
-    attestations: list[dict] = None,
-    license_type: str = TEST_LICENSE_TYPE
+    selected_jurisdictions: list[str] = None, attestations: list[dict] = None, license_type: str = TEST_LICENSE_TYPE
 ):
     if not selected_jurisdictions:
         selected_jurisdictions = ['ky']
@@ -478,7 +476,8 @@ class TestPostPurchasePrivileges(TstFunction):
 
     @patch('handlers.privileges.PurchaseClient')
     def test_post_purchase_privileges_returns_400_if_license_type_does_not_match_any_home_state_license(
-            self, mock_purchase_client_constructor):
+        self, mock_purchase_client_constructor
+    ):
         from handlers.privileges import post_purchase_privileges
 
         self._when_purchase_client_successfully_processes_request(mock_purchase_client_constructor)
@@ -490,8 +489,9 @@ class TestPostPurchasePrivileges(TstFunction):
         self.assertEqual(400, resp['statusCode'])
         response_body = json.loads(resp['body'])
 
-        self.assertEqual({'message': 'Specified license type does not match any home state license type.'},
-                         response_body)
+        self.assertEqual(
+            {'message': 'Specified license type does not match any home state license type.'}, response_body
+        )
 
     @patch('handlers.privileges.PurchaseClient')
     @patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat('2024-11-08T23:59:59+00:00'))

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_history.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_history.py
@@ -7,6 +7,7 @@ from moto import mock_aws
 from .. import TstFunction
 
 TEST_COMPACT = 'aslp'
+TEST_AUD_LICENSE_TYPE_ABBR = 'aud'
 MOCK_START_TIME = '2024-01-01T00:00:00Z'
 MOCK_END_TIME = '2024-01-02T00:00:00Z'
 MOCK_TRANSACTION_LIMIT = 500
@@ -59,7 +60,7 @@ def _generate_mock_transaction(
     for jurisdiction in jurisdictions:
         transaction['lineItems'].append(
             {
-                'itemId': f'priv:{TEST_COMPACT}-{jurisdiction}',
+                'itemId': f'priv:{TEST_COMPACT}-{jurisdiction}-{TEST_AUD_LICENSE_TYPE_ABBR}',
                 'name': f'{jurisdiction.upper()} Compact Privilege',
                 'description': f'Compact Privilege for {jurisdiction}',
                 'quantity': '1',
@@ -262,7 +263,7 @@ class TestProcessSettledTransactions(TstFunction):
                     'lineItems': [
                         {
                             'description': 'Compact Privilege for oh',
-                            'itemId': 'priv:aslp-oh',
+                            'itemId': 'priv:aslp-oh-aud',
                             'name': 'OH Compact Privilege',
                             'quantity': '1',
                             'taxable': 'False',
@@ -489,7 +490,7 @@ class TestProcessSettledTransactions(TstFunction):
             [
                 {
                     'description': 'Compact Privilege for ky',
-                    'itemId': 'priv:aslp-ky',
+                    'itemId': 'priv:aslp-ky-aud',
                     'name': 'KY Compact Privilege',
                     'privilegeId': latest_transaction_privilege_id,
                     'quantity': '1',
@@ -505,7 +506,7 @@ class TestProcessSettledTransactions(TstFunction):
             [
                 {
                     'description': 'Compact Privilege for ky',
-                    'itemId': 'priv:aslp-ky',
+                    'itemId': 'priv:aslp-ky-aud',
                     'name': 'KY Compact Privilege',
                     'privilegeId': original_transaction_privilege_id,
                     'quantity': '1',
@@ -560,7 +561,7 @@ class TestProcessSettledTransactions(TstFunction):
             [
                 {
                     'description': 'Compact Privilege for oh',
-                    'itemId': 'priv:aslp-oh',
+                    'itemId': 'priv:aslp-oh-aud',
                     'name': 'OH Compact Privilege',
                     'privilegeId': privilege_id_oh,
                     'quantity': '1',
@@ -569,7 +570,7 @@ class TestProcessSettledTransactions(TstFunction):
                 },
                 {
                     'description': 'Compact Privilege for ky',
-                    'itemId': 'priv:aslp-ky',
+                    'itemId': 'priv:aslp-ky-aud',
                     'name': 'KY Compact Privilege',
                     'privilegeId': privilege_id_ky,
                     'quantity': '1',
@@ -578,7 +579,7 @@ class TestProcessSettledTransactions(TstFunction):
                 },
                 {
                     'description': 'Compact Privilege for ne',
-                    'itemId': 'priv:aslp-ne',
+                    'itemId': 'priv:aslp-ne-aud',
                     'name': 'NE Compact Privilege',
                     'privilegeId': privilege_id_ne,
                     'quantity': '1',

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_transaction_reporting.py
@@ -12,6 +12,7 @@ from moto import mock_aws
 from .. import TstFunction
 
 TEST_COMPACT = 'aslp'
+TEST_AUD_LICENSE_TYPE_ABBR = 'aud'
 # Test transaction data
 MOCK_TRANSACTION_ID = 'mockTransactionIdPlaceholder'
 MOCK_BATCH_ID = '67890'
@@ -75,7 +76,7 @@ def _generate_mock_transaction(
     line_items = [
         {
             'description': f'Compact Privilege for {jurisdiction.upper()}',
-            'itemId': f'priv:{TEST_COMPACT}-{jurisdiction}',
+            'itemId': f'priv:{TEST_COMPACT}-{jurisdiction}-{TEST_AUD_LICENSE_TYPE_ABBR}',
             'name': f'{jurisdiction.upper()} Compact Privilege',
             # setting this as '1.0' to simulate behavior we've seen returned from authorize.net
             'quantity': '1.0',

--- a/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
@@ -22,6 +22,8 @@ MOCK_LICENSEE_ID = '89a6377e-c3a5-40e5-bca5-317ec854c570'
 
 MOCK_LICENSEE_TRANSACTION_FEE_AMOUNT = 5
 
+MOCK_LICENSE_TYPE_ABBR = 'slp'
+
 # Test constants for transaction history tests
 MOCK_BATCH_ID = '12345'
 MOCK_BATCH_ID_2 = '12346'
@@ -222,6 +224,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
+            license_type_abbreviation=MOCK_LICENSE_TYPE_ABBR,
             user_active_military=False,
         )
 
@@ -245,6 +248,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
+            license_type_abbreviation=MOCK_LICENSE_TYPE_ABBR,
             user_active_military=False,
         )
 
@@ -294,6 +298,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
+            license_type_abbreviation=MOCK_LICENSE_TYPE_ABBR,
             user_active_military=False,
         )
 
@@ -303,7 +308,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         # we check every line item of the object to ensure that the correct values are being set
         self.assertEqual(2, len(api_contract_v1_obj.transactionRequest.lineItems.lineItem))
         # first line item is the jurisdiction fee
-        self.assertEqual('priv:aslp-oh', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].itemId)
+        self.assertEqual('priv:aslp-oh-slp', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].itemId)
         self.assertEqual('Ohio Compact Privilege', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].name)
         self.assertEqual(100.00, api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].unitPrice)
         self.assertEqual(1, api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].quantity)
@@ -346,6 +351,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(include_licensee_charges=True),
             selected_jurisdictions=_generate_selected_jurisdictions(test_jurisdictions),
+            license_type_abbreviation=MOCK_LICENSE_TYPE_ABBR,
             user_active_military=False,
         )
 
@@ -355,7 +361,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         # we check every line item of the object to ensure that the correct values are being set
         self.assertEqual(4, len(api_contract_v1_obj.transactionRequest.lineItems.lineItem))
         # first line item is the jurisdiction fee
-        self.assertEqual('priv:aslp-oh', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].itemId)
+        self.assertEqual('priv:aslp-oh-slp', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].itemId)
         self.assertEqual('Ohio Compact Privilege', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].name)
         self.assertEqual(50.00, api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].unitPrice)
         self.assertEqual(1, api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].quantity)
@@ -363,7 +369,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             'Compact Privilege for Ohio', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].description
         )
         # the second line item is the jurisdiction fee for kentucky
-        self.assertEqual('priv:aslp-ky', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].itemId)
+        self.assertEqual('priv:aslp-ky-slp', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].itemId)
         self.assertEqual(
             'Kentucky Compact Privilege', api_contract_v1_obj.transactionRequest.lineItems.lineItem[1].name
         )
@@ -413,6 +419,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
+            license_type_abbreviation=MOCK_LICENSE_TYPE_ABBR,
             user_active_military=False,
         )
 
@@ -439,6 +446,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
             order_information=_generate_default_order_information(),
             compact_configuration=_generate_aslp_compact_configuration(),
             selected_jurisdictions=_generate_selected_jurisdictions(),
+            license_type_abbreviation=MOCK_LICENSE_TYPE_ABBR,
             user_active_military=True,
         )
 
@@ -447,7 +455,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         # we check every line item of the object to ensure that the correct values are being set
         self.assertEqual(2, len(api_contract_v1_obj.transactionRequest.lineItems.lineItem))
         # verify jurisdiction fee line item with military discount
-        self.assertEqual('priv:aslp-oh', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].itemId)
+        self.assertEqual('priv:aslp-oh-slp', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].itemId)
         self.assertEqual('Ohio Compact Privilege', api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].name)
         self.assertEqual(75.00, api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].unitPrice)
         self.assertEqual(1, api_contract_v1_obj.transactionRequest.lineItems.lineItem[0].quantity)
@@ -478,6 +486,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
                 order_information=_generate_default_order_information(),
                 compact_configuration=_generate_aslp_compact_configuration(),
                 selected_jurisdictions=_generate_selected_jurisdictions(),
+                license_type_abbreviation=MOCK_LICENSE_TYPE_ABBR,
                 user_active_military=False,
             )
 
@@ -498,6 +507,7 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
                 order_information=_generate_default_order_information(),
                 compact_configuration=_generate_aslp_compact_configuration(),
                 selected_jurisdictions=_generate_selected_jurisdictions(),
+                license_type_abbreviation=MOCK_LICENSE_TYPE_ABBR,
                 user_active_military=False,
             )
 

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -492,8 +492,12 @@ class ApiModel:
             description='Post purchase privileges request model',
             schema=JsonSchema(
                 type=JsonSchemaType.OBJECT,
-                required=['selectedJurisdictions', 'orderInformation', 'attestations'],
+                required=['licenseType', 'selectedJurisdictions', 'orderInformation', 'attestations'],
                 properties={
+                    'licenseType': JsonSchema(
+                        type=JsonSchemaType.STRING,
+                        description='The type of license the provider is purchasing',
+                    ),
                     'selectedJurisdictions': JsonSchema(
                         type=JsonSchemaType.ARRAY,
                         # setting a max length to prevent abuse

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -497,6 +497,7 @@ class ApiModel:
                     'licenseType': JsonSchema(
                         type=JsonSchemaType.STRING,
                         description='The type of license the provider is purchasing a privilege for.',
+                        enum=self.stack.license_types,
                     ),
                     'selectedJurisdictions': JsonSchema(
                         type=JsonSchemaType.ARRAY,
@@ -1525,6 +1526,7 @@ class ApiModel:
                         type=JsonSchemaType.STRING,
                         description='Type of license',
                         max_length=500,
+                        enum=self.stack.license_types
                     ),
                     'compact': JsonSchema(
                         type=JsonSchemaType.STRING,

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -496,7 +496,7 @@ class ApiModel:
                 properties={
                     'licenseType': JsonSchema(
                         type=JsonSchemaType.STRING,
-                        description='The type of license the provider is purchasing',
+                        description='The type of license the provider is purchasing a privilege for.',
                     ),
                     'selectedJurisdictions': JsonSchema(
                         type=JsonSchemaType.ARRAY,

--- a/backend/compact-connect/tests/resources/snapshots/POST_PROVIDER_USERS_REGISTRATION_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/POST_PROVIDER_USERS_REGISTRATION_REQUEST_SCHEMA.json
@@ -91,6 +91,13 @@
     },
     "licenseType": {
       "description": "Type of license",
+      "enum": [
+        "audiologist",
+        "speech-language pathologist",
+        "occupational therapist",
+        "occupational therapy assistant",
+        "licensed professional counselor"
+      ],
       "maxLength": 500,
       "type": "string"
     },

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
@@ -2,6 +2,13 @@
   "properties": {
     "licenseType": {
       "description": "The type of license the provider is purchasing a privilege for.",
+      "enum": [
+        "audiologist",
+        "speech-language pathologist",
+        "occupational therapist",
+        "occupational therapy assistant",
+        "licensed professional counselor"
+      ],
       "type": "string"
     },
     "selectedJurisdictions": {

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
@@ -1,5 +1,9 @@
 {
   "properties": {
+    "licenseType": {
+      "description": "The type of license the provider is purchasing",
+      "type": "string"
+    },
     "selectedJurisdictions": {
       "items": {
         "description": "Jurisdictions a provider has selected to purchase privileges in.",
@@ -173,6 +177,7 @@
     }
   },
   "required": [
+    "licenseType",
     "selectedJurisdictions",
     "orderInformation",
     "attestations"

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "licenseType": {
-      "description": "The type of license the provider is purchasing",
+      "description": "The type of license the provider is purchasing a privilege for.",
       "type": "string"
     },
     "selectedJurisdictions": {

--- a/backend/compact-connect/tests/smoke/load_test_privilege_purchasing.py
+++ b/backend/compact-connect/tests/smoke/load_test_privilege_purchasing.py
@@ -10,6 +10,7 @@ from smoke_common import (
     SmokeTestFailureException,
     call_provider_users_me_endpoint,
     get_provider_user_auth_headers_cached,
+    get_license_type_abbreviation
 )
 
 # Load-Testing Script for populating authorize.net with transactions
@@ -55,8 +56,9 @@ def delete_existing_privileges():
     dynamodb_table = config.provider_user_dynamodb_table
 
     for privilege in privileges:
+        license_type_abbreviation = get_license_type_abbreviation(privilege['licenseType'])
         privilege_pk = f'{compact}#PROVIDER#{provider_id}'
-        privilege_sk = f'{compact}#PROVIDER#privilege/{privilege["jurisdiction"]}#'
+        privilege_sk = f'{compact}#PROVIDER#privilege/{privilege["jurisdiction"]}/{license_type_abbreviation}#'
         logger.info(f'Deleting privilege record:\n{privilege_pk}\n{privilege_sk}')
         dynamodb_table.delete_item(
             Key={
@@ -107,7 +109,7 @@ def get_required_attestations(provider_data: dict) -> list[dict]:
     return attestations
 
 
-def purchase_privilege(jurisdiction: str, card_number: str, attestations: list[dict]) -> str:
+def purchase_privilege(jurisdiction: str, card_number: str, attestations: list[dict], license_type: str) -> str:
     """Purchase a privilege for the given jurisdiction using the specified card number."""
     post_body = {
         'orderInformation': {
@@ -130,6 +132,7 @@ def purchase_privilege(jurisdiction: str, card_number: str, attestations: list[d
         },
         'selectedJurisdictions': [jurisdiction],
         'attestations': attestations,
+        'licenseType': license_type,
     }
 
     headers = get_provider_user_auth_headers_cached()
@@ -154,6 +157,8 @@ def run_load_test(num_iterations: int):
 
     # Get provider data and attestations
     provider_data = call_provider_users_me_endpoint()
+    # Grab the license type from the user's first license
+    license_type = provider_data['licenses'][0]['licenseType']
     attestations = get_required_attestations(provider_data)
 
     for iteration in range(num_iterations):
@@ -178,7 +183,7 @@ def run_load_test(num_iterations: int):
 
             for jurisdiction, card in jurisdictions:
                 try:
-                    purchase_privilege(jurisdiction, card, attestations)
+                    purchase_privilege(jurisdiction, card, attestations, license_type)
                 except Exception as e:
                     logger.error(f'Failed to purchase privilege for {jurisdiction} with card {card}: {str(e)}')
                     continue

--- a/backend/compact-connect/tests/smoke/load_test_privilege_purchasing.py
+++ b/backend/compact-connect/tests/smoke/load_test_privilege_purchasing.py
@@ -9,8 +9,8 @@ from faker import Faker
 from smoke_common import (
     SmokeTestFailureException,
     call_provider_users_me_endpoint,
+    get_license_type_abbreviation,
     get_provider_user_auth_headers_cached,
-    get_license_type_abbreviation
 )
 
 # Load-Testing Script for populating authorize.net with transactions

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -8,8 +8,8 @@ from config import config, logger
 from smoke_common import (
     SmokeTestFailureException,
     call_provider_users_me_endpoint,
-    get_provider_user_auth_headers_cached,
     get_license_type_abbreviation,
+    get_provider_user_auth_headers_cached,
 )
 
 # This script can be run locally to test the privilege purchasing flow against a sandbox environment
@@ -203,8 +203,9 @@ def test_purchasing_privilege():
         if not matching_attestation_from_system:
             raise SmokeTestFailureException(f'No matching attestation found for {attestation["attestationId"]}')
         if attestation['version'] != matching_attestation_from_system['version']:
-            raise SmokeTestFailureException('Attestation version in privilege record does not match '
-                                            'latest version in system')
+            raise SmokeTestFailureException(
+                'Attestation version in privilege record does not match latest version in system'
+            )
 
     logger.info(f'Successfully purchased privilege record: {matching_privilege}')
 

--- a/backend/compact-connect/tests/smoke/smoke_common.py
+++ b/backend/compact-connect/tests/smoke/smoke_common.py
@@ -169,6 +169,7 @@ def get_staff_user_auth_headers(username: str, password: str = _TEST_STAFF_USER_
         'Authorization': 'Bearer ' + tokens['AccessToken'],
     }
 
+
 def get_license_type_abbreviation(license_type: str):
     """
     Gets the abbreviation for a specific license type.

--- a/backend/compact-connect/tests/smoke/smoke_common.py
+++ b/backend/compact-connect/tests/smoke/smoke_common.py
@@ -26,6 +26,7 @@ with open('cdk.json') as context_file:
     _context = json.load(context_file)['context']
 JURISDICTIONS = _context['jurisdictions']
 COMPACTS = _context['compacts']
+LICENSE_TYPES = _context['license_types']
 
 os.environ['COMPACTS'] = json.dumps(COMPACTS)
 os.environ['JURISDICTIONS'] = json.dumps(JURISDICTIONS)
@@ -167,6 +168,15 @@ def get_staff_user_auth_headers(username: str, password: str = _TEST_STAFF_USER_
     return {
         'Authorization': 'Bearer ' + tokens['AccessToken'],
     }
+
+def get_license_type_abbreviation(license_type: str):
+    """
+    Gets the abbreviation for a specific license type.
+    """
+    all_license_types = []
+    for compact in LICENSE_TYPES:
+        all_license_types.extend(LICENSE_TYPES[compact])
+    return next((lt['abbreviation'] for lt in all_license_types if lt['name'] == license_type), None)
 
 
 def get_api_base_url():


### PR DESCRIPTION
As part of supporting multiple license types in the same home state, this adds a `licenseType` field to the request body of the privilege purchase endpoint. The endpoint now validates that the specified license type matches one of the provider's home state licenses before proceeding with the privilege purchase.

### Requirements List
- This is a backwards incompatible change, when this is merged the UI will not be able to purchase privileges until [this PR for the corresponding front end change is merged. ](https://github.com/csg-org/CompactConnect/pull/627)

### Description List
- Add required `licenseType` field to POST privilege purchase request body
- Validation license type matches one of provider's home state licenses

### Testing List
- updated api schema snapshots
- updated smoke tests and verified change in sandbox env
- functional/unit test coverage added for validation logic
- Code review

Closes #572 
