### PR TITLE
Reference data event bus through SSM parameter (#731)

### DIFF
--- a/backend/compact-connect/common_constructs/ssm_parameter_utility.py
+++ b/backend/compact-connect/common_constructs/ssm_parameter_utility.py
@@ -1,0 +1,46 @@
+from aws_cdk.aws_events import EventBus
+from aws_cdk.aws_ssm import StringParameter
+from constructs import Construct
+
+DATA_EVENT_BUS_ARN_SSM_PARAMETER_NAME = '/deployment/event-bridge/event-bus/data-event-bus-arn'
+
+
+class SSMParameterUtility:
+    """
+    Utility class for SSM parameter operations.
+
+    This class provides static methods for common SSM parameter operations,
+    such as loading resources from SSM parameters to bypass cross-stack references.
+    """
+
+    @staticmethod
+    def set_data_event_bus_arn_ssm_parameter(scope: Construct, data_event_bus: EventBus) -> StringParameter:
+        return StringParameter(
+            scope,
+            'DataEventBusArnParameter',
+            parameter_name=DATA_EVENT_BUS_ARN_SSM_PARAMETER_NAME,
+            string_value=data_event_bus.event_bus_arn,
+        )
+
+    @staticmethod
+    def load_data_event_bus_from_ssm_parameter(scope: Construct) -> EventBus:
+        """
+        Load the data event bus from an SSM parameter.
+
+        This pattern breaks cross-stack references by storing and retrieving
+        the event bus ARN in SSM Parameter Store rather than using a direct reference,
+        which helps avoid issues with CloudFormation stack updates.
+
+        Args:
+            scope: The CDK construct scope
+
+        Returns:
+            The EventBus construct
+        """
+        data_event_bus_arn = StringParameter.from_string_parameter_name(
+            scope,
+            'DataEventBusArnParameter',
+            string_parameter_name=DATA_EVENT_BUS_ARN_SSM_PARAMETER_NAME,
+        )
+
+        return EventBus.from_event_bus_arn(scope, 'DataEventBus', event_bus_arn=data_event_bus_arn.string_value)

--- a/backend/compact-connect/stacks/ingest_stack.py
+++ b/backend/compact-connect/stacks/ingest_stack.py
@@ -5,11 +5,12 @@ import os
 from aws_cdk import Duration
 from aws_cdk.aws_cloudwatch import Alarm, ComparisonOperator, Metric, Stats, TreatMissingData
 from aws_cdk.aws_cloudwatch_actions import SnsAction
-from aws_cdk.aws_events import EventPattern, Rule
+from aws_cdk.aws_events import EventBus, EventPattern, Rule
 from aws_cdk.aws_events_targets import SqsQueue
 from cdk_nag import NagSuppressions
 from common_constructs.python_function import PythonFunction
 from common_constructs.queued_lambda_processor import QueuedLambdaProcessor
+from common_constructs.ssm_parameter_utility import SSMParameterUtility
 from common_constructs.stack import AppStack, Stack
 from constructs import Construct
 
@@ -27,9 +28,11 @@ class IngestStack(AppStack):
         **kwargs,
     ):
         super().__init__(scope, construct_id, environment_name=environment_name, **kwargs)
-        self._add_v1_ingest_chain(persistent_stack)
+        # We explicitly get the event bus arn from parameter store, to avoid issues with cross stack updates
+        data_event_bus = SSMParameterUtility.load_data_event_bus_from_ssm_parameter(self)
+        self._add_v1_ingest_chain(persistent_stack, data_event_bus)
 
-    def _add_v1_ingest_chain(self, persistent_stack: ps.PersistentStack):
+    def _add_v1_ingest_chain(self, persistent_stack: ps.PersistentStack, data_event_bus: EventBus):
         ingest_handler = PythonFunction(
             self,
             'V1IngestHandler',
@@ -39,14 +42,14 @@ class IngestStack(AppStack):
             handler='ingest_license_message',
             timeout=Duration.minutes(1),
             environment={
-                'EVENT_BUS_NAME': persistent_stack.data_event_bus.event_bus_name,
+                'EVENT_BUS_NAME': data_event_bus.event_bus_name,
                 'PROVIDER_TABLE_NAME': persistent_stack.provider_table.table_name,
                 **self.common_env_vars,
             },
             alarm_topic=persistent_stack.alarm_topic,
         )
         persistent_stack.provider_table.grant_read_write_data(ingest_handler)
-        persistent_stack.data_event_bus.grant_put_events_to(ingest_handler)
+        data_event_bus.grant_put_events_to(ingest_handler)
 
         NagSuppressions.add_resource_suppressions_by_path(
             Stack.of(ingest_handler.role),
@@ -90,7 +93,7 @@ class IngestStack(AppStack):
         ingest_rule = Rule(
             self,
             'V1IngestEventRule',
-            event_bus=persistent_stack.data_event_bus,
+            event_bus=data_event_bus,
             event_pattern=EventPattern(detail_type=['license.ingest']),
             targets=[SqsQueue(processor.queue, dead_letter_queue=processor.dlq)],
         )
@@ -103,7 +106,7 @@ class IngestStack(AppStack):
                 namespace='AWS/Events',
                 metric_name='FailedInvocations',
                 dimensions_map={
-                    'EventBusName': persistent_stack.data_event_bus.event_bus_name,
+                    'EventBusName': data_event_bus.event_bus_name,
                     'RuleName': ingest_rule.rule_name,
                 },
                 period=Duration.minutes(5),

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -15,6 +15,7 @@ from common_constructs.data_migration import DataMigration
 from common_constructs.nodejs_function import NodejsFunction
 from common_constructs.python_function import COMMON_PYTHON_LAMBDA_LAYER_SSM_PARAMETER_NAME
 from common_constructs.security_profile import SecurityProfile
+from common_constructs.ssm_parameter_utility import SSMParameterUtility
 from common_constructs.stack import AppStack
 from constructs import Construct
 
@@ -106,7 +107,18 @@ class PersistentStack(AppStack):
             auto_delete_objects=removal_policy == RemovalPolicy.DESTROY,
         )
 
-        self.data_event_bus = EventBus(self, 'DataEventBus')
+        # This resource should not be referenced directly as a cross stack reference, any reference should
+        # be made through the SSM parameter
+        self._data_event_bus = EventBus(self, 'DataEventBus')
+        # We Store the data event bus name in SSM Parameter Store
+        # to avoid issues with cross stack references due to the fact that
+        # you can't update a CloudFormation exported value that is being referenced by a resource in another stack.
+        self.data_event_bus_arn_ssm_parameter = SSMParameterUtility.set_data_event_bus_arn_ssm_parameter(
+            self, self._data_event_bus
+        )
+        # TODO - these are needed until pipeline migration effort is complete  # noqa: FIX002
+        self.export_value(self._data_event_bus.event_bus_arn)
+        self.export_value(self._data_event_bus.event_bus_name)
 
         self._add_data_resources(removal_policy=removal_policy)
         self._add_migrations()
@@ -241,7 +253,7 @@ class PersistentStack(AppStack):
             self,
             'SSNTable',
             removal_policy=removal_policy,
-            data_event_bus=self.data_event_bus,
+            data_event_bus=self._data_event_bus,
             alarm_topic=self.alarm_topic,
         )
 
@@ -255,7 +267,7 @@ class PersistentStack(AppStack):
             bucket_encryption_key=self.ssn_table.key,
             removal_policy=removal_policy,
             auto_delete_objects=removal_policy == RemovalPolicy.DESTROY,
-            event_bus=self.data_event_bus,
+            event_bus=self._data_event_bus,
             license_preprocessing_queue=self.ssn_table.preprocessor_queue.queue,
             license_upload_role=self.ssn_table.license_upload_role,
         )
@@ -302,7 +314,7 @@ class PersistentStack(AppStack):
             scope=self,
             construct_id='DataEventTable',
             encryption_key=self.shared_encryption_key,
-            event_bus=self.data_event_bus,
+            event_bus=self._data_event_bus,
             alarm_topic=self.alarm_topic,
             removal_policy=removal_policy,
         )

--- a/backend/compact-connect/stacks/persistent_stack/data_event_table.py
+++ b/backend/compact-connect/stacks/persistent_stack/data_event_table.py
@@ -116,7 +116,7 @@ class DataEventTable(Table):
                 namespace='AWS/Events',
                 metric_name='FailedInvocations',
                 dimensions_map={
-                    'EventBusName': stack.data_event_bus.event_bus_name,
+                    'EventBusName': event_bus.event_bus_name,
                     'RuleName': event_receiver_rule.rule_name,
                 },
                 period=Duration.minutes(5),

--- a/backend/compact-connect/tests/app/base.py
+++ b/backend/compact-connect/tests/app/base.py
@@ -212,7 +212,7 @@ class TstAppABC(ABC):
 
     def _inspect_data_events_table(self, persistent_stack: PersistentStack, persistent_stack_template: Template):
         # Ensure our DataEventTable and queues are created
-        event_bus_logical_id = persistent_stack.get_logical_id(persistent_stack.data_event_bus.node.default_child)
+        event_bus_logical_id = persistent_stack.get_logical_id(persistent_stack._data_event_bus.node.default_child)  # noqa: SLF001 private_member_access
         queue_logical_id = persistent_stack.get_logical_id(
             persistent_stack.data_event_table.event_processor.queue.node.default_child
         )


### PR DESCRIPTION
While testing the pipeline migration, we hit an issue where the event bus needs to be renamed, as it is using the pipeline stack as part of its name. This creates a cross stack reference issue since it is being referenced by several other stacks, and you cannot change a stack export value while it is still being referenced by other stacks. In order to address this, this PR replaces the direct reference with an SSM parameter, which can be changed without causing the stacks to fail deployment. This PR will need to be merged and deployed first, before the subsequent pipeline change can be run through.

This change is a precursor to the following tickets: https://github.com/csg-org/CompactConnect/issues/705 https://github.com/csg-org/CompactConnect/issues/580 https://github.com/csg-org/CompactConnect/issues/424

