### PR TITLE
Add AL, MS, LA, AR to OCTP config

### DIFF
--- a/backend/compact-connect/compact-config/octp/alabama.yml
+++ b/backend/compact-connect/compact-config/octp/alabama.yml
@@ -1,0 +1,12 @@
+# PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
+jurisdictionName: "Alabama"
+postalAbbreviation: "al"
+jurisdictionFee: 100
+jurisdictionOperationsTeamEmails:
+    - "cloud-team-nonprod-alerts@inspiringapps.com"
+jurisdictionAdverseActionsNotificationEmails: []
+jurisdictionSummaryReportNotificationEmails: []
+jurisprudenceRequirements:
+    required: true
+licenseeRegistrationEnabledForEnvironments: ["test"]
+activeEnvironments: ["test"]

--- a/backend/compact-connect/compact-config/octp/arkansas.yml
+++ b/backend/compact-connect/compact-config/octp/arkansas.yml
@@ -1,0 +1,12 @@
+# PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
+jurisdictionName: "Arkansas"
+postalAbbreviation: "ar"
+jurisdictionFee: 100
+jurisdictionOperationsTeamEmails:
+    - "cloud-team-nonprod-alerts@inspiringapps.com"
+jurisdictionAdverseActionsNotificationEmails: []
+jurisdictionSummaryReportNotificationEmails: []
+jurisprudenceRequirements:
+    required: true
+licenseeRegistrationEnabledForEnvironments: ["test"]
+activeEnvironments: ["test"]

--- a/backend/compact-connect/compact-config/octp/louisiana.yml
+++ b/backend/compact-connect/compact-config/octp/louisiana.yml
@@ -1,0 +1,12 @@
+# PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
+jurisdictionName: "Louisiana"
+postalAbbreviation: "la"
+jurisdictionFee: 100
+jurisdictionOperationsTeamEmails:
+    - "cloud-team-nonprod-alerts@inspiringapps.com"
+jurisdictionAdverseActionsNotificationEmails: []
+jurisdictionSummaryReportNotificationEmails: []
+jurisprudenceRequirements:
+    required: true
+licenseeRegistrationEnabledForEnvironments: ["test"]
+activeEnvironments: ["test"]

--- a/backend/compact-connect/compact-config/octp/mississippi.yml
+++ b/backend/compact-connect/compact-config/octp/mississippi.yml
@@ -1,0 +1,12 @@
+# PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
+jurisdictionName: "Mississippi"
+postalAbbreviation: "ms"
+jurisdictionFee: 100
+jurisdictionOperationsTeamEmails:
+    - "cloud-team-nonprod-alerts@inspiringapps.com"
+jurisdictionAdverseActionsNotificationEmails: []
+jurisdictionSummaryReportNotificationEmails: []
+jurisprudenceRequirements:
+    required: true
+licenseeRegistrationEnabledForEnvironments: ["test"]
+activeEnvironments: ["test"]

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_TEST_ENV_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_TEST_ENV_INPUT.json
@@ -389,6 +389,44 @@
     ],
     "octp": [
       {
+        "jurisdictionName": "Alabama",
+        "postalAbbreviation": "al",
+        "jurisdictionFee": 100,
+        "jurisdictionOperationsTeamEmails": [
+          "cloud-team-nonprod-alerts@inspiringapps.com"
+        ],
+        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionSummaryReportNotificationEmails": [],
+        "jurisprudenceRequirements": {
+          "required": true
+        },
+        "licenseeRegistrationEnabledForEnvironments": [
+          "test"
+        ],
+        "activeEnvironments": [
+          "test"
+        ]
+      },
+      {
+        "jurisdictionName": "Arkansas",
+        "postalAbbreviation": "ar",
+        "jurisdictionFee": 100,
+        "jurisdictionOperationsTeamEmails": [
+          "cloud-team-nonprod-alerts@inspiringapps.com"
+        ],
+        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionSummaryReportNotificationEmails": [],
+        "jurisprudenceRequirements": {
+          "required": true
+        },
+        "licenseeRegistrationEnabledForEnvironments": [
+          "test"
+        ],
+        "activeEnvironments": [
+          "test"
+        ]
+      },
+      {
         "jurisdictionName": "Kentucky",
         "postalAbbreviation": "ky",
         "jurisdictionFee": 100,
@@ -397,6 +435,44 @@
           "discountType": "FLAT_RATE",
           "discountAmount": 10
         },
+        "jurisdictionOperationsTeamEmails": [
+          "cloud-team-nonprod-alerts@inspiringapps.com"
+        ],
+        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionSummaryReportNotificationEmails": [],
+        "jurisprudenceRequirements": {
+          "required": true
+        },
+        "licenseeRegistrationEnabledForEnvironments": [
+          "test"
+        ],
+        "activeEnvironments": [
+          "test"
+        ]
+      },
+      {
+        "jurisdictionName": "Louisiana",
+        "postalAbbreviation": "la",
+        "jurisdictionFee": 100,
+        "jurisdictionOperationsTeamEmails": [
+          "cloud-team-nonprod-alerts@inspiringapps.com"
+        ],
+        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionSummaryReportNotificationEmails": [],
+        "jurisprudenceRequirements": {
+          "required": true
+        },
+        "licenseeRegistrationEnabledForEnvironments": [
+          "test"
+        ],
+        "activeEnvironments": [
+          "test"
+        ]
+      },
+      {
+        "jurisdictionName": "Mississippi",
+        "postalAbbreviation": "ms",
+        "jurisdictionFee": 100,
         "jurisdictionOperationsTeamEmails": [
           "cloud-team-nonprod-alerts@inspiringapps.com"
         ],


### PR DESCRIPTION
These states have expressed a design to test out the system. This adds their needed configuration files to the OCTP compact

### Testing List
- Verified state configs are deployed to DB under OCTP compact configuration

Closes #698 
