### PR TITLE
Frontend/updating purchase flow nav

### DIFF
--- a/webroot/src/components/PrivilegePurchaseAttestation/PrivilegePurchaseAttestation.less
+++ b/webroot/src/components/PrivilegePurchaseAttestation/PrivilegePurchaseAttestation.less
@@ -79,42 +79,7 @@
         }
 
         .button-row {
-            display: flex;
-            flex-direction: column-reverse;
-            align-items: center;
-            justify-content: center;
-            width: 100%;
-            margin-top: 2rem;
-
-            @media @tabletWidth {
-                flex-direction: row;
-                align-items: flex-end;
-                justify-content: space-between;
-            }
-
-            :deep(.input-container) {
-                margin-bottom: 1rem;
-
-                @media @tabletWidth {
-                    margin-bottom: unset;
-                }
-            }
-
-            .right-cell {
-                display: flex;
-                flex-direction: row;
-                align-items: center;
-                justify-content: center;
-
-                @media @tabletWidth {
-                    align-items: flex-end;
-                    justify-content: space-between;
-                }
-
-                .back {
-                    margin-right: 1rem;
-                }
-            }
+            .purchase-flow-buttons();
         }
     }
 

--- a/webroot/src/components/PrivilegePurchaseAttestation/PrivilegePurchaseAttestation.vue
+++ b/webroot/src/components/PrivilegePurchaseAttestation/PrivilegePurchaseAttestation.vue
@@ -33,24 +33,28 @@
                 </div>
             </div>
             <div v-if="areFormInputsSet" class="button-row">
-                <InputButton
-                    :isTextLike="true"
-                    :label="$t('common.cancel')"
-                    :aria-label="$t('common.cancel')"
-                    class="cancel"
-                    @click="handleCancelClicked"
-                />
-                <div class="right-cell">
+                <div class="form-nav-buttons">
+                    <InputSubmit
+                        :formInput="formData.submit"
+                        class="form-nav-button"
+                        :label="submitLabel"
+                        :isEnabled="!isFormLoading"
+                    />
                     <InputButton
                         :label="$t('common.back')"
                         :aria-label="$t('common.back')"
-                        class="back"
+                        class="form-nav-button back"
+                        :isTransparent="true"
                         @click="handleBackClicked"
                     />
-                    <InputSubmit
-                        :formInput="formData.submit"
-                        :label="submitLabel"
-                        :isEnabled="!isFormLoading"
+                </div>
+                <div class="form-override-buttons">
+                    <InputButton
+                        :isTextLike="true"
+                        :label="$t('common.cancel')"
+                        :aria-label="$t('common.cancel')"
+                        class="form-override-button cancel"
+                        @click="handleCancelClicked"
                     />
                 </div>
             </div>

--- a/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.less
+++ b/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.less
@@ -21,42 +21,7 @@
         }
 
         .button-row {
-            display: flex;
-            flex-direction: column-reverse;
-            align-items: center;
-            justify-content: center;
-            width: 100%;
-            margin-top: 2rem;
-
-            @media @tabletWidth {
-                flex-direction: row;
-                align-items: flex-end;
-                justify-content: space-between;
-            }
-
-            :deep(.input-container) {
-                margin-bottom: 1rem;
-
-                @media @tabletWidth {
-                    margin-bottom: unset;
-                }
-            }
-
-            .right-cell {
-                display: flex;
-                flex-direction: row;
-                align-items: center;
-                justify-content: center;
-
-                @media @tabletWidth {
-                    align-items: flex-end;
-                    justify-content: space-between;
-                }
-
-                .back-button {
-                    margin-right: 1rem;
-                }
-            }
+            .purchase-flow-buttons();
         }
 
         .finalize-purchase-container {

--- a/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.vue
+++ b/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.vue
@@ -111,25 +111,28 @@
             </div>
             <div v-if="formErrorMessage" class="form-error-message">{{formErrorMessage}}</div>
             <div class="button-row">
-                <InputButton
-                    :label="cancelText"
-                    :isTextLike="true"
-                    aria-label="close modal"
-                    class="cancel-button"
-                    @click="handleCancelClicked"
-                />
-                <div class="right-cell">
+                <div class="form-nav-buttons">
+                    <InputSubmit
+                        :formInput="formData.submit"
+                        class="form-nav-button"
+                        :label="submitLabel"
+                        :isEnabled="!isFormLoading && isSubmitEnabled"
+                    />
                     <InputButton
                         :label="backText"
                         :isTransparent="true"
                         aria-label="close modal"
-                        class="back-button"
+                        class="form-nav-button back-button"
                         @click="handleBackClicked"
                     />
-                    <InputSubmit
-                        :formInput="formData.submit"
-                        :label="submitLabel"
-                        :isEnabled="!isFormLoading && isSubmitEnabled"
+                </div>
+                <div class="form-override-buttons">
+                    <InputButton
+                        :label="cancelText"
+                        :isTextLike="true"
+                        aria-label="close modal"
+                        class="form-override-button cancel-button"
+                        @click="handleCancelClicked"
                     />
                 </div>
             </div>

--- a/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.less
+++ b/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.less
@@ -25,55 +25,7 @@
         }
 
         .button-row {
-            position: fixed;
-            bottom: 0;
-            z-index: 3;
-            display: flex;
-            flex-direction: column-reverse;
-            align-items: center;
-            justify-content: center;
-            width: 100%;
-            margin-top: 2rem;
-            padding-top: 1rem;
-            background-color: @veryLightGrey;
-
-            @media @tabletWidth {
-                position: unset;
-                display: flex;
-                flex-direction: row;
-                align-items: flex-end;
-                justify-content: space-between;
-                width: 100%;
-                margin-top: 2rem;
-                background-color: unset;
-            }
-
-            :deep(.input-container) {
-                margin-bottom: 1rem;
-
-                @media @tabletWidth {
-                    margin-bottom: unset;
-                }
-
-                input {
-                    width: 41vw;
-
-                    @media @tabletWidth {
-                        width: unset;
-                    }
-                }
-            }
-
-            .right-cell {
-                display: flex;
-                flex-direction: row;
-                align-items: flex-end;
-                justify-content: space-between;
-
-                .back-button {
-                    margin-right: 1rem;
-                }
-            }
+            .purchase-flow-buttons();
         }
 
         .confirm-info-core-container {

--- a/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.vue
+++ b/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.vue
@@ -86,25 +86,28 @@
                 </div>
             </div>
             <div v-if="areFormInputsSet" class="button-row">
-                <InputButton
-                    :label="cancelText"
-                    :isTextLike="true"
-                    :aria-label="cancelText"
-                    class="icon icon-close-modal"
-                    @click="handleCancelClicked"
-                />
-                <div class="right-cell">
+                <div class="form-nav-buttons">
+                    <InputSubmit
+                        :formInput="formData.submit"
+                        class="form-nav-button"
+                        :label="$t('common.confirm')"
+                        :isEnabled="!isFormLoading"
+                    />
                     <InputButton
                         :label="backText"
                         :aria-label="backText"
-                        class="back-button"
+                        class="form-nav-button back-button"
                         :isTransparent="true"
                         @click="handleBackClicked"
                     />
-                    <InputSubmit
-                        :formInput="formData.submit"
-                        :label="$t('common.confirm')"
-                        :isEnabled="!isFormLoading"
+                </div>
+                <div class="form-override-buttons">
+                    <InputButton
+                        :label="cancelText"
+                        :isTextLike="true"
+                        :aria-label="cancelText"
+                        class="form-override-button icon icon-close-modal"
+                        @click="handleCancelClicked"
                     />
                 </div>
             </div>

--- a/webroot/src/components/PrivilegePurchaseLicense/PrivilegePurchaseLicense.less
+++ b/webroot/src/components/PrivilegePurchaseLicense/PrivilegePurchaseLicense.less
@@ -14,55 +14,7 @@
         width: 100%;
 
         .button-row {
-            position: fixed;
-            bottom: 0;
-            z-index: 3;
-            display: flex;
-            flex-direction: column-reverse;
-            align-items: center;
-            justify-content: center;
-            width: 100%;
-            margin-top: 2rem;
-            padding-top: 1rem;
-            background-color: @veryLightGrey;
-
-            @media @tabletWidth {
-                position: unset;
-                display: flex;
-                flex-direction: row;
-                align-items: flex-end;
-                justify-content: space-between;
-                width: 100%;
-                margin-top: 2rem;
-                background-color: unset;
-            }
-
-            :deep(.input-container) {
-                margin-bottom: 1rem;
-
-                @media @tabletWidth {
-                    margin-bottom: unset;
-                }
-
-                input {
-                    width: 41vw;
-
-                    @media @tabletWidth {
-                        width: unset;
-                    }
-                }
-            }
-
-            .right-cell {
-                display: flex;
-                flex-direction: row;
-                align-items: flex-end;
-                justify-content: space-between;
-
-                .back-button {
-                    margin-right: 1rem;
-                }
-            }
+            .purchase-flow-buttons();
         }
 
         .select-license-core-container {

--- a/webroot/src/components/PrivilegePurchaseLicense/PrivilegePurchaseLicense.vue
+++ b/webroot/src/components/PrivilegePurchaseLicense/PrivilegePurchaseLicense.vue
@@ -23,25 +23,28 @@
                 </div>
             </div>
             <div class="button-row">
-                <InputButton
-                    :label="cancelText"
-                    :isTextLike="true"
-                    :aria-label="cancelText"
-                    class="icon icon-close-modal"
-                    @click="handleCancelClicked"
-                />
-                <div class="right-cell">
+                <div class="form-nav-buttons">
+                    <InputSubmit
+                        :formInput="formData.submit"
+                        class="form-nav-button"
+                        :label="submitLabel"
+                        :isEnabled="!isFormLoading"
+                    />
                     <InputButton
                         :label="backText"
                         :aria-label="backText"
-                        class="back-button"
+                        class="form-nav-button back-button"
                         :isTransparent="true"
                         @click="handleBackClicked"
                     />
-                    <InputSubmit
-                        :formInput="formData.submit"
-                        :label="submitLabel"
-                        :isEnabled="!isFormLoading"
+                </div>
+                <div class="form-override-buttons">
+                    <InputButton
+                        :label="cancelText"
+                        :isTextLike="true"
+                        :aria-label="cancelText"
+                        class="form-override-button icon icon-close-modal"
+                        @click="handleCancelClicked"
                     />
                 </div>
             </div>

--- a/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.less
+++ b/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.less
@@ -14,55 +14,7 @@
         width: 100%;
 
         .button-row {
-            position: fixed;
-            bottom: 0;
-            z-index: 3;
-            display: flex;
-            flex-direction: column-reverse;
-            align-items: center;
-            justify-content: center;
-            width: 100%;
-            margin-top: 2rem;
-            padding-top: 1rem;
-            background-color: @veryLightGrey;
-
-            @media @tabletWidth {
-                position: unset;
-                display: flex;
-                flex-direction: row;
-                align-items: flex-end;
-                justify-content: space-between;
-                width: 100%;
-                margin-top: 2rem;
-                background-color: unset;
-            }
-
-            :deep(.input-container) {
-                margin-bottom: 1rem;
-
-                @media @tabletWidth {
-                    margin-bottom: unset;
-                }
-
-                input {
-                    width: 41vw;
-
-                    @media @tabletWidth {
-                        width: unset;
-                    }
-                }
-            }
-
-            .right-cell {
-                display: flex;
-                flex-direction: row;
-                align-items: flex-end;
-                justify-content: space-between;
-
-                .back-button {
-                    margin-right: 1rem;
-                }
-            }
+            .purchase-flow-buttons();
         }
 
         .select-privileges-core-container {

--- a/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
+++ b/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
@@ -85,25 +85,28 @@
                     </div>
                 </div>
                 <div class="button-row">
-                    <InputButton
-                        :label="cancelText"
-                        :isTextLike="true"
-                        :aria-label="cancelText"
-                        class="icon icon-close-modal"
-                        @click="handleCancelClicked"
-                    />
-                    <div class="right-cell">
+                    <div class="form-nav-buttons">
+                        <InputSubmit
+                            :formInput="formData.submit"
+                            class="form-nav-button"
+                            :label="submitLabel"
+                            :isEnabled="!isFormLoading && isAtLeastOnePrivilegeChosen && areAllAttesationsConfirmed"
+                        />
                         <InputButton
                             :label="backText"
                             :aria-label="backText"
-                            class="back-button"
+                            class="form-nav-button back-button"
                             :isTransparent="true"
                             @click="handleBackClicked"
                         />
-                        <InputSubmit
-                            :formInput="formData.submit"
-                            :label="submitLabel"
-                            :isEnabled="!isFormLoading && isAtLeastOnePrivilegeChosen && areAllAttesationsConfirmed"
+                    </div>
+                    <div class="form-override-buttons">
+                        <InputButton
+                            :label="cancelText"
+                            :isTextLike="true"
+                            :aria-label="cancelText"
+                            class="form-override-button icon icon-close-modal"
+                            @click="handleCancelClicked"
                         />
                     </div>
                 </div>

--- a/webroot/src/components/PrivilegePurchaseSuccessful/PrivilegePurchaseSuccessful.less
+++ b/webroot/src/components/PrivilegePurchaseSuccessful/PrivilegePurchaseSuccessful.less
@@ -5,21 +5,6 @@
 //  Created by InspiringApps on 11/5/2024.
 //
 .purchase-success-container {
-    .button-row {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-end;
-        padding: 2rem 0;
-
-        @media @desktopWidth {
-            width: 72rem;
-        }
-
-        @media @desktopWidth {
-            width: 90rem;
-        }
-    }
-
     .purchase-success-core {
         padding: 2rem 2rem 2rem 2rem;
         border-radius: 20px;
@@ -41,5 +26,9 @@
         .purchase-success-content {
             padding: 2rem 0;
         }
+    }
+
+    .button-row {
+        .purchase-flow-buttons();
     }
 }

--- a/webroot/src/components/PrivilegePurchaseSuccessful/PrivilegePurchaseSuccessful.vue
+++ b/webroot/src/components/PrivilegePurchaseSuccessful/PrivilegePurchaseSuccessful.vue
@@ -16,12 +16,14 @@
             </div>
         </div>
         <div class="button-row">
-            <InputButton
-                :label="finishText"
-                aria-label="finish"
-                class="finish-button"
-                @click="handleFinishClicked"
-            />
+            <div class="form-nav-buttons">
+                <InputButton
+                    :label="finishText"
+                    aria-label="finish"
+                    class="form-nav-button finish-button"
+                    @click="handleFinishClicked"
+                />
+            </div>
         </div>
     </div>
 </template>

--- a/webroot/src/styles.common/_mixins.less
+++ b/webroot/src/styles.common/_mixins.less
@@ -12,3 +12,4 @@
 @import './mixins/element-focus';
 @import './mixins/lazy-load';
 @import './mixins/visually-hidden';
+@import './mixins/purchase-flow-buttons';

--- a/webroot/src/styles.common/mixins/purchase-flow-buttons.less
+++ b/webroot/src/styles.common/mixins/purchase-flow-buttons.less
@@ -1,0 +1,73 @@
+//
+//  purchase-flow-buttons.less
+//  CompactConnect
+//
+//  Created by InspiringApps on 04/16/25.
+//
+
+.purchase-flow-buttons() {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    margin-top: 2rem;
+    padding: 1rem 2rem;
+    background-color: @veryLightGrey;
+
+    @media @tabletWidth {
+        position: unset;
+        display: flex;
+        flex-direction: row-reverse;
+        align-items: flex-end;
+        justify-content: space-between;
+        width: 100%;
+        margin-top: 2rem;
+        padding: 1rem 0;
+        background-color: unset;
+    }
+
+    .form-nav-buttons {
+        display: flex;
+        flex-direction: row-reverse;
+        width: 100%;
+
+        @media @tabletWidth {
+            width: auto;
+        }
+
+        .form-nav-button {
+            flex-grow: 1;
+            margin-bottom: 0.8rem;
+
+            @media @tabletWidth {
+                width: auto;
+            }
+
+            // If "back" button is ever made first in tab order, change this to `:not(:first-child)`
+            &:not(:last-child) {
+                margin-left: 1rem;
+            }
+
+            :deep(.input-button),
+            :deep(.input-submit) {
+                width: 100%;
+            }
+        }
+    }
+
+    .form-override-buttons {
+        .form-override-button {
+            margin-bottom: 0.8rem;
+
+            :deep(.input-button) {
+                font-weight: @fontWeight;
+                text-decoration: underline;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Create a common style mixin for the purchase-flow button UI
- Update the purchase-flow HTML templates to support the desired tab order of buttons
- Various HTML / style cleanup in the purchase-flow button UI
- Minor style updates to match the latest designs

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - As a practitioner who is able to purchase privileges, begin the purchase process
    - Go through the purchase forms on both mobile and desktop, making sure the buttons at the bottom of each form still look & work as expected from the designs (e.g. Cancel, Back, Next)
    - Confirm keyboard tab navigation on each purchase form has the order of the tab selection of the buttons at the bottom of each form order as follows: 1) Next / Continue, 2) Back, 3) Cancel

Closes #549 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Unified and improved button row styling across all purchase-related forms for a more consistent and responsive layout.
  - Primary navigation buttons (submit, back) are now grouped together and visually separated from the cancel button in all purchase flows.
  - Enhanced button alignment and spacing for better usability on both desktop and mobile devices.
- **New Features**
  - Introduced a reusable style for purchase flow buttons, ensuring consistent appearance and behavior throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->