### PR TITLE
lowercase fl postal code

### DIFF
--- a/backend/compact-connect/compact-config/coun/florida.yml
+++ b/backend/compact-connect/compact-config/coun/florida.yml
@@ -1,6 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Florida"
-postalAbbreviation: "FL"
+postalAbbreviation: "fl"
 jurisdictionFee: 15
 jurisdictionOperationsTeamEmails:
     - "cloud-team-nonprod-alerts@inspiringapps.com"

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_TEST_ENV_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_TEST_ENV_INPUT.json
@@ -497,7 +497,7 @@
     "coun": [
       {
         "jurisdictionName": "Florida",
-        "postalAbbreviation": "FL",
+        "postalAbbreviation": "fl",
         "jurisdictionFee": 15,
         "jurisdictionOperationsTeamEmails": [
           "cloud-team-nonprod-alerts@inspiringapps.com"


### PR DESCRIPTION
Postal codes for compact configuration files must be lowercase. This fixes the previous config change which had FL instead of fl


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the postal abbreviation for Florida to use lowercase letters in configuration and related test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->