### PR TITLE
Frontend/privilege select keyboard updates

### DIFF
--- a/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
+++ b/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
@@ -44,6 +44,7 @@
                                         <div
                                             @click.prevent="toggleStateSelected(state)"
                                             @keyup.enter="toggleStateSelected(state)"
+                                            @keyup.space="toggleStateSelected(state)"
                                             tabindex="0"
                                             class="enabled-state-overlay"
                                         />

--- a/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.ts
+++ b/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.ts
@@ -98,6 +98,14 @@ class SelectedStatePurchaseInformation extends mixins(MixinForm) {
         return date;
     }
 
+    get jurisprudenceInputRef(): HTMLElement | null {
+        return document.getElementById((this.jurisprudenceCheckInput?.id || ''));
+    }
+
+    get scopeOfPracticeInputRef(): HTMLElement | null {
+        return document.getElementById((this.scopeOfPracticeCheckInput?.id || ''));
+    }
+
     get expirationDateText(): string {
         return this.$t('licensing.expirationDate');
     }
@@ -186,18 +194,16 @@ class SelectedStatePurchaseInformation extends mixins(MixinForm) {
     // Methods
     //
     initFormInputs(): void {
-        const initFormData: any = {
+        this.formData = reactive({
             submitJurisprudenceUnderstanding: new FormInput({
-                isSubmitInput: true,
                 id: 'submit-jurisprudence-understanding',
+                isSubmitInput: true,
             }),
             submitScopeUnderstanding: new FormInput({
-                isSubmitInput: true,
                 id: 'submit-scope-understanding',
+                isSubmitInput: true,
             }),
-        };
-
-        this.formData = reactive(initFormData);
+        });
     }
 
     handleJurisprudenceClicked(): void {
@@ -248,6 +254,7 @@ class SelectedStatePurchaseInformation extends mixins(MixinForm) {
         if (isJurisprudencePending && jurisprudenceCheckInput) {
             this.setJurisprudenceInputValue(true);
             this.$store.dispatch('setModalIsOpen', false);
+            this.jurisprudenceInputRef?.focus();
             this.isJurisprudencePending = false;
         }
     }
@@ -258,6 +265,7 @@ class SelectedStatePurchaseInformation extends mixins(MixinForm) {
         if (isScopeOfPracticePending && scopeOfPracticeCheckInput) {
             this.setScopeInputValue(true);
             this.$store.dispatch('setModalIsOpen', false);
+            this.scopeOfPracticeInputRef?.focus();
             this.isScopeOfPracticePending = false;
         }
     }
@@ -268,6 +276,7 @@ class SelectedStatePurchaseInformation extends mixins(MixinForm) {
         if (isJurisprudencePending && jurisprudenceCheckInput) {
             this.setJurisprudenceInputValue(false);
             this.$store.dispatch('setModalIsOpen', false);
+            this.jurisprudenceInputRef?.focus();
             this.isJurisprudencePending = false;
         }
     }
@@ -278,6 +287,7 @@ class SelectedStatePurchaseInformation extends mixins(MixinForm) {
         if (isScopeOfPracticePending && scopeOfPracticeCheckInput) {
             this.setScopeInputValue(false);
             this.$store.dispatch('setModalIsOpen', false);
+            this.scopeOfPracticeInputRef?.focus();
             this.isScopeOfPracticePending = false;
         }
     }


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Added space handler to privilege select DOM
- Updated selected privilege checkboxes to be focused after closing corresponding modal dialog
- Minor code consistency cleanup to remove `any` type

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Begin the purchase flow as a licensee
    - On the privilege-select UI, confirm state checkboxes are selectable / deselectable with spacebar
    - On the selected privilege cards, make sure the attestation checkboxes are active after closing the modal confirmations

Closes #548 
