### PR TITLE
Bug/work around authorizenet bug

### DIFF
--- a/backend/compact-connect/tests/common_constructs/test_data_migration.py
+++ b/backend/compact-connect/tests/common_constructs/test_data_migration.py
@@ -13,7 +13,9 @@ class TestDataMigration(TestCase):
     def test_data_migration_synthesizes(self):
         from common_constructs.data_migration import DataMigration
 
-        app = App()
+        # Suppresses lambda bundling for tests
+        context = {'aws:cdk:bundling-stacks': []}
+        app = App(context=context)
         stack = Stack(app, 'Stack')
 
         # Create a role for the migration function

--- a/backend/setuptools-workaround/Dockerfile
+++ b/backend/setuptools-workaround/Dockerfile
@@ -1,0 +1,5 @@
+FROM public.ecr.aws/sam/build-python3.12
+
+USER root
+RUN pip install 'setuptools<78'
+USER nobody

--- a/backend/setuptools-workaround/README.md
+++ b/backend/setuptools-workaround/README.md
@@ -1,0 +1,25 @@
+# Authorize.Net setuptools bug workaround
+
+Authorize.Net's python SDK, `authorizenet` currently has [a bug that makes it uninstallable in environments that use the latest
+of python-maintained library management tools](https://github.com/AuthorizeNet/sdk-python/issues/166). Specifically, `setuptools`, with version `78+` stopped supporting some long-deprecated configuration arguments, which the `authorizenet` library still uses. In the hopes that Authorize.Net will quickly remedy this bug, we have adopted a temporary work-around to unblock our deploy pipelines: We've custom-built a docker image for building our lambdas that includes a downgraded version of `setuptools`.
+
+If the Authorize.Net bug is not resolved quickly, we should consider a more permanent work-around, as this manually-built image is not an ideal or supportable feature to maintain.
+
+## Steps to reproduce this work-around:
+1) Create a public docker repository with one of the many services that offer one
+2) Build an image with this `Dockerfile`:
+
+   `docker build . -t local/build-python3.12`
+
+3) Push this image to the public registry that you control:
+   ```sh
+   docker tag local/build-python3.12 <your registry url>:build-python3.12
+   docker push <your registry url>:build-python3.12
+   ```
+
+4) Override the default bundler image url with your custom one in `PythonFunction` at [python_function.py](../compact-connect/common_constructs/python_function.py) by adding this to the `super().__init__()` call:
+   ```python
+   bundling=BundlingOptions(
+       image=DockerImage.from_registry('<your registry url>:build-python3.12'),
+   ),
+   ```


### PR DESCRIPTION
Authorize.Net's python SDK, `authorizenet` currently has [a bug that makes it uninstallable in environments that use the latest of python-maintained library management tools](https://github.com/AuthorizeNet/sdk-python/issues/166). Specifically, `setuptools`, with version `78+` stopped supporting some long-deprecated configuration arguments, which the `authorizenet` library still uses. In the hopes that Authorize.Net will quickly remedy this bug, we have adopted a temporary work-around to unblock our deploy pipelines: We've custom-built a docker image for building our lambdas that includes a downgraded version of `setuptools`.

This work-around is far from an ideal solution, so we should discuss it carefully before approving. Unfortunately, it is also the only short-term solution I can see to getting our pipeline unblocked.

### Description List
- Add a `Dockerfile` to build a custom SAM python lambda builder image with downgraded setuptools
- Update `PythonLambda` to use this custom image, as hosted in a public registry we've created for the purpose

### Testing List
- Code review
