### PR TITLE
activate jurisdictions for coun compact in test env

### DIFF
--- a/backend/compact-connect/compact-config/coun/kentucky.yml
+++ b/backend/compact-connect/compact-config/coun/kentucky.yml
@@ -12,4 +12,4 @@ jurisdictionAdverseActionsNotificationEmails: []
 jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: true
-activeEnvironments: []
+activeEnvironments: ["test"]

--- a/backend/compact-connect/compact-config/coun/nebraska.yml
+++ b/backend/compact-connect/compact-config/coun/nebraska.yml
@@ -12,4 +12,4 @@ jurisdictionAdverseActionsNotificationEmails: []
 jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: true
-activeEnvironments: []
+activeEnvironments: ["test"]

--- a/backend/compact-connect/compact-config/coun/ohio.yml
+++ b/backend/compact-connect/compact-config/coun/ohio.yml
@@ -12,4 +12,4 @@ jurisdictionAdverseActionsNotificationEmails: []
 jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: true
-activeEnvironments: []
+activeEnvironments: ["test"]

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/api.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/compact/api.py
@@ -23,5 +23,5 @@ class CompactOptionsResponseSchema(ForgivingSchema):
     compactAbbr = String(required=True, allow_none=False, validate=OneOf(config.compacts))
     compactName = String(required=True, allow_none=False)
     compactCommissionFee = Nested(CompactCommissionFeeSchema(), required=True, allow_none=False)
-    transactionFeeConfiguration = Nested(TransactionFeeConfigurationResponseSchema(), required=True, allow_none=False)
+    transactionFeeConfiguration = Nested(TransactionFeeConfigurationResponseSchema(), required=False, allow_none=False)
     type = String(required=True, allow_none=False, validate=OneOf([COMPACT_TYPE]))

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_INPUT.json
@@ -434,6 +434,70 @@
         ]
       }
     ],
-    "coun": []
+    "coun": [
+      {
+        "jurisdictionName": "Kentucky",
+        "postalAbbreviation": "ky",
+        "jurisdictionFee": 100,
+        "militaryDiscount": {
+          "active": true,
+          "discountType": "FLAT_RATE",
+          "discountAmount": 10
+        },
+        "jurisdictionOperationsTeamEmails": [
+          "cloud-team-nonprod-alerts@inspiringapps.com"
+        ],
+        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionSummaryReportNotificationEmails": [],
+        "jurisprudenceRequirements": {
+          "required": true
+        },
+        "activeEnvironments": [
+          "test"
+        ]
+      },
+      {
+        "jurisdictionName": "Nebraska",
+        "postalAbbreviation": "ne",
+        "jurisdictionFee": 100,
+        "militaryDiscount": {
+          "active": true,
+          "discountType": "FLAT_RATE",
+          "discountAmount": 10
+        },
+        "jurisdictionOperationsTeamEmails": [
+          "cloud-team-nonprod-alerts@inspiringapps.com"
+        ],
+        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionSummaryReportNotificationEmails": [],
+        "jurisprudenceRequirements": {
+          "required": true
+        },
+        "activeEnvironments": [
+          "test"
+        ]
+      },
+      {
+        "jurisdictionName": "Ohio",
+        "postalAbbreviation": "oh",
+        "jurisdictionFee": 100,
+        "militaryDiscount": {
+          "active": true,
+          "discountType": "FLAT_RATE",
+          "discountAmount": 10
+        },
+        "jurisdictionOperationsTeamEmails": [
+          "cloud-team-nonprod-alerts@inspiringapps.com"
+        ],
+        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionSummaryReportNotificationEmails": [],
+        "jurisprudenceRequirements": {
+          "required": true
+        },
+        "activeEnvironments": [
+          "test"
+        ]
+      }
+    ]
   }
 }

--- a/backend/compact-connect/tests/resources/snapshots/JURISDICTION_RESOURCE_SERVER_CONFIGURATION_TEST_ENV.json
+++ b/backend/compact-connect/tests/resources/snapshots/JURISDICTION_RESOURCE_SERVER_CONFIGURATION_TEST_ENV.json
@@ -20,6 +20,22 @@
         "ScopeName": "aslp.write"
       },
       {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
         "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
         "ScopeName": "octp.admin"
       },
@@ -58,6 +74,22 @@
         "ScopeName": "aslp.write"
       },
       {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
         "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
         "ScopeName": "octp.admin"
       },
@@ -94,6 +126,22 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
       },
       {
         "ScopeDescription": "Admin access for the octp compact within the jurisdiction",


### PR DESCRIPTION
We are ready to perform testing for the coun compact in the test environment. Activating these test jurisdictions so users can purchase test privileges.

Also addressing issue identified with the API schema validation, which was setting an optional field as required.
