### PR TITLE
Add states to beta environment

### DIFF
--- a/backend/compact-connect/compact-config/aslp.yml
+++ b/backend/compact-connect/compact-config/aslp.yml
@@ -14,7 +14,7 @@ compactAdverseActionsNotificationEmails: []
 compactSummaryReportNotificationEmails: []
 licenseeRegistrationEnabledForEnvironments: ["test"]
 
-activeEnvironments: ["test"]
+activeEnvironments: ["test", "beta"]
 
 attestations:
   - attestationId: "jurisprudence-confirmation"

--- a/backend/compact-connect/compact-config/aslp/ohio.yml
+++ b/backend/compact-connect/compact-config/aslp/ohio.yml
@@ -10,4 +10,4 @@ jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: false
 licenseeRegistrationEnabledForEnvironments: []
-activeEnvironments: []
+activeEnvironments: ["beta"]

--- a/backend/compact-connect/compact-config/octp/alabama.yml
+++ b/backend/compact-connect/compact-config/octp/alabama.yml
@@ -9,4 +9,4 @@ jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: true
 licenseeRegistrationEnabledForEnvironments: ["test"]
-activeEnvironments: ["test"]
+activeEnvironments: ["test", "beta"]

--- a/backend/compact-connect/compact-config/octp/arkansas.yml
+++ b/backend/compact-connect/compact-config/octp/arkansas.yml
@@ -10,4 +10,5 @@ jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: false
 licenseeRegistrationEnabledForEnvironments: []
-activeEnvironments: []
+activeEnvironments: ["beta"]
+

--- a/backend/compact-connect/compact-config/octp/louisiana.yml
+++ b/backend/compact-connect/compact-config/octp/louisiana.yml
@@ -9,4 +9,4 @@ jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: true
 licenseeRegistrationEnabledForEnvironments: ["test"]
-activeEnvironments: ["test"]
+activeEnvironments: ["test", "beta"]

--- a/backend/compact-connect/compact-config/octp/mississippi.yml
+++ b/backend/compact-connect/compact-config/octp/mississippi.yml
@@ -9,4 +9,4 @@ jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: true
 licenseeRegistrationEnabledForEnvironments: ["test"]
-activeEnvironments: ["test"]
+activeEnvironments: ["test", "beta"]

--- a/backend/compact-connect/tests/app/test_pipeline.py
+++ b/backend/compact-connect/tests/app/test_pipeline.py
@@ -130,15 +130,15 @@ class TestBackendPipeline(TstAppABC, TestCase):
             overwrite_snapshot=overwrite_snapshot,
         )
 
-    def test_synth_generates_jurisdiction_resource_servers_with_expected_scopes_for_staff_users_test_stage(self):
+    def test_synth_generates_jurisdiction_resource_servers_with_expected_scopes_for_staff_users_beta_stage(self):
         """
         Test that the jurisdiction resource servers are created with the expected scopes
         for the staff users in the test environment.
         """
-        persistent_stack = self.app.test_backend_pipeline_stack.test_stage.persistent_stack
+        persistent_stack = self.app.beta_backend_pipeline_stack.beta_backend_stage.persistent_stack
         self._when_testing_jurisdiction_resource_servers(
             persistent_stack=persistent_stack,
-            snapshot_name='JURISDICTION_RESOURCE_SERVER_CONFIGURATION_TEST_ENV',
+            snapshot_name='JURISDICTION_RESOURCE_SERVER_CONFIGURATION_BETA_ENV',
             overwrite_snapshot=False,
         )
 
@@ -191,8 +191,8 @@ class TestBackendPipeline(TstAppABC, TestCase):
         )
         self.assertEqual(0, len(implicit_grant_clients))
 
-    def test_synth_generates_compact_configuration_upload_custom_resource_with_expected_test_configuration_data(self):
-        persistent_stack = self.app.test_backend_pipeline_stack.test_stage.persistent_stack
+    def test_synth_generates_compact_configuration_upload_custom_resource_with_expected_beta_configuration_data(self):
+        persistent_stack = self.app.beta_backend_pipeline_stack.beta_backend_stage.persistent_stack
         persistent_stack_template = Template.from_stack(persistent_stack)
 
         # Ensure our provider user pool is created with expected custom attributes
@@ -212,7 +212,7 @@ class TestBackendPipeline(TstAppABC, TestCase):
         # If the configuration values for any jurisdiction changes, the snapshot will need to be updated.
         self.compare_snapshot(
             actual=sorted_compact_configuration,
-            snapshot_name='COMPACT_CONFIGURATION_UPLOADER_TEST_ENV_INPUT',
+            snapshot_name='COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT',
             overwrite_snapshot=False,
         )
 

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
@@ -21,106 +21,8 @@
         "test"
       ],
       "activeEnvironments": [
-        "test"
-      ],
-      "attestations": [
-        {
-          "attestationId": "jurisprudence-confirmation",
-          "displayName": "Jurisprudence Confirmation.",
-          "description": "For displaying the jurisprudence confirmation.",
-          "text": "I understand that an attestation is a legally binding statement. I understand that providing false information on this application could result in a loss of my licenses and/or privileges. I acknowledge that the Commission may audit jurisprudence attestations at their discretion.",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "scope-of-practice-attestation",
-          "displayName": "Scope of Practice Attestation",
-          "description": "For displaying the scope of practice attestation.",
-          "text": "I hereby attest and affirm that I have reviewed, understand, and will abide by this state's scope of practice and all applicable laws and rules when practicing in the state. I understand that the issuance of a Compact Privilege authorizes me to legally practice in the member jurisdiction in accordance with the laws and rules governing practice of my profession in that jurisdiction.\n\nIf I violate the practice act, the appropriate board may take action against my Compact Privilege, which may result in the revocation of other Compact Privileges I may hold. I will also be prohibited from obtaining any other Compact Privileges for a period of at least two (2) years.",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "personal-information-home-state-attestation",
-          "displayName": "Personal Information Home State Attestation",
-          "description": "For declaring that the applicant is a resident of the state they have listed as their home state.",
-          "text": "I hereby attest and affirm that this is my personal and licensure information and that I am a resident of the state listed on this page.*",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "personal-information-address-attestation",
-          "displayName": "Personal Information Address Attestation",
-          "description": "For declaring that the applicant is a resident of the state they have listed as their home state.",
-          "text": "I hereby attest and affirm that the address information provided herein is my current address. I further consent to accept service of process at this address. I will notify the Commission and my former and new Home States of a change in my Home State address or email address. I understand that I am only eligible for a Compact Privilege if I am a licensee in my Home State as defined by the Compact. If I mislead the Compact Commission about my Home State, the appropriate board may take action against my License or Compact Privilege, which may result in the revocation of other Compact Privileges I may hold. I may also be prohibited from obtaining other Compact Privileges for a period of two years.",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "not-under-investigation-attestation",
-          "displayName": "Not Under Investigation Attestation",
-          "description": "For declaring that the applicant is not currently under investigation.",
-          "text": "I hereby attest and affirm that I am not currently under investigation by any board, agency, department, association, certifying body, or other body.",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "under-investigation-attestation",
-          "displayName": "Under Investigation Attestation",
-          "description": "For declaring that the applicant is currently under investigation.",
-          "text": "I hereby attest and affirm that I am currently under investigation by any board, agency, department, association, certifying body, or other body. I understand that if any investigation results in a disciplinary action, my Compact Privileges may be revoked.",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "discipline-no-current-encumbrance-attestation",
-          "displayName": "No Current Discipline Encumbrance Attestation",
-          "description": "For declaring that the applicant has no encumbrances on any state license.",
-          "text": "I hereby attest and affirm that I have no encumbrance (any discipline that restricts my full practice or any unmet condition before returning to a full and unrestricted license, including, but not limited, to probation, supervision, completion of a program, and/or completion of CEs) on ANY state license.",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "discipline-no-prior-encumbrance-attestation",
-          "displayName": "No Discipline Encumbrance For Prior Two Yeats Attestation",
-          "description": "For declaring that the applicant has no encumbrances on any state license within the last two years.",
-          "text": "I hereby attest and affirm that I have not had any encumbrance on ANY state license within the previous two years from date of this application for a Compact Privilege.",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "provision-of-true-information-attestation",
-          "displayName": "Provision of True Information Attestation",
-          "description": "For declaring that the applicant has provided true information.",
-          "text": "I hereby attest and affirm that all information contained in this privilege application is true to the best of my knowledge.",
-          "required": true,
-          "locale": "en"
-        },
-        {
-          "attestationId": "military-affiliation-confirmation-attestation",
-          "displayName": "Military Affiliation Confirmation Attestation",
-          "description": "For declaring that the applicant's military affiliation documentation is accurate.",
-          "text": "I hereby attest and affirm that my current military status documentation as uploaded to CompactConnect is accurate.",
-          "required": true,
-          "locale": "en"
-        }
-      ]
-    },
-    {
-      "compactAbbr": "coun",
-      "compactName": "Counseling",
-      "compactCommissionFee": {
-        "feeType": "FLAT_RATE",
-        "feeAmount": 3.5
-      },
-      "compactOperationsTeamEmails": [],
-      "compactAdverseActionsNotificationEmails": [],
-      "compactSummaryReportNotificationEmails": [],
-      "licenseeRegistrationEnabledForEnvironments": [
-        "test"
-      ],
-      "activeEnvironments": [
-        "test"
+        "test",
+        "beta"
       ],
       "attestations": [
         {
@@ -316,51 +218,22 @@
   "jurisdictions": {
     "aslp": [
       {
-        "jurisdictionName": "Kentucky",
-        "postalAbbreviation": "ky",
-        "jurisdictionFee": 100,
-        "militaryDiscount": {
-          "active": true,
-          "discountType": "FLAT_RATE",
-          "discountAmount": 10
-        },
+        "jurisdictionName": "Ohio",
+        "postalAbbreviation": "oh",
+        "jurisdictionFee": 25,
         "jurisdictionOperationsTeamEmails": [
-          "cloud-team-nonprod-alerts@inspiringapps.com"
+          "gregg.thornton@shp.ohio.gov"
         ],
-        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionAdverseActionsNotificationEmails": [
+          "gregg.thornton@shp.ohio.gov"
+        ],
         "jurisdictionSummaryReportNotificationEmails": [],
         "jurisprudenceRequirements": {
-          "required": true
+          "required": false
         },
-        "licenseeRegistrationEnabledForEnvironments": [
-          "test"
-        ],
+        "licenseeRegistrationEnabledForEnvironments": [],
         "activeEnvironments": [
-          "test"
-        ]
-      },
-      {
-        "jurisdictionName": "Nebraska",
-        "postalAbbreviation": "ne",
-        "jurisdictionFee": 100,
-        "militaryDiscount": {
-          "active": true,
-          "discountType": "FLAT_RATE",
-          "discountAmount": 10
-        },
-        "jurisdictionOperationsTeamEmails": [
-          "cloud-team-nonprod-alerts@inspiringapps.com"
-        ],
-        "jurisdictionAdverseActionsNotificationEmails": [],
-        "jurisdictionSummaryReportNotificationEmails": [],
-        "jurisprudenceRequirements": {
-          "required": true
-        },
-        "licenseeRegistrationEnabledForEnvironments": [
-          "test"
-        ],
-        "activeEnvironments": [
-          "test"
+          "beta"
         ]
       }
     ],
@@ -381,31 +254,27 @@
           "test"
         ],
         "activeEnvironments": [
-          "test"
+          "test",
+          "beta"
         ]
       },
       {
-        "jurisdictionName": "Kentucky",
-        "postalAbbreviation": "ky",
-        "jurisdictionFee": 100,
-        "militaryDiscount": {
-          "active": true,
-          "discountType": "FLAT_RATE",
-          "discountAmount": 10
-        },
+        "jurisdictionName": "Arkansas",
+        "postalAbbreviation": "ar",
+        "jurisdictionFee": 3,
         "jurisdictionOperationsTeamEmails": [
-          "cloud-team-nonprod-alerts@inspiringapps.com"
+          "ASMBOTOperations@armedicalboard.org"
         ],
-        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionAdverseActionsNotificationEmails": [
+          "ASMBOTAdverseActions@armedicalboard.org"
+        ],
         "jurisdictionSummaryReportNotificationEmails": [],
         "jurisprudenceRequirements": {
-          "required": true
+          "required": false
         },
-        "licenseeRegistrationEnabledForEnvironments": [
-          "test"
-        ],
+        "licenseeRegistrationEnabledForEnvironments": [],
         "activeEnvironments": [
-          "test"
+          "beta"
         ]
       },
       {
@@ -424,7 +293,8 @@
           "test"
         ],
         "activeEnvironments": [
-          "test"
+          "test",
+          "beta"
         ]
       },
       {
@@ -443,31 +313,8 @@
           "test"
         ],
         "activeEnvironments": [
-          "test"
-        ]
-      },
-      {
-        "jurisdictionName": "Nebraska",
-        "postalAbbreviation": "ne",
-        "jurisdictionFee": 100,
-        "militaryDiscount": {
-          "active": true,
-          "discountType": "FLAT_RATE",
-          "discountAmount": 10
-        },
-        "jurisdictionOperationsTeamEmails": [
-          "cloud-team-nonprod-alerts@inspiringapps.com"
-        ],
-        "jurisdictionAdverseActionsNotificationEmails": [],
-        "jurisdictionSummaryReportNotificationEmails": [],
-        "jurisprudenceRequirements": {
-          "required": true
-        },
-        "licenseeRegistrationEnabledForEnvironments": [
-          "test"
-        ],
-        "activeEnvironments": [
-          "test"
+          "test",
+          "beta"
         ]
       },
       {
@@ -493,99 +340,6 @@
         "activeEnvironments": [
           "test",
           "beta"
-        ]
-      }
-    ],
-    "coun": [
-      {
-        "jurisdictionName": "Florida",
-        "postalAbbreviation": "fl",
-        "jurisdictionFee": 15,
-        "jurisdictionOperationsTeamEmails": [
-          "cloud-team-nonprod-alerts@inspiringapps.com"
-        ],
-        "jurisdictionAdverseActionsNotificationEmails": [],
-        "jurisdictionSummaryReportNotificationEmails": [],
-        "jurisprudenceRequirements": {
-          "required": false
-        },
-        "licenseeRegistrationEnabledForEnvironments": [
-          "test"
-        ],
-        "activeEnvironments": [
-          "test"
-        ]
-      },
-      {
-        "jurisdictionName": "Kentucky",
-        "postalAbbreviation": "ky",
-        "jurisdictionFee": 100,
-        "militaryDiscount": {
-          "active": true,
-          "discountType": "FLAT_RATE",
-          "discountAmount": 10
-        },
-        "jurisdictionOperationsTeamEmails": [
-          "cloud-team-nonprod-alerts@inspiringapps.com"
-        ],
-        "jurisdictionAdverseActionsNotificationEmails": [],
-        "jurisdictionSummaryReportNotificationEmails": [],
-        "jurisprudenceRequirements": {
-          "required": true
-        },
-        "licenseeRegistrationEnabledForEnvironments": [
-          "test"
-        ],
-        "activeEnvironments": [
-          "test"
-        ]
-      },
-      {
-        "jurisdictionName": "Nebraska",
-        "postalAbbreviation": "ne",
-        "jurisdictionFee": 100,
-        "militaryDiscount": {
-          "active": true,
-          "discountType": "FLAT_RATE",
-          "discountAmount": 10
-        },
-        "jurisdictionOperationsTeamEmails": [
-          "cloud-team-nonprod-alerts@inspiringapps.com"
-        ],
-        "jurisdictionAdverseActionsNotificationEmails": [],
-        "jurisdictionSummaryReportNotificationEmails": [],
-        "jurisprudenceRequirements": {
-          "required": true
-        },
-        "licenseeRegistrationEnabledForEnvironments": [
-          "test"
-        ],
-        "activeEnvironments": [
-          "test"
-        ]
-      },
-      {
-        "jurisdictionName": "Ohio",
-        "postalAbbreviation": "oh",
-        "jurisdictionFee": 100,
-        "militaryDiscount": {
-          "active": true,
-          "discountType": "FLAT_RATE",
-          "discountAmount": 10
-        },
-        "jurisdictionOperationsTeamEmails": [
-          "cloud-team-nonprod-alerts@inspiringapps.com"
-        ],
-        "jurisdictionAdverseActionsNotificationEmails": [],
-        "jurisdictionSummaryReportNotificationEmails": [],
-        "jurisprudenceRequirements": {
-          "required": true
-        },
-        "licenseeRegistrationEnabledForEnvironments": [
-          "test"
-        ],
-        "activeEnvironments": [
-          "test"
         ]
       }
     ]

--- a/backend/compact-connect/tests/resources/snapshots/JURISDICTION_RESOURCE_SERVER_CONFIGURATION_BETA_ENV.json
+++ b/backend/compact-connect/tests/resources/snapshots/JURISDICTION_RESOURCE_SERVER_CONFIGURATION_BETA_ENV.json
@@ -22,63 +22,9 @@
     ]
   },
   {
-    "Identifier": "fl",
-    "Name": "fl",
+    "Identifier": "ar",
+    "Name": "ar",
     "Scopes": [
-      {
-        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
-        "ScopeName": "coun.admin"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
-        "ScopeName": "coun.readPrivate"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
-        "ScopeName": "coun.readSSN"
-      },
-      {
-        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
-        "ScopeName": "coun.write"
-      }
-    ]
-  },
-  {
-    "Identifier": "ky",
-    "Name": "ky",
-    "Scopes": [
-      {
-        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
-        "ScopeName": "aslp.admin"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
-        "ScopeName": "aslp.readPrivate"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
-        "ScopeName": "aslp.readSSN"
-      },
-      {
-        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
-        "ScopeName": "aslp.write"
-      },
-      {
-        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
-        "ScopeName": "coun.admin"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
-        "ScopeName": "coun.readPrivate"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
-        "ScopeName": "coun.readSSN"
-      },
-      {
-        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
-        "ScopeName": "coun.write"
-      },
       {
         "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
         "ScopeName": "octp.admin"
@@ -142,8 +88,8 @@
     ]
   },
   {
-    "Identifier": "ne",
-    "Name": "ne",
+    "Identifier": "oh",
+    "Name": "oh",
     "Scopes": [
       {
         "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
@@ -160,60 +106,6 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
-      },
-      {
-        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
-        "ScopeName": "coun.admin"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
-        "ScopeName": "coun.readPrivate"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
-        "ScopeName": "coun.readSSN"
-      },
-      {
-        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
-        "ScopeName": "coun.write"
-      },
-      {
-        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
-        "ScopeName": "octp.admin"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
-        "ScopeName": "octp.readPrivate"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
-        "ScopeName": "octp.readSSN"
-      },
-      {
-        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
-        "ScopeName": "octp.write"
-      }
-    ]
-  },
-  {
-    "Identifier": "oh",
-    "Name": "oh",
-    "Scopes": [
-      {
-        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
-        "ScopeName": "coun.admin"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
-        "ScopeName": "coun.readPrivate"
-      },
-      {
-        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
-        "ScopeName": "coun.readSSN"
-      },
-      {
-        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
-        "ScopeName": "coun.write"
       },
       {
         "ScopeDescription": "Admin access for the octp compact within the jurisdiction",


### PR DESCRIPTION
These states are scheduled to test the license upload API in the beta environment.
This adds them to the beta environment so that when the change is merged into the
main branch the infrastructure will be put in place to allow us to create app clients for them.

Now that we are frequently making config changes to jurisdictions,
the test environment snapshots for the compact config are causing more friction than
benefit. Beta and Prod are better candidates for snapshot tests, as they change less
frequently and we care more about the compacts/jurisdictions we are letting into
those environments. This replaces the test env snapshots with beta env snapshots
for tracking compact config.

This is a precursor to #708, #744, #706, #707, and #709


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration settings for Ohio and Arkansas jurisdictions to include the "beta" environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->