### PR TITLE
Feat/Setting Privilege Fee Per License Type

### DIFF
--- a/backend/compact-connect/common_constructs/stack.py
+++ b/backend/compact-connect/common_constructs/stack.py
@@ -59,9 +59,14 @@ class Stack(CdkStack):
         )
 
     @cached_property
-    def license_types(self):
-        """Flattened list of all license types across all compacts"""
+    def license_type_names(self):
+        """Flattened list of all license type names across all compacts"""
         return [typ['name'] for compact in self.node.get_context('license_types').values() for typ in compact]
+
+    @cached_property
+    def license_types(self):
+        """Dictionary of license types by compact"""
+        return self.node.get_context('license_types')
 
     @cached_property
     def common_env_vars(self):

--- a/backend/compact-connect/compact-config/aslp/kentucky.yml
+++ b/backend/compact-connect/compact-config/aslp/kentucky.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "aud"
+    amount: 100
+  - licenseTypeAbbreviation: "slp"
+    amount: 100
 militaryDiscount:
     active: true
     discountType: "FLAT_RATE"

--- a/backend/compact-connect/compact-config/aslp/kentucky.yml
+++ b/backend/compact-connect/compact-config/aslp/kentucky.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "aud"

--- a/backend/compact-connect/compact-config/aslp/nebraska.yml
+++ b/backend/compact-connect/compact-config/aslp/nebraska.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "aud"

--- a/backend/compact-connect/compact-config/aslp/nebraska.yml
+++ b/backend/compact-connect/compact-config/aslp/nebraska.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "aud"
+    amount: 100
+  - licenseTypeAbbreviation: "slp"
+    amount: 100
 militaryDiscount:
     active: true
     discountType: "FLAT_RATE"

--- a/backend/compact-connect/compact-config/aslp/ohio.yml
+++ b/backend/compact-connect/compact-config/aslp/ohio.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 25
 privilegeFees:
   - licenseTypeAbbreviation: "aud"

--- a/backend/compact-connect/compact-config/aslp/ohio.yml
+++ b/backend/compact-connect/compact-config/aslp/ohio.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
 jurisdictionFee: 25
+privilegeFees:
+  - licenseTypeAbbreviation: "aud"
+    amount: 25
+  - licenseTypeAbbreviation: "slp"
+    amount: 25
 jurisdictionOperationsTeamEmails:
     - "gregg.thornton@shp.ohio.gov"
 jurisdictionAdverseActionsNotificationEmails: ["gregg.thornton@shp.ohio.gov"]

--- a/backend/compact-connect/compact-config/coun/florida.yml
+++ b/backend/compact-connect/compact-config/coun/florida.yml
@@ -2,6 +2,9 @@
 jurisdictionName: "Florida"
 postalAbbreviation: "fl"
 jurisdictionFee: 15
+privilegeFees:
+  - licenseTypeAbbreviation: "lpc"
+    amount: 15
 jurisdictionOperationsTeamEmails:
     - "cloud-team-nonprod-alerts@inspiringapps.com"
 jurisdictionAdverseActionsNotificationEmails: []

--- a/backend/compact-connect/compact-config/coun/florida.yml
+++ b/backend/compact-connect/compact-config/coun/florida.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Florida"
 postalAbbreviation: "fl"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 15
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"

--- a/backend/compact-connect/compact-config/coun/kentucky.yml
+++ b/backend/compact-connect/compact-config/coun/kentucky.yml
@@ -2,6 +2,9 @@
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "lpc"
+    amount: 100
 militaryDiscount:
     active: true
     discountType: "FLAT_RATE"

--- a/backend/compact-connect/compact-config/coun/kentucky.yml
+++ b/backend/compact-connect/compact-config/coun/kentucky.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"

--- a/backend/compact-connect/compact-config/coun/nebraska.yml
+++ b/backend/compact-connect/compact-config/coun/nebraska.yml
@@ -2,6 +2,9 @@
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "lpc"
+    amount: 100
 militaryDiscount:
     active: true
     discountType: "FLAT_RATE"

--- a/backend/compact-connect/compact-config/coun/nebraska.yml
+++ b/backend/compact-connect/compact-config/coun/nebraska.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"

--- a/backend/compact-connect/compact-config/coun/ohio.yml
+++ b/backend/compact-connect/compact-config/coun/ohio.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"

--- a/backend/compact-connect/compact-config/coun/ohio.yml
+++ b/backend/compact-connect/compact-config/coun/ohio.yml
@@ -2,6 +2,9 @@
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "lpc"
+    amount: 100
 militaryDiscount:
     active: true
     discountType: "FLAT_RATE"

--- a/backend/compact-connect/compact-config/octp/alabama.yml
+++ b/backend/compact-connect/compact-config/octp/alabama.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Alabama"
 postalAbbreviation: "al"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"

--- a/backend/compact-connect/compact-config/octp/alabama.yml
+++ b/backend/compact-connect/compact-config/octp/alabama.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Alabama"
 postalAbbreviation: "al"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "ot"
+    amount: 100
+  - licenseTypeAbbreviation: "ota"
+    amount: 100
 jurisdictionOperationsTeamEmails:
     - "cloud-team-nonprod-alerts@inspiringapps.com"
 jurisdictionAdverseActionsNotificationEmails: []

--- a/backend/compact-connect/compact-config/octp/arkansas.yml
+++ b/backend/compact-connect/compact-config/octp/arkansas.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Arkansas"
 postalAbbreviation: "ar"
 jurisdictionFee: 3
+privilegeFees:
+  - licenseTypeAbbreviation: "ot"
+    amount: 3
+  - licenseTypeAbbreviation: "ota"
+    amount: 3
 jurisdictionOperationsTeamEmails:
     - "ASMBOTOperations@armedicalboard.org"
 jurisdictionAdverseActionsNotificationEmails: ["ASMBOTAdverseActions@armedicalboard.org"]

--- a/backend/compact-connect/compact-config/octp/arkansas.yml
+++ b/backend/compact-connect/compact-config/octp/arkansas.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Arkansas"
 postalAbbreviation: "ar"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 3
 privilegeFees:
   - licenseTypeAbbreviation: "ot"

--- a/backend/compact-connect/compact-config/octp/kentucky.yml
+++ b/backend/compact-connect/compact-config/octp/kentucky.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"

--- a/backend/compact-connect/compact-config/octp/kentucky.yml
+++ b/backend/compact-connect/compact-config/octp/kentucky.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "ot"
+    amount: 100
+  - licenseTypeAbbreviation: "ota"
+    amount: 100
 militaryDiscount:
     active: true
     discountType: "FLAT_RATE"

--- a/backend/compact-connect/compact-config/octp/louisiana.yml
+++ b/backend/compact-connect/compact-config/octp/louisiana.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Louisiana"
 postalAbbreviation: "la"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"

--- a/backend/compact-connect/compact-config/octp/louisiana.yml
+++ b/backend/compact-connect/compact-config/octp/louisiana.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Louisiana"
 postalAbbreviation: "la"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "ot"
+    amount: 100
+  - licenseTypeAbbreviation: "ota"
+    amount: 100
 jurisdictionOperationsTeamEmails:
     - "cloud-team-nonprod-alerts@inspiringapps.com"
 jurisdictionAdverseActionsNotificationEmails: []

--- a/backend/compact-connect/compact-config/octp/mississippi.yml
+++ b/backend/compact-connect/compact-config/octp/mississippi.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Mississippi"
 postalAbbreviation: "ms"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"

--- a/backend/compact-connect/compact-config/octp/mississippi.yml
+++ b/backend/compact-connect/compact-config/octp/mississippi.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Mississippi"
 postalAbbreviation: "ms"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "ot"
+    amount: 100
+  - licenseTypeAbbreviation: "ota"
+    amount: 100
 jurisdictionOperationsTeamEmails:
     - "cloud-team-nonprod-alerts@inspiringapps.com"
 jurisdictionAdverseActionsNotificationEmails: []

--- a/backend/compact-connect/compact-config/octp/nebraska.yml
+++ b/backend/compact-connect/compact-config/octp/nebraska.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "ot"
+    amount: 100
+  - licenseTypeAbbreviation: "ota"
+    amount: 100
 militaryDiscount:
     active: true
     discountType: "FLAT_RATE"

--- a/backend/compact-connect/compact-config/octp/nebraska.yml
+++ b/backend/compact-connect/compact-config/octp/nebraska.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"

--- a/backend/compact-connect/compact-config/octp/ohio.yml
+++ b/backend/compact-connect/compact-config/octp/ohio.yml
@@ -2,6 +2,11 @@
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
 jurisdictionFee: 100
+privilegeFees:
+  - licenseTypeAbbreviation: "ot"
+    amount: 100
+  - licenseTypeAbbreviation: "ota"
+    amount: 100
 militaryDiscount:
     active: true
     discountType: "FLAT_RATE"

--- a/backend/compact-connect/compact-config/octp/ohio.yml
+++ b/backend/compact-connect/compact-config/octp/ohio.yml
@@ -1,6 +1,7 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
 jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"

--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "LicenseApi",
-    "version": "2025-04-09T19:05:00Z"
+    "version": "2025-04-21T18:51:13Z"
   },
   "servers": [
     {
@@ -44,7 +44,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenwFGulMUQaDdj"
+                  "$ref": "#/components/schemas/SandboLicen4jYlbJEqVm3D"
                 }
               }
             }
@@ -81,7 +81,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenB23GYrSs53bY"
+                "$ref": "#/components/schemas/SandboLicenm6UNWux1K7jI"
               }
             }
           },
@@ -93,7 +93,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenZ8v81WzIHwtt"
+                  "$ref": "#/components/schemas/SandboLicenQSPhWWXWfNXY"
                 }
               }
             }
@@ -115,6 +115,7 @@
               "al/octp.admin",
               "ky/octp.admin",
               "coun/admin",
+              "fl/coun.admin",
               "ne/coun.admin",
               "oh/coun.admin",
               "ky/coun.admin"
@@ -149,7 +150,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenSFaEGGWOs5rH"
+                  "$ref": "#/components/schemas/SandboLicen8Bgi0jUvOUWT"
                 }
               }
             }
@@ -198,7 +199,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicengjlgpZjVzkm0"
+                "$ref": "#/components/schemas/SandboLicenp4yschyzjUCa"
               }
             }
           },
@@ -210,7 +211,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenI0o69vT5mLnQ"
+                  "$ref": "#/components/schemas/SandboLicenXPOL25KuB6gU"
                 }
               }
             }
@@ -232,6 +233,7 @@
               "al/octp.write",
               "ky/octp.write",
               "coun/write",
+              "fl/coun.write",
               "ne/coun.write",
               "oh/coun.write",
               "ky/coun.write"
@@ -274,7 +276,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicen61FG2ANFq1QV"
+                  "$ref": "#/components/schemas/SandboLicen0nXo7c1qXD2j"
                 }
               }
             }
@@ -296,6 +298,7 @@
               "al/octp.write",
               "ky/octp.write",
               "coun/write",
+              "fl/coun.write",
               "ne/coun.write",
               "oh/coun.write",
               "ky/coun.write"
@@ -328,7 +331,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenPInSC2X2AxXt"
+                "$ref": "#/components/schemas/SandboLicenoci9tyPqoGRb"
               }
             }
           },
@@ -340,7 +343,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLiceng85RwCdi1noV"
+                  "$ref": "#/components/schemas/SandboLicenCAt3nUfAzyDS"
                 }
               }
             }
@@ -391,7 +394,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenoFlA6mMLRot9"
+                  "$ref": "#/components/schemas/SandboLicenExAfURF0KyCV"
                 }
               }
             }
@@ -456,7 +459,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenKFMSs4LH04ge"
+                "$ref": "#/components/schemas/SandboLiceno4bc0FEXEiqd"
               }
             }
           },
@@ -468,7 +471,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -490,6 +493,7 @@
               "al/octp.admin",
               "ky/octp.admin",
               "coun/admin",
+              "fl/coun.admin",
               "ne/coun.admin",
               "oh/coun.admin",
               "ky/coun.admin"
@@ -532,7 +536,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicen6wJmla1yTAGQ"
+                  "$ref": "#/components/schemas/SandboLicenYP3jtaBIRotR"
                 }
               }
             }
@@ -554,6 +558,7 @@
               "al/octp.readSSN",
               "ky/octp.readSSN",
               "coun/readSSN",
+              "fl/coun.readSSN",
               "ne/coun.readSSN",
               "oh/coun.readSSN",
               "ky/coun.readSSN"
@@ -587,7 +592,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenA9brFoJmUQbH"
+                  "$ref": "#/components/schemas/SandboLicenhXaGWPqhKBJo"
                 }
               }
             }
@@ -609,6 +614,7 @@
               "al/octp.admin",
               "ky/octp.admin",
               "coun/admin",
+              "fl/coun.admin",
               "ne/coun.admin",
               "oh/coun.admin",
               "ky/coun.admin"
@@ -631,7 +637,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenabBbcK2mVUnw"
+                "$ref": "#/components/schemas/SandboLicenWESuCctDlYLE"
               }
             }
           },
@@ -650,7 +656,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenQFRhMGr2bagu"
+                  "$ref": "#/components/schemas/SandboLicenRzb6RcNujpi3"
                 }
               }
             }
@@ -672,6 +678,7 @@
               "al/octp.admin",
               "ky/octp.admin",
               "coun/admin",
+              "fl/coun.admin",
               "ne/coun.admin",
               "oh/coun.admin",
               "ky/coun.admin"
@@ -706,7 +713,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -723,7 +730,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenQFRhMGr2bagu"
+                  "$ref": "#/components/schemas/SandboLicenRzb6RcNujpi3"
                 }
               }
             }
@@ -745,6 +752,7 @@
               "al/octp.admin",
               "ky/octp.admin",
               "coun/admin",
+              "fl/coun.admin",
               "ne/coun.admin",
               "oh/coun.admin",
               "ky/coun.admin"
@@ -777,7 +785,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -787,7 +795,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -809,6 +817,7 @@
               "al/octp.admin",
               "ky/octp.admin",
               "coun/admin",
+              "fl/coun.admin",
               "ne/coun.admin",
               "oh/coun.admin",
               "ky/coun.admin"
@@ -839,7 +848,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenuSgVopjVWnQa"
+                "$ref": "#/components/schemas/SandboLicen5CJrQuzQSW0z"
               }
             }
           },
@@ -851,7 +860,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -868,7 +877,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenQFRhMGr2bagu"
+                  "$ref": "#/components/schemas/SandboLicenRzb6RcNujpi3"
                 }
               }
             }
@@ -890,6 +899,7 @@
               "al/octp.admin",
               "ky/octp.admin",
               "coun/admin",
+              "fl/coun.admin",
               "ne/coun.admin",
               "oh/coun.admin",
               "ky/coun.admin"
@@ -924,7 +934,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -934,7 +944,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -956,6 +966,7 @@
               "al/octp.admin",
               "ky/octp.admin",
               "coun/admin",
+              "fl/coun.admin",
               "ne/coun.admin",
               "oh/coun.admin",
               "ky/coun.admin"
@@ -982,7 +993,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenoFlA6mMLRot9"
+                  "$ref": "#/components/schemas/SandboLicenExAfURF0KyCV"
                 }
               }
             }
@@ -1011,7 +1022,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicencEG2kojhh6C4"
+                "$ref": "#/components/schemas/SandboLicen5sjWzLjzC0Me"
               }
             }
           },
@@ -1023,7 +1034,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenU2Y3EB3VHeXm"
+                  "$ref": "#/components/schemas/SandboLicenFnewF1AZM2GM"
                 }
               }
             }
@@ -1050,7 +1061,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenpdWD3FUE6e5Q"
+                "$ref": "#/components/schemas/SandboLicen5Z3puRc3DTqO"
               }
             }
           },
@@ -1062,7 +1073,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -1081,7 +1092,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenPGRYIh9ayyi1"
+                "$ref": "#/components/schemas/SandboLicen6ovbaZqPmZBv"
               }
             }
           },
@@ -1093,7 +1104,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -1119,7 +1130,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenSFaEGGWOs5rH"
+                  "$ref": "#/components/schemas/SandboLicen8Bgi0jUvOUWT"
                 }
               }
             }
@@ -1143,7 +1154,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenPInSC2X2AxXt"
+                "$ref": "#/components/schemas/SandboLicenoci9tyPqoGRb"
               }
             }
           },
@@ -1155,7 +1166,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicentklD8M9BL5Nl"
+                  "$ref": "#/components/schemas/SandboLicentsQ8lKig1Cko"
                 }
               }
             }
@@ -1189,7 +1200,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenLThHI3i02jpN"
+                  "$ref": "#/components/schemas/SandboLicenPcpJhdyLvKNR"
                 }
               }
             }
@@ -1213,7 +1224,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenbp9Kh9OUxbWh"
+                "$ref": "#/components/schemas/SandboLicenjav5FWmSNS0o"
               }
             }
           },
@@ -1225,7 +1236,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicentvvhq6mfX3YL"
+                  "$ref": "#/components/schemas/SandboLicenFKIspyClyPtn"
                 }
               }
             }
@@ -1256,7 +1267,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenIQZ5lZQUELIS"
+                  "$ref": "#/components/schemas/SandboLicenFKxpmby47TyR"
                 }
               }
             }
@@ -1277,7 +1288,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -1294,7 +1305,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenQFRhMGr2bagu"
+                  "$ref": "#/components/schemas/SandboLicenRzb6RcNujpi3"
                 }
               }
             }
@@ -1313,7 +1324,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SandboLicenPAGHyHzOZttU"
+                "$ref": "#/components/schemas/SandboLicennJUDf4nosBCY"
               }
             }
           },
@@ -1325,7 +1336,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicennbCiTFugFRZw"
+                  "$ref": "#/components/schemas/SandboLicen2XGMfkiyQuog"
                 }
               }
             }
@@ -1342,7 +1353,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SandboLicenQFRhMGr2bagu"
+                  "$ref": "#/components/schemas/SandboLicenRzb6RcNujpi3"
                 }
               }
             }
@@ -1360,7 +1371,364 @@
   },
   "components": {
     "schemas": {
-      "SandboLicenoFlA6mMLRot9": {
+      "SandboLicen4jYlbJEqVm3D": {
+        "type": "object",
+        "properties": {
+          "dateCreated": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "compact": {
+            "type": "string",
+            "enum": [
+              "aslp",
+              "octp",
+              "coun"
+            ]
+          },
+          "attestationType": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "attestation"
+            ]
+          },
+          "locale": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SandboLicenoci9tyPqoGRb": {
+        "required": [
+          "query"
+        ],
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "lastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "string"
+              },
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "query": {
+            "type": "object",
+            "properties": {
+              "providerId": {
+                "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
+                "type": "string",
+                "description": "Internal UUID for the provider"
+              },
+              "jurisdiction": {
+                "type": "string",
+                "description": "Filter for providers with privilege/license in a jurisdiction",
+                "enum": [
+                  "al",
+                  "ak",
+                  "az",
+                  "ar",
+                  "ca",
+                  "co",
+                  "ct",
+                  "de",
+                  "dc",
+                  "fl",
+                  "ga",
+                  "hi",
+                  "id",
+                  "il",
+                  "in",
+                  "ia",
+                  "ks",
+                  "ky",
+                  "la",
+                  "me",
+                  "md",
+                  "ma",
+                  "mi",
+                  "mn",
+                  "ms",
+                  "mo",
+                  "mt",
+                  "ne",
+                  "nv",
+                  "nh",
+                  "nj",
+                  "nm",
+                  "ny",
+                  "nc",
+                  "nd",
+                  "oh",
+                  "ok",
+                  "or",
+                  "pa",
+                  "pr",
+                  "ri",
+                  "sc",
+                  "sd",
+                  "tn",
+                  "tx",
+                  "ut",
+                  "vt",
+                  "va",
+                  "vi",
+                  "wa",
+                  "wv",
+                  "wi",
+                  "wy"
+                ]
+              },
+              "givenName": {
+                "maxLength": 100,
+                "type": "string",
+                "description": "Filter for providers with a given name (familyName is required if givenName is provided)"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "type": "string",
+                "description": "Filter for providers with a family name"
+              }
+            },
+            "additionalProperties": false,
+            "description": "The query parameters"
+          },
+          "sorting": {
+            "required": [
+              "key"
+            ],
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key to sort results by",
+                "enum": [
+                  "dateOfUpdate",
+                  "familyName"
+                ]
+              },
+              "direction": {
+                "type": "string",
+                "description": "Direction to sort results by",
+                "enum": [
+                  "ascending",
+                  "descending"
+                ]
+              }
+            },
+            "description": "How to sort results"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicennJUDf4nosBCY": {
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicen5Z3puRc3DTqO": {
+        "required": [
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The status to set the military affiliation to.",
+            "enum": [
+              "inactive"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicen6ovbaZqPmZBv": {
+        "required": [
+          "compact",
+          "dob",
+          "email",
+          "familyName",
+          "givenName",
+          "jurisdiction",
+          "licenseType",
+          "partialSocial",
+          "token"
+        ],
+        "type": "object",
+        "properties": {
+          "licenseType": {
+            "maxLength": 500,
+            "type": "string",
+            "description": "Type of license",
+            "enum": [
+              "audiologist",
+              "speech-language pathologist",
+              "occupational therapist",
+              "occupational therapy assistant",
+              "licensed professional counselor"
+            ]
+          },
+          "compact": {
+            "maxLength": 100,
+            "type": "string",
+            "description": "Compact name"
+          },
+          "dob": {
+            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+            "type": "string",
+            "description": "Date of birth in YYYY-MM-DD format"
+          },
+          "givenName": {
+            "maxLength": 200,
+            "type": "string",
+            "description": "Provider's given name"
+          },
+          "familyName": {
+            "maxLength": 200,
+            "type": "string",
+            "description": "Provider's family name"
+          },
+          "jurisdiction": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "Two-letter jurisdiction code",
+            "enum": [
+              "al",
+              "ak",
+              "az",
+              "ar",
+              "ca",
+              "co",
+              "ct",
+              "de",
+              "dc",
+              "fl",
+              "ga",
+              "hi",
+              "id",
+              "il",
+              "in",
+              "ia",
+              "ks",
+              "ky",
+              "la",
+              "me",
+              "md",
+              "ma",
+              "mi",
+              "mn",
+              "ms",
+              "mo",
+              "mt",
+              "ne",
+              "nv",
+              "nh",
+              "nj",
+              "nm",
+              "ny",
+              "nc",
+              "nd",
+              "oh",
+              "ok",
+              "or",
+              "pa",
+              "pr",
+              "ri",
+              "sc",
+              "sd",
+              "tn",
+              "tx",
+              "ut",
+              "vt",
+              "va",
+              "vi",
+              "wa",
+              "wv",
+              "wi",
+              "wy"
+            ]
+          },
+          "partialSocial": {
+            "maxLength": 4,
+            "minLength": 4,
+            "type": "string",
+            "description": "Last 4 digits of SSN"
+          },
+          "email": {
+            "maxLength": 100,
+            "minLength": 5,
+            "type": "string",
+            "description": "Provider's email address",
+            "format": "email"
+          },
+          "token": {
+            "type": "string",
+            "description": "ReCAPTCHA token"
+          }
+        }
+      },
+      "SandboLicenYP3jtaBIRotR": {
+        "required": [
+          "ssn"
+        ],
+        "type": "object",
+        "properties": {
+          "ssn": {
+            "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+            "type": "string",
+            "description": "The provider's social security number"
+          }
+        }
+      },
+      "SandboLiceno4bc0FEXEiqd": {
+        "type": "object",
+        "properties": {
+          "deactivationNote": {
+            "maxLength": 256,
+            "type": "string",
+            "description": "Note describing why the privilege is being deactivated"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenExAfURF0KyCV": {
         "required": [
           "birthMonthDay",
           "compact",
@@ -3183,7 +3551,92 @@
           }
         }
       },
-      "SandboLicenLThHI3i02jpN": {
+      "SandboLicenWESuCctDlYLE": {
+        "required": [
+          "attributes",
+          "permissions"
+        ],
+        "type": "object",
+        "properties": {
+          "permissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "object",
+                  "properties": {
+                    "readPrivate": {
+                      "type": "boolean"
+                    },
+                    "admin": {
+                      "type": "boolean"
+                    },
+                    "readSSN": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jurisdictions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "readPrivate": {
+                            "type": "boolean"
+                          },
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "write": {
+                            "type": "boolean"
+                          },
+                          "readSSN": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "attributes": {
+            "required": [
+              "email",
+              "familyName",
+              "givenName"
+            ],
+            "type": "object",
+            "properties": {
+              "givenName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "familyName": {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              "email": {
+                "maxLength": 100,
+                "minLength": 5,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenPcpJhdyLvKNR": {
         "required": [
           "compact",
           "dateOfUpdate",
@@ -3504,7 +3957,7 @@
           }
         }
       },
-      "SandboLicenQFRhMGr2bagu": {
+      "SandboLicenRzb6RcNujpi3": {
         "required": [
           "attributes",
           "permissions",
@@ -3601,176 +4054,470 @@
         },
         "additionalProperties": false
       },
-      "SandboLicenwFGulMUQaDdj": {
+      "SandboLicen2XGMfkiyQuog": {
+        "required": [
+          "message"
+        ],
         "type": "object",
         "properties": {
-          "dateCreated": {
+          "message": {
             "type": "string",
-            "format": "date-time"
-          },
-          "compact": {
-            "type": "string",
-            "enum": [
-              "aslp",
-              "octp",
-              "coun"
-            ]
-          },
-          "attestationType": {
-            "type": "string"
-          },
-          "text": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "attestation"
-            ]
-          },
-          "locale": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "required": {
-            "type": "boolean"
+            "description": "A message about the request"
           }
         }
       },
-      "SandboLicenPInSC2X2AxXt": {
+      "SandboLicen5sjWzLjzC0Me": {
         "required": [
-          "query"
+          "affiliationType",
+          "fileNames"
+        ],
+        "type": "object",
+        "properties": {
+          "affiliationType": {
+            "type": "string",
+            "description": "The type of military affiliation",
+            "enum": [
+              "militaryMember",
+              "militaryMemberSpouse"
+            ]
+          },
+          "fileNames": {
+            "type": "array",
+            "description": "List of military affiliation file names",
+            "items": {
+              "maxLength": 150,
+              "type": "string",
+              "description": "The name of the file being uploaded"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenjav5FWmSNS0o": {
+        "required": [
+          "attestations",
+          "licenseType",
+          "orderInformation",
+          "selectedJurisdictions"
+        ],
+        "type": "object",
+        "properties": {
+          "licenseType": {
+            "type": "string",
+            "description": "The type of license the provider is purchasing a privilege for.",
+            "enum": [
+              "audiologist",
+              "speech-language pathologist",
+              "occupational therapist",
+              "occupational therapy assistant",
+              "licensed professional counselor"
+            ]
+          },
+          "attestations": {
+            "type": "array",
+            "description": "List of attestations that the user has agreed to",
+            "items": {
+              "required": [
+                "attestationId",
+                "version"
+              ],
+              "type": "object",
+              "properties": {
+                "attestationId": {
+                  "maxLength": 100,
+                  "type": "string",
+                  "description": "The ID of the attestation"
+                },
+                "version": {
+                  "maxLength": 10,
+                  "pattern": "^\\d+$",
+                  "type": "string",
+                  "description": "The version of the attestation"
+                }
+              }
+            }
+          },
+          "orderInformation": {
+            "required": [
+              "billing",
+              "card"
+            ],
+            "type": "object",
+            "properties": {
+              "card": {
+                "required": [
+                  "cvv",
+                  "expiration",
+                  "number"
+                ],
+                "type": "object",
+                "properties": {
+                  "number": {
+                    "maxLength": 19,
+                    "minLength": 13,
+                    "type": "string",
+                    "description": "The card number"
+                  },
+                  "cvv": {
+                    "maxLength": 4,
+                    "minLength": 3,
+                    "type": "string",
+                    "description": "The card cvv"
+                  },
+                  "expiration": {
+                    "maxLength": 7,
+                    "minLength": 7,
+                    "type": "string",
+                    "description": "The card expiration date"
+                  }
+                }
+              },
+              "billing": {
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "state",
+                  "streetAddress",
+                  "zip"
+                ],
+                "type": "object",
+                "properties": {
+                  "zip": {
+                    "maxLength": 10,
+                    "minLength": 5,
+                    "type": "string",
+                    "description": "The zip code for the card"
+                  },
+                  "firstName": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "The first name on the card"
+                  },
+                  "lastName": {
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "The last name on the card"
+                  },
+                  "streetAddress": {
+                    "maxLength": 150,
+                    "minLength": 2,
+                    "type": "string",
+                    "description": "The street address for the card"
+                  },
+                  "streetAddress2": {
+                    "maxLength": 150,
+                    "type": "string",
+                    "description": "The second street address for the card"
+                  },
+                  "state": {
+                    "maxLength": 2,
+                    "minLength": 2,
+                    "type": "string",
+                    "description": "The state postal abbreviation for the card"
+                  }
+                }
+              }
+            }
+          },
+          "selectedJurisdictions": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Jurisdictions a provider has selected to purchase privileges in.",
+              "enum": [
+                "al",
+                "ak",
+                "az",
+                "ar",
+                "ca",
+                "co",
+                "ct",
+                "de",
+                "dc",
+                "fl",
+                "ga",
+                "hi",
+                "id",
+                "il",
+                "in",
+                "ia",
+                "ks",
+                "ky",
+                "la",
+                "me",
+                "md",
+                "ma",
+                "mi",
+                "mn",
+                "ms",
+                "mo",
+                "mt",
+                "ne",
+                "nv",
+                "nh",
+                "nj",
+                "nm",
+                "ny",
+                "nc",
+                "nd",
+                "oh",
+                "ok",
+                "or",
+                "pa",
+                "pr",
+                "ri",
+                "sc",
+                "sd",
+                "tn",
+                "tx",
+                "ut",
+                "vt",
+                "va",
+                "vi",
+                "wa",
+                "wv",
+                "wi",
+                "wy"
+              ]
+            }
+          }
+        }
+      },
+      "SandboLicenQSPhWWXWfNXY": {
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the request"
+          }
+        }
+      },
+      "SandboLicenFKxpmby47TyR": {
+        "required": [
+          "items",
+          "pagination"
         ],
         "type": "object",
         "properties": {
           "pagination": {
             "type": "object",
             "properties": {
+              "prevLastKey": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "object"
+              },
               "lastKey": {
                 "maxLength": 1024,
                 "minLength": 1,
-                "type": "string"
+                "type": "object"
               },
               "pageSize": {
                 "maximum": 100,
                 "minimum": 5,
                 "type": "integer"
               }
-            },
-            "additionalProperties": false
+            }
           },
-          "query": {
-            "type": "object",
-            "properties": {
-              "providerId": {
-                "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]{1}[0-9a-f]{3}-[0-9a-f]{12}",
-                "type": "string",
-                "description": "Internal UUID for the provider"
-              },
-              "jurisdiction": {
-                "type": "string",
-                "description": "Filter for providers with privilege/license in a jurisdiction",
-                "enum": [
-                  "al",
-                  "ak",
-                  "az",
-                  "ar",
-                  "ca",
-                  "co",
-                  "ct",
-                  "de",
-                  "dc",
-                  "fl",
-                  "ga",
-                  "hi",
-                  "id",
-                  "il",
-                  "in",
-                  "ia",
-                  "ks",
-                  "ky",
-                  "la",
-                  "me",
-                  "md",
-                  "ma",
-                  "mi",
-                  "mn",
-                  "ms",
-                  "mo",
-                  "mt",
-                  "ne",
-                  "nv",
-                  "nh",
-                  "nj",
-                  "nm",
-                  "ny",
-                  "nc",
-                  "nd",
-                  "oh",
-                  "ok",
-                  "or",
-                  "pa",
-                  "pr",
-                  "ri",
-                  "sc",
-                  "sd",
-                  "tn",
-                  "tx",
-                  "ut",
-                  "vt",
-                  "va",
-                  "vi",
-                  "wa",
-                  "wv",
-                  "wi",
-                  "wy"
-                ]
-              },
-              "givenName": {
-                "maxLength": 100,
-                "type": "string",
-                "description": "Filter for providers with a given name (familyName is required if givenName is provided)"
-              },
-              "familyName": {
-                "maxLength": 100,
-                "type": "string",
-                "description": "Filter for providers with a family name"
-              }
-            },
-            "additionalProperties": false,
-            "description": "The query parameters"
-          },
-          "sorting": {
-            "required": [
-              "key"
-            ],
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "description": "The key to sort results by",
-                "enum": [
-                  "dateOfUpdate",
-                  "familyName"
-                ]
-              },
-              "direction": {
-                "type": "string",
-                "description": "Direction to sort results by",
-                "enum": [
-                  "ascending",
-                  "descending"
-                ]
-              }
-            },
-            "description": "How to sort results"
+          "items": {
+            "maxLength": 100,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "required": [
+                    "compactAbbr",
+                    "compactCommissionFee",
+                    "compactName",
+                    "transactionFeeConfiguration",
+                    "type"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "compactCommissionFee": {
+                      "required": [
+                        "feeAmount",
+                        "feeType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "feeAmount": {
+                          "type": "number"
+                        },
+                        "feeType": {
+                          "type": "string",
+                          "enum": [
+                            "FLAT_RATE"
+                          ]
+                        }
+                      }
+                    },
+                    "compactAbbr": {
+                      "type": "string",
+                      "description": "The abbreviation of the compact"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "compact"
+                      ]
+                    },
+                    "transactionFeeConfiguration": {
+                      "required": [
+                        "licenseeCharges"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "licenseeCharges": {
+                          "required": [
+                            "active",
+                            "chargeAmount",
+                            "chargeType"
+                          ],
+                          "type": "object",
+                          "properties": {
+                            "chargeType": {
+                              "type": "string",
+                              "description": "The type of transaction fee charge",
+                              "enum": [
+                                "FLAT_FEE_PER_PRIVILEGE"
+                              ]
+                            },
+                            "active": {
+                              "type": "boolean",
+                              "description": "Whether the compact is charging licensees transaction fees"
+                            },
+                            "chargeAmount": {
+                              "type": "number",
+                              "description": "The amount to charge per privilege purchased"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "compactName": {
+                      "type": "string",
+                      "description": "The full name of the compact"
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "jurisdictionFee",
+                    "jurisdictionName",
+                    "jurisprudenceRequirements",
+                    "postalAbbreviation",
+                    "privilegeFees",
+                    "type"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "privilegeFees": {
+                      "type": "array",
+                      "description": "The fees for the privileges",
+                      "items": {
+                        "required": [
+                          "amount",
+                          "licenseTypeAbbreviation"
+                        ],
+                        "type": "object",
+                        "properties": {
+                          "amount": {
+                            "type": "number"
+                          },
+                          "licenseTypeAbbreviation": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "militaryDiscount": {
+                      "required": [
+                        "active",
+                        "discountAmount",
+                        "discountType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the military discount is active"
+                        },
+                        "discountAmount": {
+                          "type": "number",
+                          "description": "The amount of the discount"
+                        },
+                        "discountType": {
+                          "type": "string",
+                          "description": "The type of discount",
+                          "enum": [
+                            "FLAT_RATE"
+                          ]
+                        }
+                      }
+                    },
+                    "postalAbbreviation": {
+                      "type": "string",
+                      "description": "The postal abbreviation of the jurisdiction"
+                    },
+                    "jurisprudenceRequirements": {
+                      "required": [
+                        "required"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "required": {
+                          "type": "boolean",
+                          "description": "Whether jurisprudence requirements exist"
+                        }
+                      }
+                    },
+                    "jurisdictionName": {
+                      "type": "string",
+                      "description": "The name of the jurisdiction"
+                    },
+                    "jurisdictionFee": {
+                      "type": "number",
+                      "description": "The fee for the jurisdiction"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "jurisdiction"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
           }
-        },
-        "additionalProperties": false
+        }
       },
-      "SandboLicenSFaEGGWOs5rH": {
+      "SandboLicen0nXo7c1qXD2j": {
+        "required": [
+          "fields"
+        ],
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "SandboLicen8Bgi0jUvOUWT": {
         "type": "array",
         "items": {
           "required": [
@@ -3794,7 +4541,49 @@
           }
         }
       },
-      "SandboLicentklD8M9BL5Nl": {
+      "SandboLicenXPOL25KuB6gU": {
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenm6UNWux1K7jI": {
+        "required": [
+          "apiLoginId",
+          "processor",
+          "transactionKey"
+        ],
+        "type": "object",
+        "properties": {
+          "apiLoginId": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string",
+            "description": "The api login id for the payment processor"
+          },
+          "transactionKey": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string",
+            "description": "The transaction key for the payment processor"
+          },
+          "processor": {
+            "type": "string",
+            "description": "The type of payment processor",
+            "enum": [
+              "authorize.net"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicentsQ8lKig1Cko": {
         "required": [
           "pagination",
           "providers"
@@ -4119,226 +4908,7 @@
           }
         }
       },
-      "SandboLicenI0o69vT5mLnQ": {
-        "required": [
-          "message"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicengjlgpZjVzkm0": {
-        "maxLength": 100,
-        "type": "array",
-        "items": {
-          "required": [
-            "compactEligibility",
-            "dateOfBirth",
-            "dateOfExpiration",
-            "dateOfIssuance",
-            "dateOfRenewal",
-            "familyName",
-            "givenName",
-            "homeAddressCity",
-            "homeAddressPostalCode",
-            "homeAddressState",
-            "homeAddressStreet1",
-            "licenseStatus",
-            "licenseType"
-          ],
-          "type": "object",
-          "properties": {
-            "homeAddressStreet2": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "npi": {
-              "pattern": "^[0-9]{10}$",
-              "type": "string"
-            },
-            "homeAddressPostalCode": {
-              "maxLength": 7,
-              "minLength": 5,
-              "type": "string"
-            },
-            "givenName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeAddressStreet1": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "compactEligibility": {
-              "type": "string",
-              "enum": [
-                "eligible",
-                "ineligible"
-              ]
-            },
-            "dateOfBirth": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "suffix": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "dateOfIssuance": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "licenseType": {
-              "type": "string",
-              "enum": [
-                "audiologist",
-                "speech-language pathologist",
-                "occupational therapist",
-                "occupational therapy assistant",
-                "licensed professional counselor"
-              ]
-            },
-            "emailAddress": {
-              "maxLength": 100,
-              "minLength": 5,
-              "type": "string",
-              "format": "email"
-            },
-            "dateOfExpiration": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "phoneNumber": {
-              "pattern": "^\\+[0-9]{8,15}$",
-              "type": "string"
-            },
-            "homeAddressState": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "dateOfRenewal": {
-              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-              "type": "string",
-              "format": "date"
-            },
-            "licenseStatus": {
-              "type": "string",
-              "enum": [
-                "active",
-                "inactive"
-              ]
-            },
-            "familyName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "homeAddressCity": {
-              "maxLength": 100,
-              "minLength": 2,
-              "type": "string"
-            },
-            "licenseNumber": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "middleName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            },
-            "licenseStatusName": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "SandboLicenU2Y3EB3VHeXm": {
-        "required": [
-          "affiliationType",
-          "dateOfUpdate",
-          "dateOfUpload",
-          "documentUploadFields",
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "dateOfUpload": {
-            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-            "type": "string",
-            "description": "The date the document was uploaded",
-            "format": "date"
-          },
-          "affiliationType": {
-            "type": "string",
-            "description": "The type of military affiliation",
-            "enum": [
-              "militaryMember",
-              "militaryMemberSpouse"
-            ]
-          },
-          "fileNames": {
-            "type": "array",
-            "description": "List of military affiliation file names",
-            "items": {
-              "type": "string",
-              "description": "The name of the file being uploaded"
-            }
-          },
-          "dateOfUpdate": {
-            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-            "type": "string",
-            "description": "The date the document was last updated",
-            "format": "date"
-          },
-          "status": {
-            "type": "string",
-            "description": "The status of the military affiliation"
-          },
-          "documentUploadFields": {
-            "type": "array",
-            "description": "The fields used to upload documents",
-            "items": {
-              "type": "object",
-              "properties": {
-                "fields": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "The form fields used to upload the document"
-                },
-                "url": {
-                  "type": "string",
-                  "description": "The url to upload the document to"
-                }
-              },
-              "description": "The fields used to upload a specific document"
-            }
-          }
-        }
-      },
-      "SandboLicenabBbcK2mVUnw": {
-        "required": [
-          "attributes",
-          "permissions"
-        ],
+      "SandboLicen5CJrQuzQSW0z": {
         "type": "object",
         "properties": {
           "permissions": {
@@ -4389,201 +4959,137 @@
               },
               "additionalProperties": false
             }
-          },
-          "attributes": {
-            "required": [
-              "email",
-              "familyName",
-              "givenName"
-            ],
+          }
+        },
+        "additionalProperties": false
+      },
+      "SandboLicenhXaGWPqhKBJo": {
+        "type": "object",
+        "properties": {
+          "pagination": {
             "type": "object",
             "properties": {
-              "givenName": {
-                "maxLength": 100,
+              "prevLastKey": {
+                "maxLength": 1024,
                 "minLength": 1,
-                "type": "string"
+                "type": "object"
               },
-              "familyName": {
-                "maxLength": 100,
+              "lastKey": {
+                "maxLength": 1024,
                 "minLength": 1,
-                "type": "string"
+                "type": "object"
               },
-              "email": {
-                "maxLength": 100,
-                "minLength": 5,
-                "type": "string"
+              "pageSize": {
+                "maximum": 100,
+                "minimum": 5,
+                "type": "integer"
               }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenPGRYIh9ayyi1": {
-        "required": [
-          "compact",
-          "dob",
-          "email",
-          "familyName",
-          "givenName",
-          "jurisdiction",
-          "licenseType",
-          "partialSocial",
-          "token"
-        ],
-        "type": "object",
-        "properties": {
-          "licenseType": {
-            "maxLength": 500,
-            "type": "string",
-            "description": "Type of license",
-            "enum": [
-              "audiologist",
-              "speech-language pathologist",
-              "occupational therapist",
-              "occupational therapy assistant",
-              "licensed professional counselor"
-            ]
+            }
           },
-          "compact": {
-            "maxLength": 100,
-            "type": "string",
-            "description": "Compact name"
-          },
-          "dob": {
-            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
-            "type": "string",
-            "description": "Date of birth in YYYY-MM-DD format"
-          },
-          "givenName": {
-            "maxLength": 200,
-            "type": "string",
-            "description": "Provider's given name"
-          },
-          "familyName": {
-            "maxLength": 200,
-            "type": "string",
-            "description": "Provider's family name"
-          },
-          "jurisdiction": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "Two-letter jurisdiction code",
-            "enum": [
-              "al",
-              "ak",
-              "az",
-              "ar",
-              "ca",
-              "co",
-              "ct",
-              "de",
-              "dc",
-              "fl",
-              "ga",
-              "hi",
-              "id",
-              "il",
-              "in",
-              "ia",
-              "ks",
-              "ky",
-              "la",
-              "me",
-              "md",
-              "ma",
-              "mi",
-              "mn",
-              "ms",
-              "mo",
-              "mt",
-              "ne",
-              "nv",
-              "nh",
-              "nj",
-              "nm",
-              "ny",
-              "nc",
-              "nd",
-              "oh",
-              "ok",
-              "or",
-              "pa",
-              "pr",
-              "ri",
-              "sc",
-              "sd",
-              "tn",
-              "tx",
-              "ut",
-              "vt",
-              "va",
-              "vi",
-              "wa",
-              "wv",
-              "wi",
-              "wy"
-            ]
-          },
-          "partialSocial": {
-            "maxLength": 4,
-            "minLength": 4,
-            "type": "string",
-            "description": "Last 4 digits of SSN"
-          },
-          "email": {
-            "maxLength": 100,
-            "minLength": 5,
-            "type": "string",
-            "description": "Provider's email address",
-            "format": "email"
-          },
-          "token": {
-            "type": "string",
-            "description": "ReCAPTCHA token"
-          }
-        }
-      },
-      "SandboLicenPAGHyHzOZttU": {
-        "type": "object",
-        "properties": {
-          "attributes": {
-            "type": "object",
-            "properties": {
-              "givenName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
+          "users": {
+            "type": "array",
+            "items": {
+              "required": [
+                "attributes",
+                "permissions",
+                "status",
+                "userId"
+              ],
+              "type": "object",
+              "properties": {
+                "permissions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "actions": {
+                        "type": "object",
+                        "properties": {
+                          "readPrivate": {
+                            "type": "boolean"
+                          },
+                          "admin": {
+                            "type": "boolean"
+                          },
+                          "readSSN": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "jurisdictions": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "actions": {
+                              "type": "object",
+                              "properties": {
+                                "readPrivate": {
+                                  "type": "boolean"
+                                },
+                                "admin": {
+                                  "type": "boolean"
+                                },
+                                "write": {
+                                  "type": "boolean"
+                                },
+                                "readSSN": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "attributes": {
+                  "required": [
+                    "email",
+                    "familyName",
+                    "givenName"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "givenName": {
+                      "maxLength": 100,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "familyName": {
+                      "maxLength": 100,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "email": {
+                      "maxLength": 100,
+                      "minLength": 5,
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "userId": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "inactive"
+                  ]
+                }
               },
-              "familyName": {
-                "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
+              "additionalProperties": false
+            }
           }
         },
         "additionalProperties": false
       },
-      "SandboLicenpdWD3FUE6e5Q": {
-        "required": [
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "The status to set the military affiliation to.",
-            "enum": [
-              "inactive"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLiceng85RwCdi1noV": {
+      "SandboLicenCAt3nUfAzyDS": {
         "required": [
           "pagination"
         ],
@@ -4929,261 +5435,22 @@
           }
         }
       },
-      "SandboLicenKFMSs4LH04ge": {
-        "type": "object",
-        "properties": {
-          "deactivationNote": {
-            "maxLength": 256,
-            "type": "string",
-            "description": "Note describing why the privilege is being deactivated"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenuSgVopjVWnQa": {
-        "type": "object",
-        "properties": {
-          "permissions": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "actions": {
-                  "type": "object",
-                  "properties": {
-                    "readPrivate": {
-                      "type": "boolean"
-                    },
-                    "admin": {
-                      "type": "boolean"
-                    },
-                    "readSSN": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "jurisdictions": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "readPrivate": {
-                            "type": "boolean"
-                          },
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          },
-                          "readSSN": {
-                            "type": "boolean"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenIQZ5lZQUELIS": {
-        "required": [
-          "items",
-          "pagination"
-        ],
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "items": {
-            "maxLength": 100,
-            "type": "array",
-            "items": {
-              "type": "object",
-              "oneOf": [
-                {
-                  "required": [
-                    "compactAbbr",
-                    "compactCommissionFee",
-                    "compactName",
-                    "transactionFeeConfiguration",
-                    "type"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "compactCommissionFee": {
-                      "required": [
-                        "feeAmount",
-                        "feeType"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "feeAmount": {
-                          "type": "number"
-                        },
-                        "feeType": {
-                          "type": "string",
-                          "enum": [
-                            "FLAT_RATE"
-                          ]
-                        }
-                      }
-                    },
-                    "compactAbbr": {
-                      "type": "string",
-                      "description": "The abbreviation of the compact"
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "compact"
-                      ]
-                    },
-                    "transactionFeeConfiguration": {
-                      "required": [
-                        "licenseeCharges"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "licenseeCharges": {
-                          "required": [
-                            "active",
-                            "chargeAmount",
-                            "chargeType"
-                          ],
-                          "type": "object",
-                          "properties": {
-                            "chargeType": {
-                              "type": "string",
-                              "description": "The type of transaction fee charge",
-                              "enum": [
-                                "FLAT_FEE_PER_PRIVILEGE"
-                              ]
-                            },
-                            "active": {
-                              "type": "boolean",
-                              "description": "Whether the compact is charging licensees transaction fees"
-                            },
-                            "chargeAmount": {
-                              "type": "number",
-                              "description": "The amount to charge per privilege purchased"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "compactName": {
-                      "type": "string",
-                      "description": "The full name of the compact"
-                    }
-                  }
-                },
-                {
-                  "required": [
-                    "jurisdictionFee",
-                    "jurisdictionName",
-                    "jurisprudenceRequirements",
-                    "postalAbbreviation",
-                    "type"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "militaryDiscount": {
-                      "required": [
-                        "active",
-                        "discountAmount",
-                        "discountType"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "active": {
-                          "type": "boolean",
-                          "description": "Whether the military discount is active"
-                        },
-                        "discountAmount": {
-                          "type": "number",
-                          "description": "The amount of the discount"
-                        },
-                        "discountType": {
-                          "type": "string",
-                          "description": "The type of discount",
-                          "enum": [
-                            "FLAT_RATE"
-                          ]
-                        }
-                      }
-                    },
-                    "postalAbbreviation": {
-                      "type": "string",
-                      "description": "The postal abbreviation of the jurisdiction"
-                    },
-                    "jurisprudenceRequirements": {
-                      "required": [
-                        "required"
-                      ],
-                      "type": "object",
-                      "properties": {
-                        "required": {
-                          "type": "boolean",
-                          "description": "Whether jurisprudence requirements exist"
-                        }
-                      }
-                    },
-                    "jurisdictionName": {
-                      "type": "string",
-                      "description": "The name of the jurisdiction"
-                    },
-                    "jurisdictionFee": {
-                      "type": "number",
-                      "description": "The fee for the jurisdiction"
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "jurisdiction"
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "SandboLicencEG2kojhh6C4": {
+      "SandboLicenFnewF1AZM2GM": {
         "required": [
           "affiliationType",
-          "fileNames"
+          "dateOfUpdate",
+          "dateOfUpload",
+          "documentUploadFields",
+          "status"
         ],
         "type": "object",
         "properties": {
+          "dateOfUpload": {
+            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+            "type": "string",
+            "description": "The date the document was uploaded",
+            "format": "date"
+          },
           "affiliationType": {
             "type": "string",
             "description": "The type of military affiliation",
@@ -5196,418 +5463,44 @@
             "type": "array",
             "description": "List of military affiliation file names",
             "items": {
-              "maxLength": 150,
               "type": "string",
               "description": "The name of the file being uploaded"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenbp9Kh9OUxbWh": {
-        "required": [
-          "attestations",
-          "licenseType",
-          "orderInformation",
-          "selectedJurisdictions"
-        ],
-        "type": "object",
-        "properties": {
-          "licenseType": {
-            "type": "string",
-            "description": "The type of license the provider is purchasing a privilege for.",
-            "enum": [
-              "audiologist",
-              "speech-language pathologist",
-              "occupational therapist",
-              "occupational therapy assistant",
-              "licensed professional counselor"
-            ]
           },
-          "attestations": {
+          "dateOfUpdate": {
+            "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+            "type": "string",
+            "description": "The date the document was last updated",
+            "format": "date"
+          },
+          "status": {
+            "type": "string",
+            "description": "The status of the military affiliation"
+          },
+          "documentUploadFields": {
             "type": "array",
-            "description": "List of attestations that the user has agreed to",
+            "description": "The fields used to upload documents",
             "items": {
-              "required": [
-                "attestationId",
-                "version"
-              ],
               "type": "object",
               "properties": {
-                "attestationId": {
-                  "maxLength": 100,
-                  "type": "string",
-                  "description": "The ID of the attestation"
-                },
-                "version": {
-                  "maxLength": 10,
-                  "pattern": "^\\d+$",
-                  "type": "string",
-                  "description": "The version of the attestation"
-                }
-              }
-            }
-          },
-          "orderInformation": {
-            "required": [
-              "billing",
-              "card"
-            ],
-            "type": "object",
-            "properties": {
-              "card": {
-                "required": [
-                  "cvv",
-                  "expiration",
-                  "number"
-                ],
-                "type": "object",
-                "properties": {
-                  "number": {
-                    "maxLength": 19,
-                    "minLength": 13,
-                    "type": "string",
-                    "description": "The card number"
-                  },
-                  "cvv": {
-                    "maxLength": 4,
-                    "minLength": 3,
-                    "type": "string",
-                    "description": "The card cvv"
-                  },
-                  "expiration": {
-                    "maxLength": 7,
-                    "minLength": 7,
-                    "type": "string",
-                    "description": "The card expiration date"
-                  }
-                }
-              },
-              "billing": {
-                "required": [
-                  "firstName",
-                  "lastName",
-                  "state",
-                  "streetAddress",
-                  "zip"
-                ],
-                "type": "object",
-                "properties": {
-                  "zip": {
-                    "maxLength": 10,
-                    "minLength": 5,
-                    "type": "string",
-                    "description": "The zip code for the card"
-                  },
-                  "firstName": {
-                    "maxLength": 100,
-                    "minLength": 1,
-                    "type": "string",
-                    "description": "The first name on the card"
-                  },
-                  "lastName": {
-                    "maxLength": 100,
-                    "minLength": 1,
-                    "type": "string",
-                    "description": "The last name on the card"
-                  },
-                  "streetAddress": {
-                    "maxLength": 150,
-                    "minLength": 2,
-                    "type": "string",
-                    "description": "The street address for the card"
-                  },
-                  "streetAddress2": {
-                    "maxLength": 150,
-                    "type": "string",
-                    "description": "The second street address for the card"
-                  },
-                  "state": {
-                    "maxLength": 2,
-                    "minLength": 2,
-                    "type": "string",
-                    "description": "The state postal abbreviation for the card"
-                  }
-                }
-              }
-            }
-          },
-          "selectedJurisdictions": {
-            "maxLength": 100,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "Jurisdictions a provider has selected to purchase privileges in.",
-              "enum": [
-                "al",
-                "ak",
-                "az",
-                "ar",
-                "ca",
-                "co",
-                "ct",
-                "de",
-                "dc",
-                "fl",
-                "ga",
-                "hi",
-                "id",
-                "il",
-                "in",
-                "ia",
-                "ks",
-                "ky",
-                "la",
-                "me",
-                "md",
-                "ma",
-                "mi",
-                "mn",
-                "ms",
-                "mo",
-                "mt",
-                "ne",
-                "nv",
-                "nh",
-                "nj",
-                "nm",
-                "ny",
-                "nc",
-                "nd",
-                "oh",
-                "ok",
-                "or",
-                "pa",
-                "pr",
-                "ri",
-                "sc",
-                "sd",
-                "tn",
-                "tx",
-                "ut",
-                "vt",
-                "va",
-                "vi",
-                "wa",
-                "wv",
-                "wi",
-                "wy"
-              ]
-            }
-          }
-        }
-      },
-      "SandboLicennbCiTFugFRZw": {
-        "required": [
-          "message"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string",
-            "description": "A message about the request"
-          }
-        }
-      },
-      "SandboLicen6wJmla1yTAGQ": {
-        "required": [
-          "ssn"
-        ],
-        "type": "object",
-        "properties": {
-          "ssn": {
-            "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
-            "type": "string",
-            "description": "The provider's social security number"
-          }
-        }
-      },
-      "SandboLicenA9brFoJmUQbH": {
-        "type": "object",
-        "properties": {
-          "pagination": {
-            "type": "object",
-            "properties": {
-              "prevLastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "lastKey": {
-                "maxLength": 1024,
-                "minLength": 1,
-                "type": "object"
-              },
-              "pageSize": {
-                "maximum": 100,
-                "minimum": 5,
-                "type": "integer"
-              }
-            }
-          },
-          "users": {
-            "type": "array",
-            "items": {
-              "required": [
-                "attributes",
-                "permissions",
-                "status",
-                "userId"
-              ],
-              "type": "object",
-              "properties": {
-                "permissions": {
+                "fields": {
                   "type": "object",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "actions": {
-                        "type": "object",
-                        "properties": {
-                          "readPrivate": {
-                            "type": "boolean"
-                          },
-                          "admin": {
-                            "type": "boolean"
-                          },
-                          "readSSN": {
-                            "type": "boolean"
-                          }
-                        }
-                      },
-                      "jurisdictions": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "object",
-                          "properties": {
-                            "actions": {
-                              "type": "object",
-                              "properties": {
-                                "readPrivate": {
-                                  "type": "boolean"
-                                },
-                                "admin": {
-                                  "type": "boolean"
-                                },
-                                "write": {
-                                  "type": "boolean"
-                                },
-                                "readSSN": {
-                                  "type": "boolean"
-                                }
-                              },
-                              "additionalProperties": false
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                },
-                "attributes": {
-                  "required": [
-                    "email",
-                    "familyName",
-                    "givenName"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "givenName": {
-                      "maxLength": 100,
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "maxLength": 100,
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "email": {
-                      "maxLength": 100,
-                      "minLength": 5,
-                      "type": "string"
-                    }
+                    "type": "string"
                   },
-                  "additionalProperties": false
+                  "description": "The form fields used to upload the document"
                 },
-                "userId": {
-                  "type": "string"
-                },
-                "status": {
+                "url": {
                   "type": "string",
-                  "enum": [
-                    "active",
-                    "inactive"
-                  ]
+                  "description": "The url to upload the document to"
                 }
               },
-              "additionalProperties": false
+              "description": "The fields used to upload a specific document"
             }
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicenZ8v81WzIHwtt": {
-        "required": [
-          "message"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string",
-            "description": "A message about the request"
           }
         }
       },
-      "SandboLicenB23GYrSs53bY": {
-        "required": [
-          "apiLoginId",
-          "processor",
-          "transactionKey"
-        ],
-        "type": "object",
-        "properties": {
-          "apiLoginId": {
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string",
-            "description": "The api login id for the payment processor"
-          },
-          "transactionKey": {
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string",
-            "description": "The transaction key for the payment processor"
-          },
-          "processor": {
-            "type": "string",
-            "description": "The type of payment processor",
-            "enum": [
-              "authorize.net"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SandboLicen61FG2ANFq1QV": {
-        "required": [
-          "fields"
-        ],
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "url": {
-            "type": "string"
-          }
-        }
-      },
-      "SandboLicentvvhq6mfX3YL": {
+      "SandboLicenFKIspyClyPtn": {
         "required": [
           "transactionId"
         ],
@@ -5621,6 +5514,144 @@
             "type": "string",
             "description": "The transaction id for the purchase"
           }
+        }
+      },
+      "SandboLicenp4yschyzjUCa": {
+        "maxLength": 100,
+        "type": "array",
+        "items": {
+          "required": [
+            "compactEligibility",
+            "dateOfBirth",
+            "dateOfExpiration",
+            "dateOfIssuance",
+            "dateOfRenewal",
+            "familyName",
+            "givenName",
+            "homeAddressCity",
+            "homeAddressPostalCode",
+            "homeAddressState",
+            "homeAddressStreet1",
+            "licenseStatus",
+            "licenseType"
+          ],
+          "type": "object",
+          "properties": {
+            "homeAddressStreet2": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "npi": {
+              "pattern": "^[0-9]{10}$",
+              "type": "string"
+            },
+            "homeAddressPostalCode": {
+              "maxLength": 7,
+              "minLength": 5,
+              "type": "string"
+            },
+            "givenName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeAddressStreet1": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "compactEligibility": {
+              "type": "string",
+              "enum": [
+                "eligible",
+                "ineligible"
+              ]
+            },
+            "dateOfBirth": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "suffix": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "dateOfIssuance": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "licenseType": {
+              "type": "string",
+              "enum": [
+                "audiologist",
+                "speech-language pathologist",
+                "occupational therapist",
+                "occupational therapy assistant",
+                "licensed professional counselor"
+              ]
+            },
+            "emailAddress": {
+              "maxLength": 100,
+              "minLength": 5,
+              "type": "string",
+              "format": "email"
+            },
+            "dateOfExpiration": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "phoneNumber": {
+              "pattern": "^\\+[0-9]{8,15}$",
+              "type": "string"
+            },
+            "homeAddressState": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "dateOfRenewal": {
+              "pattern": "^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$",
+              "type": "string",
+              "format": "date"
+            },
+            "licenseStatus": {
+              "type": "string",
+              "enum": [
+                "active",
+                "inactive"
+              ]
+            },
+            "familyName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "homeAddressCity": {
+              "maxLength": 100,
+              "minLength": 2,
+              "type": "string"
+            },
+            "licenseNumber": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "middleName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "licenseStatusName": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/backend/compact-connect/lambdas/nodejs/tests/lib/jurisdiction-client.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lib/jurisdiction-client.test.ts
@@ -23,8 +23,33 @@ const SAMPLE_JURISDICTION_ITEMS = [
         'jurisdictionAdverseActionsNotificationEmails': {
             'L': []
         },
+        // deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
         'jurisdictionFee': {
             'N': '100'
+        },
+        'privilegeFees': {
+            'L': [
+                {
+                    'M': {
+                        'licenseTypeAbbreviation': {
+                            'S': 'aud'
+                        },
+                        'amount': {
+                            'N': '100'
+                        }
+                    }
+                },
+                {
+                    'M': {
+                        'licenseTypeAbbreviation': {
+                            'S': 'slp'
+                        },
+                        'amount': {
+                            'N': '100'
+                        }
+                    }
+                }
+            ]
         },
         'jurisdictionName': {
             'S': 'ohio'
@@ -82,8 +107,33 @@ const SAMPLE_JURISDICTION_ITEMS = [
         'jurisdictionAdverseActionsNotificationEmails': {
             'L': []
         },
+        // deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
         'jurisdictionFee': {
             'N': '100'
+        },
+        'privilegeFees': {
+            'L': [
+                {
+                    'M': {
+                        'licenseTypeAbbreviation': {
+                            'S': 'aud'
+                        },
+                        'amount': {
+                            'N': '100'
+                        }
+                    }
+                },
+                {
+                    'M': {
+                        'licenseTypeAbbreviation': {
+                            'S': 'slp'
+                        },
+                        'amount': {
+                            'N': '100'
+                        }
+                    }
+                }
+            ]
         },
         'jurisdictionName': {
             'S': 'nebraska'

--- a/backend/compact-connect/lambdas/nodejs/tests/sample-records.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/sample-records.ts
@@ -245,8 +245,33 @@ export const SAMPLE_JURISDICTION_CONFIGURATION = {
     'jurisdictionAdverseActionsNotificationEmails': {
         'L': []
     },
+    // deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
     'jurisdictionFee': {
         'N': '100'
+    },
+    'privilegeFees': {
+        'L': [
+            {
+                'M': {
+                    'licenseTypeAbbreviation': {
+                        'S': 'aud'
+                    },
+                    'amount': {
+                        'N': '100'
+                    }
+                }
+            },
+            {
+                'M': {
+                    'licenseTypeAbbreviation': {
+                        'S': 'slp'
+                    },
+                    'amount': {
+                        'N': '100'
+                    }
+                }
+            }
+        ]
     },
     'jurisdictionName': {
         'S': 'ohio'
@@ -295,7 +320,18 @@ export const SAMPLE_UNMARSHALLED_JURISDICTION_CONFIGURATION = {
     'compact': 'aslp',
     'dateOfUpdate': '2024-11-14',
     'jurisdictionAdverseActionsNotificationEmails': [],
+    // deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
     'jurisdictionFee': '100',
+    'privilegeFees': [
+        {
+            'licenseTypeAbbreviation': 'aud',
+            'amount': '100'
+        },
+        {
+            'licenseTypeAbbreviation': 'slp',
+            'amount': '100'
+        }
+    ],
     'jurisdictionName': 'ohio',
     'jurisdictionOperationsTeamEmails': [ 'justin@inspiringapps.com' ],
     'jurisdictionSummaryReportNotificationEmails': [],

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/__init__.py
@@ -41,6 +41,21 @@ class JurisdictionJurisprudenceRequirements(UserDict):
         return self['required']
 
 
+class JurisdictionPrivilegeFee(UserDict):
+    """
+    Jurisdiction license fee data model. Used to access variables without needing to know
+    the underlying key structure.
+    """
+
+    @property
+    def license_type_abbreviation(self) -> str:
+        return self['licenseTypeAbbreviation']
+
+    @property
+    def amount(self) -> Decimal:
+        return self['amount']
+
+
 class Jurisdiction(UserDict):
     """
     Jurisdiction configuration data model. Used to access variables without needing to know
@@ -59,9 +74,15 @@ class Jurisdiction(UserDict):
     def compact(self) -> str:
         return self['compact']
 
+    # Deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
+    # use privilege_fees instead
     @property
     def jurisdiction_fee(self) -> Decimal:
         return self['jurisdictionFee']
+
+    @property
+    def privilege_fees(self) -> list[JurisdictionPrivilegeFee]:
+        return [JurisdictionPrivilegeFee(fee) for fee in self.data['privilegeFees']]
 
     @property
     def military_discount(self) -> JurisdictionMilitaryDiscount | None:

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/api.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/api.py
@@ -1,6 +1,6 @@
 # ruff: noqa: N801, N815, ARG002 invalid-name unused-kwargs
 from marshmallow import Schema
-from marshmallow.fields import Boolean, Decimal, Nested, String
+from marshmallow.fields import Boolean, Decimal, List, Nested, String
 from marshmallow.validate import OneOf
 
 from cc_common.config import config
@@ -20,6 +20,11 @@ class JurisdictionJurisprudenceRequirementsResponseSchema(Schema):
     required = Boolean(required=True, allow_none=False)
 
 
+class JurisdictionPrivilegeFeeResponseSchema(Schema):
+    licenseTypeAbbreviation = String(required=True, allow_none=False)
+    amount = Decimal(required=True, allow_none=False)
+
+
 class JurisdictionOptionsResponseSchema(ForgivingSchema):
     """
     Used to enforce which fields are returned in jurisdiction objects for the
@@ -30,11 +35,13 @@ class JurisdictionOptionsResponseSchema(ForgivingSchema):
     jurisdictionName = String(required=True, allow_none=False)
     postalAbbreviation = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
     compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
-    jurisdictionFee = Decimal(required=True, allow_none=False)
+    privilegeFees = List(Nested(JurisdictionPrivilegeFeeResponseSchema()), required=True, allow_none=False)
     militaryDiscount = Nested(JurisdictionMilitaryDiscountResponseSchema(), required=False, allow_none=False)
     jurisprudenceRequirements = Nested(
         JurisdictionJurisprudenceRequirementsResponseSchema(), required=True, allow_none=False
     )
+    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
+    jurisdictionFee = Decimal(required=False, allow_none=False)
 
 
 class CompactJurisdictionsStaffUsersResponseSchema(ForgivingSchema):

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
@@ -1,11 +1,10 @@
 # ruff: noqa: N801, N815, ARG002 invalid-name unused-kwargs
-from marshmallow import Schema, pre_dump
-from marshmallow.fields import Boolean, Decimal, Email, List, Nested, String
-from marshmallow.validate import Length, OneOf
-
 from cc_common.config import config
 from cc_common.data_model.schema.base_record import BaseRecordSchema
 from cc_common.data_model.schema.jurisdiction import JURISDICTION_TYPE, JurisdictionMilitaryDiscountType
+from marshmallow import Schema, pre_dump
+from marshmallow.fields import Boolean, Decimal, Email, List, Nested, String
+from marshmallow.validate import Length, OneOf
 
 
 class JurisdictionMilitaryDiscountRecordSchema(Schema):
@@ -20,6 +19,10 @@ class JurisdictionJurisprudenceRequirementsRecordSchema(Schema):
     required = Boolean(required=True, allow_none=False)
 
 
+class JurisdictionPrivilegeFeeRecordSchema(Schema):
+    licenseTypeAbbreviation = String(required=True, allow_none=False)
+    amount = Decimal(required=True, allow_none=False, places=2)
+
 @BaseRecordSchema.register_schema(JURISDICTION_TYPE)
 class JurisdictionRecordSchema(BaseRecordSchema):
     """Schema for the root jurisdiction configuration records"""
@@ -30,7 +33,7 @@ class JurisdictionRecordSchema(BaseRecordSchema):
     jurisdictionName = String(required=True, allow_none=False)
     postalAbbreviation = String(required=True, allow_none=False, validate=OneOf(config.jurisdictions))
     compact = String(required=True, allow_none=False, validate=OneOf(config.compacts))
-    jurisdictionFee = Decimal(required=True, allow_none=False, places=2)
+    privilegeFees = List(Nested(JurisdictionPrivilegeFeeRecordSchema()), required=True, allow_none=False)
     militaryDiscount = Nested(JurisdictionMilitaryDiscountRecordSchema(), required=False, allow_none=False)
     jurisdictionOperationsTeamEmails = List(
         Email(required=True, allow_none=False), required=True, allow_none=False, validate=Length(min=1)
@@ -53,6 +56,8 @@ class JurisdictionRecordSchema(BaseRecordSchema):
     jurisprudenceRequirements = Nested(
         JurisdictionJurisprudenceRequirementsRecordSchema(), required=True, allow_none=False
     )
+    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
+    jurisdictionFee = Decimal(required=False, allow_none=False, places=2)
 
     # Generated fields
     pk = String(required=True, allow_none=False)

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
@@ -1,10 +1,11 @@
 # ruff: noqa: N801, N815, ARG002 invalid-name unused-kwargs
-from cc_common.config import config
-from cc_common.data_model.schema.base_record import BaseRecordSchema
-from cc_common.data_model.schema.jurisdiction import JURISDICTION_TYPE, JurisdictionMilitaryDiscountType
 from marshmallow import Schema, pre_dump
 from marshmallow.fields import Boolean, Decimal, Email, List, Nested, String
 from marshmallow.validate import Length, OneOf
+
+from cc_common.config import config
+from cc_common.data_model.schema.base_record import BaseRecordSchema
+from cc_common.data_model.schema.jurisdiction import JURISDICTION_TYPE, JurisdictionMilitaryDiscountType
 
 
 class JurisdictionMilitaryDiscountRecordSchema(Schema):
@@ -22,6 +23,7 @@ class JurisdictionJurisprudenceRequirementsRecordSchema(Schema):
 class JurisdictionPrivilegeFeeRecordSchema(Schema):
     licenseTypeAbbreviation = String(required=True, allow_none=False)
     amount = Decimal(required=True, allow_none=False, places=2)
+
 
 @BaseRecordSchema.register_schema(JURISDICTION_TYPE)
 class JurisdictionRecordSchema(BaseRecordSchema):

--- a/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/jurisdiction.json
+++ b/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/jurisdiction.json
@@ -6,6 +6,16 @@
   "jurisdictionName": "ohio",
   "postalAbbreviation": "oh",
   "jurisdictionFee": 100,
+  "privilegeFees": [
+    {
+      "licenseTypeAbbreviation": "aud",
+      "amount": 100
+    },
+    {
+      "licenseTypeAbbreviation": "slp",
+      "amount": 100
+    }
+  ],
   "militaryDiscount": {
     "active": true,
     "discountType": "FLAT_RATE",

--- a/backend/compact-connect/lambdas/python/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
+++ b/backend/compact-connect/lambdas/python/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
@@ -224,7 +224,7 @@ class TestCompactConfigurationUploader(TstFunction):
                     'compact': OT_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    # deprecated - will be removed when frontend is updated
+                    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
                     'jurisdictionFee': Decimal('100.00'),
                     'privilegeFees': [
                         {'licenseTypeAbbreviation': 'ot', 'amount': Decimal('100.00')},

--- a/backend/compact-connect/lambdas/python/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
+++ b/backend/compact-connect/lambdas/python/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
@@ -12,6 +12,9 @@ from .. import TstFunction
 TEST_ENVIRONMENT_NAME = 'test'
 MOCK_CURRENT_TIMESTAMP = '2024-11-08T23:59:59+00:00'
 
+ASLP_COMPACT_ABBREVIATION = 'aslp'
+OT_COMPACT_ABBREVIATION = 'octp'
+
 
 def generate_mock_attestation():
     return {
@@ -38,11 +41,21 @@ def generate_single_root_compact_config(compact_abbr: str, active_environments: 
     }
 
 
-def generate_single_jurisdiction_config(jurisdiction_name: str, postal_abbreviation: str, active_environments: list):
+def generate_single_jurisdiction_config(
+    compact: str, jurisdiction_name: str, postal_abbreviation: str, active_environments: list
+):
+    privilege_fees = (
+        [{'licenseTypeAbbreviation': 'aud', 'amount': 100}, {'licenseTypeAbbreviation': 'slp', 'amount': 100}]
+        if compact == 'aslp'
+        else [{'licenseTypeAbbreviation': 'ot', 'amount': 100}, {'licenseTypeAbbreviation': 'ota', 'amount': 100}]
+    )
+
     return {
         'jurisdictionName': jurisdiction_name,
         'postalAbbreviation': postal_abbreviation,
+        # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
         'jurisdictionFee': 100,
+        'privilegeFees': privilege_fees,
         'militaryDiscount': {'active': True, 'discountType': 'FLAT_RATE', 'discountAmount': 10},
         'jurisdictionOperationsTeamEmails': ['cloud-team@example.com'],
         'jurisdictionAdverseActionsNotificationEmails': [],
@@ -56,17 +69,23 @@ def generate_single_jurisdiction_config(jurisdiction_name: str, postal_abbreviat
 def generate_mock_compact_configuration():
     return {
         'compacts': [
-            generate_single_root_compact_config('aslp', active_environments=[TEST_ENVIRONMENT_NAME]),
-            generate_single_root_compact_config('octp', active_environments=[]),
+            generate_single_root_compact_config(ASLP_COMPACT_ABBREVIATION, active_environments=[TEST_ENVIRONMENT_NAME]),
+            generate_single_root_compact_config(OT_COMPACT_ABBREVIATION, active_environments=[]),
         ],
         'jurisdictions': {
-            'aslp': [
-                generate_single_jurisdiction_config('nebraska', 'ne', active_environments=[TEST_ENVIRONMENT_NAME]),
-                generate_single_jurisdiction_config('ohio', 'oh', active_environments=[]),
+            ASLP_COMPACT_ABBREVIATION: [
+                generate_single_jurisdiction_config(
+                    ASLP_COMPACT_ABBREVIATION, 'nebraska', 'ne', active_environments=[TEST_ENVIRONMENT_NAME]
+                ),
+                generate_single_jurisdiction_config(ASLP_COMPACT_ABBREVIATION, 'ohio', 'oh', active_environments=[]),
             ],
-            'octp': [
-                generate_single_jurisdiction_config('nebraska', 'ne', active_environments=['sandbox']),
-                generate_single_jurisdiction_config('ohio', 'oh', active_environments=['sandbox']),
+            OT_COMPACT_ABBREVIATION: [
+                generate_single_jurisdiction_config(
+                    OT_COMPACT_ABBREVIATION, 'nebraska', 'ne', active_environments=['sandbox']
+                ),
+                generate_single_jurisdiction_config(
+                    OT_COMPACT_ABBREVIATION, 'ohio', 'oh', active_environments=['sandbox']
+                ),
             ],
         },
     }
@@ -104,8 +123,8 @@ class TestCompactConfigurationUploader(TstFunction):
             [
                 {
                     'compactAdverseActionsNotificationEmails': [],
-                    'compactCommissionFee': {'feeAmount': Decimal('3.5'), 'feeType': 'FLAT_RATE'},
-                    'compactAbbr': 'aslp',
+                    'compactCommissionFee': {'feeAmount': Decimal('3.50'), 'feeType': 'FLAT_RATE'},
+                    'compactAbbr': ASLP_COMPACT_ABBREVIATION,
                     'compactOperationsTeamEmails': [],
                     'compactSummaryReportNotificationEmails': [],
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
@@ -115,15 +134,24 @@ class TestCompactConfigurationUploader(TstFunction):
                     'type': 'compact',
                 },
                 {
-                    'compact': 'aslp',
+                    'compact': ASLP_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    'jurisdictionFee': Decimal('100'),
+                    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
+                    'jurisdictionFee': Decimal('100.00'),
+                    'privilegeFees': [
+                        {'licenseTypeAbbreviation': 'aud', 'amount': Decimal('100.00')},
+                        {'licenseTypeAbbreviation': 'slp', 'amount': Decimal('100.00')},
+                    ],
                     'jurisdictionName': 'nebraska',
                     'jurisdictionOperationsTeamEmails': ['cloud-team@example.com'],
                     'jurisdictionSummaryReportNotificationEmails': [],
                     'jurisprudenceRequirements': {'required': True},
-                    'militaryDiscount': {'active': True, 'discountAmount': Decimal('10'), 'discountType': 'FLAT_RATE'},
+                    'militaryDiscount': {
+                        'active': True,
+                        'discountAmount': Decimal('10.00'),
+                        'discountType': 'FLAT_RATE',
+                    },
                     'pk': 'aslp#CONFIGURATION',
                     'postalAbbreviation': 'ne',
                     'sk': 'aslp#JURISDICTION#ne',
@@ -131,15 +159,24 @@ class TestCompactConfigurationUploader(TstFunction):
                     'licenseeRegistrationEnabledForEnvironments': [],
                 },
                 {
-                    'compact': 'aslp',
+                    'compact': ASLP_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    'jurisdictionFee': Decimal('100'),
+                    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
+                    'jurisdictionFee': Decimal('100.00'),
+                    'privilegeFees': [
+                        {'licenseTypeAbbreviation': 'aud', 'amount': Decimal('100.00')},
+                        {'licenseTypeAbbreviation': 'slp', 'amount': Decimal('100.00')},
+                    ],
                     'jurisdictionName': 'ohio',
                     'jurisdictionOperationsTeamEmails': ['cloud-team@example.com'],
                     'jurisdictionSummaryReportNotificationEmails': [],
                     'jurisprudenceRequirements': {'required': True},
-                    'militaryDiscount': {'active': True, 'discountAmount': Decimal('10'), 'discountType': 'FLAT_RATE'},
+                    'militaryDiscount': {
+                        'active': True,
+                        'discountAmount': Decimal('10.00'),
+                        'discountType': 'FLAT_RATE',
+                    },
                     'pk': 'aslp#CONFIGURATION',
                     'postalAbbreviation': 'oh',
                     'sk': 'aslp#JURISDICTION#oh',
@@ -148,8 +185,8 @@ class TestCompactConfigurationUploader(TstFunction):
                 },
                 {
                     'compactAdverseActionsNotificationEmails': [],
-                    'compactCommissionFee': {'feeAmount': Decimal('3.5'), 'feeType': 'FLAT_RATE'},
-                    'compactAbbr': 'octp',
+                    'compactCommissionFee': {'feeAmount': Decimal('3.50'), 'feeType': 'FLAT_RATE'},
+                    'compactAbbr': OT_COMPACT_ABBREVIATION,
                     'compactOperationsTeamEmails': [],
                     'compactSummaryReportNotificationEmails': [],
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
@@ -159,15 +196,24 @@ class TestCompactConfigurationUploader(TstFunction):
                     'licenseeRegistrationEnabledForEnvironments': [],
                 },
                 {
-                    'compact': 'octp',
+                    'compact': OT_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    'jurisdictionFee': Decimal('100'),
+                    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
+                    'jurisdictionFee': Decimal('100.00'),
+                    'privilegeFees': [
+                        {'licenseTypeAbbreviation': 'ot', 'amount': Decimal('100.00')},
+                        {'licenseTypeAbbreviation': 'ota', 'amount': Decimal('100.00')},
+                    ],
                     'jurisdictionName': 'nebraska',
                     'jurisdictionOperationsTeamEmails': ['cloud-team@example.com'],
                     'jurisdictionSummaryReportNotificationEmails': [],
                     'jurisprudenceRequirements': {'required': True},
-                    'militaryDiscount': {'active': True, 'discountAmount': Decimal('10'), 'discountType': 'FLAT_RATE'},
+                    'militaryDiscount': {
+                        'active': True,
+                        'discountAmount': Decimal('10.00'),
+                        'discountType': 'FLAT_RATE',
+                    },
                     'pk': 'octp#CONFIGURATION',
                     'postalAbbreviation': 'ne',
                     'sk': 'octp#JURISDICTION#ne',
@@ -175,15 +221,24 @@ class TestCompactConfigurationUploader(TstFunction):
                     'licenseeRegistrationEnabledForEnvironments': [],
                 },
                 {
-                    'compact': 'octp',
+                    'compact': OT_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    'jurisdictionFee': Decimal('100'),
+                    # deprecated - will be removed when frontend is updated
+                    'jurisdictionFee': Decimal('100.00'),
+                    'privilegeFees': [
+                        {'licenseTypeAbbreviation': 'ot', 'amount': Decimal('100.00')},
+                        {'licenseTypeAbbreviation': 'ota', 'amount': Decimal('100.00')},
+                    ],
                     'jurisdictionName': 'ohio',
                     'jurisdictionOperationsTeamEmails': ['cloud-team@example.com'],
                     'jurisdictionSummaryReportNotificationEmails': [],
                     'jurisprudenceRequirements': {'required': True},
-                    'militaryDiscount': {'active': True, 'discountAmount': Decimal('10'), 'discountType': 'FLAT_RATE'},
+                    'militaryDiscount': {
+                        'active': True,
+                        'discountAmount': Decimal('10.00'),
+                        'discountType': 'FLAT_RATE',
+                    },
                     'pk': 'octp#CONFIGURATION',
                     'postalAbbreviation': 'oh',
                     'sk': 'octp#JURISDICTION#oh',
@@ -199,7 +254,7 @@ class TestCompactConfigurationUploader(TstFunction):
 
         mock_configuration = generate_mock_compact_configuration()
         # An empty ops team email is not allowed
-        mock_configuration['jurisdictions']['aslp'][0]['jurisdictionOperationsTeamEmails'] = []
+        mock_configuration['jurisdictions'][ASLP_COMPACT_ABBREVIATION][0]['jurisdictionOperationsTeamEmails'] = []
 
         event = {
             'RequestType': 'Create',
@@ -248,7 +303,7 @@ class TestCompactConfigurationUploader(TstFunction):
             'states you are purchasing privileges for.',
             'required': True,
             'locale': 'en',
-            'compact': 'aslp',
+            'compact': ASLP_COMPACT_ABBREVIATION,
         }
 
         self.assertEqual(expected_attestation, attestation)

--- a/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
@@ -108,7 +108,7 @@ def _generate_selected_jurisdictions(jurisdiction_items: list[dict] = None):
 
     if jurisdiction_items is None:
         jurisdiction_items = [
-            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'licenseFee': 100.00},
+            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'privilegeFee': 100.00},
         ]
 
     jurisdiction_configurations = []
@@ -118,7 +118,7 @@ def _generate_selected_jurisdictions(jurisdiction_items: list[dict] = None):
             jurisdiction = json.load(f)
             for licensee_fee in jurisdiction['privilegeFees']:
                 # DynamoDB loads this as a decimal
-                licensee_fee['amount'] = Decimal(jurisdiction_test_item['licenseFee'])
+                licensee_fee['amount'] = Decimal(jurisdiction_test_item['privilegeFee'])
 
             # set military discount to fixed amount for tests
             jurisdiction['militaryDiscount']['discountAmount'] = Decimal(25.00)
@@ -345,8 +345,8 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
         test_jurisdictions = [
-            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'licenseFee': 50.00},
-            {'postalCode': 'ky', 'jurisdictionName': 'kentucky', 'licenseFee': 200.00},
+            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'privilegeFee': 50.00},
+            {'postalCode': 'ky', 'jurisdictionName': 'kentucky', 'privilegeFee': 200.00},
         ]
 
         test_purchase_client.process_charge_for_licensee_privileges(

--- a/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
@@ -108,7 +108,7 @@ def _generate_selected_jurisdictions(jurisdiction_items: list[dict] = None):
 
     if jurisdiction_items is None:
         jurisdiction_items = [
-            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'jurisdictionFee': 100.00},
+            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'licenseFee': 100.00},
         ]
 
     jurisdiction_configurations = []
@@ -116,7 +116,10 @@ def _generate_selected_jurisdictions(jurisdiction_items: list[dict] = None):
     for jurisdiction_test_item in jurisdiction_items:
         with open('../common/tests/resources/dynamo/jurisdiction.json') as f:
             jurisdiction = json.load(f)
-            jurisdiction['jurisdictionFee'] = Decimal(jurisdiction_test_item['jurisdictionFee'])
+            for licensee_fee in jurisdiction['privilegeFees']:
+                # DynamoDB loads this as a decimal
+                licensee_fee['amount'] = Decimal(jurisdiction_test_item['licenseFee'])
+
             # set military discount to fixed amount for tests
             jurisdiction['militaryDiscount']['discountAmount'] = Decimal(25.00)
             jurisdiction['militaryDiscount']['active'] = True
@@ -342,8 +345,8 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
         test_purchase_client = PurchaseClient(secrets_manager_client=mock_secrets_manager_client)
 
         test_jurisdictions = [
-            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'jurisdictionFee': 50.00},
-            {'postalCode': 'ky', 'jurisdictionName': 'kentucky', 'jurisdictionFee': 200.00},
+            {'postalCode': 'oh', 'jurisdictionName': 'ohio', 'licenseFee': 50.00},
+            {'postalCode': 'ky', 'jurisdictionName': 'kentucky', 'licenseFee': 200.00},
         ]
 
         test_purchase_client.process_charge_for_licensee_privileges(

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -154,7 +154,7 @@ class ApiModel:
                     ],
                     additional_properties=False,
                     properties={
-                        'licenseType': JsonSchema(type=JsonSchemaType.STRING, enum=self.stack.license_types),
+                        'licenseType': JsonSchema(type=JsonSchemaType.STRING, enum=self.stack.license_type_names),
                         **self._common_license_properties,
                     },
                 ),
@@ -525,7 +525,7 @@ class ApiModel:
                     'licenseType': JsonSchema(
                         type=JsonSchemaType.STRING,
                         description='The type of license the provider is purchasing a privilege for.',
-                        enum=self.stack.license_types,
+                        enum=self.stack.license_type_names,
                     ),
                     'selectedJurisdictions': JsonSchema(
                         type=JsonSchemaType.ARRAY,
@@ -959,7 +959,7 @@ class ApiModel:
                                 type=JsonSchemaType.STRING,
                                 enum=self.stack.node.get_context('jurisdictions'),
                             ),
-                            'licenseType': JsonSchema(type=JsonSchemaType.STRING, enum=self.stack.license_types),
+                            'licenseType': JsonSchema(type=JsonSchemaType.STRING, enum=self.stack.license_type_names),
                             'dateOfUpdate': JsonSchema(
                                 type=JsonSchemaType.STRING,
                                 format='date',
@@ -1001,7 +1001,7 @@ class ApiModel:
                                             enum=self.stack.node.get_context('jurisdictions'),
                                         ),
                                         'licenseType': JsonSchema(
-                                            type=JsonSchemaType.STRING, enum=self.stack.license_types
+                                            type=JsonSchemaType.STRING, enum=self.stack.license_type_names
                                         ),
                                         'dateOfUpdate': JsonSchema(
                                             type=JsonSchemaType.STRING, format='date', pattern=cc_api.YMD_FORMAT
@@ -1106,7 +1106,7 @@ class ApiModel:
                                             enum=self.stack.node.get_context('jurisdictions'),
                                         ),
                                         'licenseType': JsonSchema(
-                                            type=JsonSchemaType.STRING, enum=self.stack.license_types
+                                            type=JsonSchemaType.STRING, enum=self.stack.license_type_names
                                         ),
                                         'dateOfUpdate': JsonSchema(
                                             type=JsonSchemaType.STRING, format='date', pattern=cc_api.YMD_FORMAT
@@ -1138,7 +1138,7 @@ class ApiModel:
                                     },
                                 ),
                             ),
-                            'licenseType': JsonSchema(type=JsonSchemaType.STRING, enum=self.stack.license_types),
+                            'licenseType': JsonSchema(type=JsonSchemaType.STRING, enum=self.stack.license_type_names),
                             **self._common_privilege_properties,
                         },
                     ),
@@ -1621,7 +1621,7 @@ class ApiModel:
                         type=JsonSchemaType.STRING,
                         description='Type of license',
                         max_length=500,
-                        enum=self.stack.license_types,
+                        enum=self.stack.license_type_names,
                     ),
                     'compact': JsonSchema(
                         type=JsonSchemaType.STRING,

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -816,8 +816,6 @@ class ApiModel:
                         'type',
                         'jurisdictionName',
                         'postalAbbreviation',
-                        # deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-                        'jurisdictionFee',
                         'privilegeFees',
                         'jurisprudenceRequirements',
                     ],

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -816,7 +816,9 @@ class ApiModel:
                         'type',
                         'jurisdictionName',
                         'postalAbbreviation',
+                        # deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
                         'jurisdictionFee',
+                        'privilegeFees',
                         'jurisprudenceRequirements',
                     ],
                     properties={
@@ -829,9 +831,22 @@ class ApiModel:
                             type=JsonSchemaType.STRING,
                             description='The postal abbreviation of the jurisdiction',
                         ),
+                        # deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
                         'jurisdictionFee': JsonSchema(
                             type=JsonSchemaType.NUMBER,
                             description='The fee for the jurisdiction',
+                        ),
+                        'privilegeFees': JsonSchema(
+                            type=JsonSchemaType.ARRAY,
+                            description='The fees for the privileges',
+                            items=JsonSchema(
+                                type=JsonSchemaType.OBJECT,
+                                required=['licenseTypeAbbreviation', 'amount'],
+                                properties={
+                                    'licenseTypeAbbreviation': JsonSchema(type=JsonSchemaType.STRING),
+                                    'amount': JsonSchema(type=JsonSchemaType.NUMBER),
+                                },
+                            )
                         ),
                         'militaryDiscount': JsonSchema(
                             type=JsonSchemaType.OBJECT,

--- a/backend/compact-connect/stacks/persistent_stack/compact_configuration_upload.py
+++ b/backend/compact-connect/stacks/persistent_stack/compact_configuration_upload.py
@@ -211,13 +211,13 @@ class CompactConfigurationUpload(Construct):
                 f'jurisdictionOperationsTeamEmails is required for jurisdiction {jurisdiction["postalAbbreviation"]}'
             )
 
-        license_type_abbreviations = [lt['abbreviation'] for lt in license_types_for_compact]
-
         # Ensure all license types are covered
         if jurisdiction.get('privilegeFees'):
-            defined_license_types = [fee['licenseTypeAbbreviation'] for fee in jurisdiction['privilegeFees']]
-            missing_license_types = set(license_type_abbreviations) - set(defined_license_types)
+            defined_license_types_list = [fee['licenseTypeAbbreviation'] for fee in jurisdiction['privilegeFees']]
+            defined_license_types_set = set(defined_license_types_list)
+            compact_license_type_abbreviations = set([lt['abbreviation'] for lt in license_types_for_compact])
 
+            missing_license_types = compact_license_type_abbreviations - defined_license_types_set
             if missing_license_types:
                 raise ValueError(
                     f'Jurisdiction {jurisdiction["postalAbbreviation"]} in Compact {compact_abbr} '
@@ -225,15 +225,16 @@ class CompactConfigurationUpload(Construct):
                 )
 
             # Check for duplicate license types
-            if len(defined_license_types) != len(set(defined_license_types)):
-                raise ValueError(f'Jurisdiction {jurisdiction["postalAbbreviation"]} has duplicate license type fees')
+            if len(defined_license_types_list) != len(defined_license_types_set):
+                raise ValueError(f'Jurisdiction {jurisdiction["postalAbbreviation"]} in Compact {compact_abbr} '
+                                 f'has duplicate license type fees')
 
             # Check for unknown license types
-            unknown_license_types = set(defined_license_types) - set(license_type_abbreviations)
+            unknown_license_types = defined_license_types_set - compact_license_type_abbreviations
             if unknown_license_types:
                 raise ValueError(
-                    f'Jurisdiction {jurisdiction["postalAbbreviation"]} defines fees for unknown license types: '
-                    f'{", ".join(unknown_license_types)}'
+                    f'Jurisdiction {jurisdiction["postalAbbreviation"]} in Compact {compact_abbr} '
+                    f'defines fees for unknown license types: {", ".join(unknown_license_types)}'
                 )
         else:
             # Neither privilegeFees nor jurisdictionFee is defined

--- a/backend/compact-connect/stacks/persistent_stack/compact_configuration_upload.py
+++ b/backend/compact-connect/stacks/persistent_stack/compact_configuration_upload.py
@@ -188,7 +188,7 @@ class CompactConfigurationUpload(Construct):
                                 formatted_jurisdiction, environment_context
                             )
                             self._validate_jurisdiction_configuration(
-                                compact=compact_abbr,
+                                compact_abbr=compact_abbr,
                                 jurisdiction=formatted_jurisdiction,
                                 license_types_for_compact=stack.license_types[compact_abbr],
                             )
@@ -203,7 +203,7 @@ class CompactConfigurationUpload(Construct):
         return jurisdiction
 
     def _validate_jurisdiction_configuration(
-        self, compact: str, jurisdiction: dict, license_types_for_compact: list[dict]
+        self, compact_abbr: str, jurisdiction: dict, license_types_for_compact: list[dict]
     ):
         """Do some basic jurisdiction configuration validation to catch some easy mistakes early"""
         if not jurisdiction.get('jurisdictionOperationsTeamEmails', []):
@@ -220,7 +220,7 @@ class CompactConfigurationUpload(Construct):
 
             if missing_license_types:
                 raise ValueError(
-                    f'Jurisdiction {jurisdiction["postalAbbreviation"]} in Compact {compact["compactAbbr"]} '
+                    f'Jurisdiction {jurisdiction["postalAbbreviation"]} in Compact {compact_abbr} '
                     f'is missing license fees for the following license types: {", ".join(missing_license_types)}'
                 )
 
@@ -238,5 +238,5 @@ class CompactConfigurationUpload(Construct):
         else:
             # Neither privilegeFees nor jurisdictionFee is defined
             raise ValueError(
-                f'Jurisdiction {jurisdiction["postalAbbreviation"]} in compact {compact} must define privilegeFees'
+                f'Jurisdiction {jurisdiction["postalAbbreviation"]} in compact {compact_abbr} must define privilegeFees'
             )

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
@@ -221,6 +221,16 @@
         "jurisdictionName": "Ohio",
         "postalAbbreviation": "oh",
         "jurisdictionFee": 25,
+        "privilegeFees": [
+          {
+            "licenseTypeAbbreviation": "aud",
+            "amount": 25
+          },
+          {
+            "licenseTypeAbbreviation": "slp",
+            "amount": 25
+          }
+        ],
         "jurisdictionOperationsTeamEmails": [
           "gregg.thornton@shp.ohio.gov"
         ],
@@ -242,6 +252,16 @@
         "jurisdictionName": "Alabama",
         "postalAbbreviation": "al",
         "jurisdictionFee": 100,
+        "privilegeFees": [
+          {
+            "licenseTypeAbbreviation": "ot",
+            "amount": 100
+          },
+          {
+            "licenseTypeAbbreviation": "ota",
+            "amount": 100
+          }
+        ],
         "jurisdictionOperationsTeamEmails": [
           "cloud-team-nonprod-alerts@inspiringapps.com"
         ],
@@ -262,6 +282,16 @@
         "jurisdictionName": "Arkansas",
         "postalAbbreviation": "ar",
         "jurisdictionFee": 3,
+        "privilegeFees": [
+          {
+            "licenseTypeAbbreviation": "ot",
+            "amount": 3
+          },
+          {
+            "licenseTypeAbbreviation": "ota",
+            "amount": 3
+          }
+        ],
         "jurisdictionOperationsTeamEmails": [
           "ASMBOTOperations@armedicalboard.org"
         ],
@@ -281,6 +311,16 @@
         "jurisdictionName": "Louisiana",
         "postalAbbreviation": "la",
         "jurisdictionFee": 100,
+        "privilegeFees": [
+          {
+            "licenseTypeAbbreviation": "ot",
+            "amount": 100
+          },
+          {
+            "licenseTypeAbbreviation": "ota",
+            "amount": 100
+          }
+        ],
         "jurisdictionOperationsTeamEmails": [
           "cloud-team-nonprod-alerts@inspiringapps.com"
         ],
@@ -301,6 +341,16 @@
         "jurisdictionName": "Mississippi",
         "postalAbbreviation": "ms",
         "jurisdictionFee": 100,
+        "privilegeFees": [
+          {
+            "licenseTypeAbbreviation": "ot",
+            "amount": 100
+          },
+          {
+            "licenseTypeAbbreviation": "ota",
+            "amount": 100
+          }
+        ],
         "jurisdictionOperationsTeamEmails": [
           "cloud-team-nonprod-alerts@inspiringapps.com"
         ],
@@ -321,6 +371,16 @@
         "jurisdictionName": "Ohio",
         "postalAbbreviation": "oh",
         "jurisdictionFee": 100,
+        "privilegeFees": [
+          {
+            "licenseTypeAbbreviation": "ot",
+            "amount": 100
+          },
+          {
+            "licenseTypeAbbreviation": "ota",
+            "amount": 100
+          }
+        ],
         "militaryDiscount": {
           "active": true,
           "discountType": "FLAT_RATE",

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_OPTIONS_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_OPTIONS_RESPONSE_SCHEMA.json
@@ -161,7 +161,6 @@
               "type",
               "jurisdictionName",
               "postalAbbreviation",
-              "jurisdictionFee",
               "privilegeFees",
               "jurisprudenceRequirements"
             ],

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_OPTIONS_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_OPTIONS_RESPONSE_SCHEMA.json
@@ -100,6 +100,25 @@
                 "description": "The fee for the jurisdiction",
                 "type": "number"
               },
+              "privilegeFees": {
+                "description": "The fees for the privileges",
+                "items": {
+                  "properties": {
+                    "licenseTypeAbbreviation": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "licenseTypeAbbreviation",
+                    "amount"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "militaryDiscount": {
                 "properties": {
                   "active": {
@@ -143,6 +162,7 @@
               "jurisdictionName",
               "postalAbbreviation",
               "jurisdictionFee",
+              "privilegeFees",
               "jurisprudenceRequirements"
             ],
             "type": "object"

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -63,7 +63,13 @@ def test_purchase_privilege_options():
         'jurisdictionName': 'Kentucky',
         'postalAbbreviation': 'ky',
         'compact': 'aslp',
+        # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
         'jurisdictionFee': 100,
+        # Note: if these values are ever updated in the compact configuration, the test will need to be updated
+        'privilegeFees': [
+            {'licenseTypeAbbreviation': 'aud', 'amount': 100},
+            {'licenseTypeAbbreviation': 'slp', 'amount': 100},
+        ],
         'militaryDiscount': {'active': True, 'discountType': 'FLAT_RATE', 'discountAmount': 10},
         'jurisprudenceRequirements': {'required': True},
     }

--- a/backend/compact-connect/tests/smoke/smoke_tests_env_example.json
+++ b/backend/compact-connect/tests/smoke/smoke_tests_env_example.json
@@ -11,5 +11,6 @@
   "CC_TEST_COGNITO_PROVIDER_USER_POOL_ID": "us-east-1_12345",
   "CC_TEST_COGNITO_PROVIDER_USER_POOL_CLIENT_ID": "72612345",
   "CC_TEST_PROVIDER_USER_USERNAME": "example@example.com",
-  "CC_TEST_PROVIDER_USER_PASSWORD": "examplePassword"
+  "CC_TEST_PROVIDER_USER_PASSWORD": "examplePassword",
+  "ENVIRONMENT_NAME": "sandboxEnvironmentNamePlaceholder"
 }


### PR DESCRIPTION
several jurisdictions have reported that they set different
privilege fees based on the type of license for which the
privilege record is being purchased. This deprecates the old
jurisdictionFee field in place of a 'privilegeFees' field, which
is a list of objects defining the amount for every license type
supported by the compact.

### Testing List
- tests/test data updated to reference new schema

Closes #635 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for jurisdiction-specific privilege fees, allowing multiple license types with distinct fee amounts per jurisdiction.
  - Added new configuration fields for privilege fees across various jurisdictions and compacts.
  - Updated API responses and schemas to include detailed privilege fee information for each license type.

- **Bug Fixes**
  - Improved validation to ensure all required license types have corresponding privilege fees and to detect duplicates or unknown license types.

- **Refactor**
  - Deprecated the single jurisdiction fee field in favor of the new privilege fees structure.
  - Enhanced fee calculation logic to apply discounts and determine fees by license type.
  - Renamed license type properties for clarity and improved configuration validation.

- **Tests**
  - Updated test data and assertions to validate the new privilege fees structure and deprecation of the old fee field.
  - Improved test coverage for multiple license types and privilege fee scenarios.

- **Chores**
  - Added new environment variable to smoke test configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->