### PR TITLE
Frontend/nav text update

### DIFF
--- a/webroot/src/components/Page/PageMainNav/PageMainNav.ts
+++ b/webroot/src/components/Page/PageMainNav/PageMainNav.ts
@@ -154,7 +154,7 @@ class PageMainNav extends Vue {
             },
             {
                 to: 'LicneseeSearchPublic',
-                label: computed(() => this.$t('navigation.licensing')),
+                label: computed(() => this.$t('navigation.licensingPublic')),
                 iconComponent: markRaw(LicenseSearchIcon),
                 isEnabled: !this.isLoggedIn,
                 isExternal: false,

--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -360,6 +360,7 @@
         "home": "Home",
         "upload": "Upload data",
         "licensing": "Search licensing data",
+        "licensingPublic": "Search health providers",
         "dashboard": "Dashboard",
         "users": "Manage users",
         "compactSettings": "Compact Settings",

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -359,6 +359,7 @@
         "home": "Hogar",
         "upload": "Subir",
         "licensing": "Licencia",
+        "licensingPublic": "Buscar proveedores de salud",
         "dashboard": "Panel",
         "users": "Usuarios",
         "compactSettings": "Configuraciones compactas",


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Updated text of the side-nav search item for public users

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Search item in side nav for public users should now say "Search health providers"

Closes #565 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the navigation bar label for the licensing-related link to better reflect public access. The label now reads "Search health providers" in English and "Buscar proveedores de salud" in Spanish, enhancing clarity for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->