### PR TITLE
Only allow compact admins to deactivate privilege

### DIFF
--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/data_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/data_client.py
@@ -489,7 +489,8 @@ class DataClient:
         # as a safety precaution, we must ensure that every privilege in the list matches the license type that we
         # attempted to change privilege for
         existing_privileges_by_jurisdiction = {
-            privilege['jurisdiction']: privilege for privilege in existing_privileges_for_license_type
+            privilege['jurisdiction']: privilege
+            for privilege in existing_privileges_for_license_type
             if privilege['licenseType'] == license_type
         }
 

--- a/backend/compact-connect/lambdas/python/migration/618_remove_military_waiver/main.py
+++ b/backend/compact-connect/lambdas/python/migration/618_remove_military_waiver/main.py
@@ -43,28 +43,19 @@ def do_migration(_properties: dict) -> None:
                     logger.info('No type defined. Skipping record.', pk=provider_record['pk'], sk=provider_record['sk'])
                     continue
                 # Prepare key for update_item
-                key = {
-                    'pk': provider_record['pk'],
-                    'sk': provider_record['sk']
-                }
+                key = {'pk': provider_record['pk'], 'sk': provider_record['sk']}
 
                 if provider_record['type'] == 'provider' or provider_record['type'] == 'license':
                     # Use update_item with REMOVE expression to safely remove the field
-                    update_expression = "REMOVE militaryWaiver"
+                    update_expression = 'REMOVE militaryWaiver'
                     logger.info('Updating record', pk=provider_record['pk'], sk=provider_record['sk'])
-                    config.provider_table.update_item(
-                        Key=key,
-                        UpdateExpression=update_expression
-                    )
+                    config.provider_table.update_item(Key=key, UpdateExpression=update_expression)
                     success_count += 1
                 elif provider_record['type'] == 'licenseUpdate':
                     # For licenseUpdate, we need to remove from both previous and updatedValues objects
-                    update_expression = "REMOVE previous.militaryWaiver, updatedValues.militaryWaiver"
+                    update_expression = 'REMOVE previous.militaryWaiver, updatedValues.militaryWaiver'
                     logger.info('Updating licenseUpdate record', pk=provider_record['pk'], sk=provider_record['sk'])
-                    config.provider_table.update_item(
-                        Key=key,
-                        UpdateExpression=update_expression
-                    )
+                    config.provider_table.update_item(Key=key, UpdateExpression=update_expression)
                     success_count += 1
                 else:
                     logger.info('Skipping record', pk=provider_record['pk'], sk=provider_record['sk'])
@@ -82,6 +73,6 @@ def do_migration(_properties: dict) -> None:
         scan_pagination = {'ExclusiveStartKey': last_evaluated_key}
 
     # Log final statistics
-    logger.info(f"Removed militaryWaiver field from {success_count} records")
+    logger.info(f'Removed militaryWaiver field from {success_count} records')
     if error_count > 0:
         raise RuntimeError('military waiver removal migration completed with errors')

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/privileges.py
@@ -4,8 +4,8 @@ from aws_lambda_powertools.metrics import MetricUnit
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from cc_common.config import config, logger, metrics
 from cc_common.data_model.schema.common import CCPermissionsAction
-from cc_common.exceptions import CCAccessDeniedException, CCInternalException, CCInvalidRequestException
-from cc_common.utils import api_handler, authorize_compact_level_only_action, get_event_scopes
+from cc_common.exceptions import CCInternalException, CCInvalidRequestException
+from cc_common.utils import api_handler, authorize_compact_level_only_action
 from event_batch_writer import EventBatchWriter
 
 

--- a/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/privileges.py
@@ -221,7 +221,7 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
         user_provider_data['items'],
         ProviderRecordType.LICENSE,
         _filter=lambda record: record['licenseType'] == body['licenseType']
-                                and record['jurisdiction'] == home_state_selection,
+        and record['jurisdiction'] == home_state_selection,
     )
 
     if not matching_license_records:
@@ -287,7 +287,7 @@ def post_purchase_privileges(event: dict, context: LambdaContext):  # noqa: ARG0
             compact_configuration=compact,
             selected_jurisdictions=selected_jurisdictions,
             license_type_abbreviation=license_type_abbr,
-            user_active_military=user_active_military
+            user_active_military=user_active_military,
         )
 
         # transaction was successful, now we create privilege records for the selected jurisdictions

--- a/backend/compact-connect/lambdas/python/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/purchase_client.py
@@ -310,8 +310,7 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
         for jurisdiction in selected_jurisdictions:
             jurisdiction_name_title_case = jurisdiction.jurisdiction_name.title()
             privilege_line_item = apicontractsv1.lineItemType()
-            privilege_line_item.itemId = \
-                f'priv:{compact_configuration.compact_abbr}-{jurisdiction.postal_abbreviation}-{license_type_abbreviation}'
+            privilege_line_item.itemId = f'priv:{compact_configuration.compact_abbr}-{jurisdiction.postal_abbreviation}-{license_type_abbreviation}'  # noqa: E501
             privilege_line_item.name = f'{jurisdiction_name_title_case} Compact Privilege'
             privilege_line_item.quantity = '1'
             privilege_line_item.unitPrice = _calculate_jurisdiction_fee(jurisdiction, user_active_military)
@@ -842,7 +841,7 @@ class PurchaseClient:
         compact_configuration: Compact,
         selected_jurisdictions: list[Jurisdiction],
         license_type_abbreviation: str,
-        user_active_military: bool
+        user_active_military: bool,
     ) -> dict:
         """
         Process a charge on a credit card for a list of privileges within a compact.

--- a/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/function/test_handlers/test_purchase_privileges.py
@@ -341,7 +341,7 @@ class TestPostPurchasePrivileges(TstFunction):
         self.assertEqual(
             {
                 'message': "Selected privilege jurisdiction 'ky' matches existing privilege "
-                           "jurisdiction for license type"
+                'jurisdiction for license type'
             },
             response_body,
         )

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -1520,7 +1520,7 @@ class ApiModel:
                         type=JsonSchemaType.STRING,
                         description='Type of license',
                         max_length=500,
-                        enum=self.stack.license_types
+                        enum=self.stack.license_types,
                     ),
                     'compact': JsonSchema(
                         type=JsonSchemaType.STRING,

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -377,8 +377,8 @@ class PersistentStack(AppStack):
                 {
                     'id': 'AwsSolutions-IAM5',
                     'reason': 'This policy contains wild-carded actions and resources but they are scoped to the '
-                              'specific actions, Table and Key that this lambda needs access to in order to perform the'
-                              'migration.',
+                    'specific actions, Table and Key that this lambda needs access to in order to perform the'
+                    'migration.',
                 },
             ],
         )

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -91,7 +91,7 @@ def test_purchasing_privilege():
     # query for all ne related privilege records
     original_privilege_records = dynamodb_table.query(
         KeyConditionExpression=Key('pk').eq(f'{compact}#PROVIDER#{provider_id}')
-                               & Key('sk').begins_with(f'{compact}#PROVIDER#privilege/ne/')
+        & Key('sk').begins_with(f'{compact}#PROVIDER#privilege/ne/')
     ).get('Items', [])
     for privilege in original_privilege_records:
         # delete the privilege records


### PR DESCRIPTION
We have received feedback from the EDs that only compact administrators should be allowed to deactivate privileges. This tightens down the scope checks to enforce only compact admins can access the endpoint.

### Description List
- restrict privilege deactivation access to compact admins

### Testing List
- update functional tests

Closes #624 
