### PR TITLE
fix/Prevent sandbox UI without domain name

### DIFF
--- a/backend/compact-connect/README.md
+++ b/backend/compact-connect/README.md
@@ -143,7 +143,7 @@ its environment:
 7) Complete the [Google reCAPTCHA Setup](#google-recaptcha-setup) steps for your sandbox environment.
 8) Run `cdk bootstrap` to add some base CDK support infrastructure to your AWS account.
 9) Run `cdk deploy 'Sandbox/*'` to get the initial backend stack resources deployed.
-10) *Optional:* Once the backend stacks have successfully deployed, deploy the frontend UI by setting the 'deploy_sandbox_ui' context field to `true` and run `cdk deploy 'SandboxUI/*'`
+10) *Optional:* If you have a domain name configured for your sandbox environment, once the backend stacks have successfully deployed, you can deploy the frontend UI by setting the 'deploy_sandbox_ui' context field to `true` and run `cdk deploy 'SandboxUI/*'`. If you do not have a domain name configured, you can still run the UI from local host (see the README.md under the webroot folder for more information about running the app on localhost).
 
 ### Subsequent sandbox deploys:
 For any future deploys, everything is set up so a simple `cdk deploy 'Sandbox/*'` should update all your infrastructure

--- a/backend/compact-connect/app.py
+++ b/backend/compact-connect/app.py
@@ -86,10 +86,18 @@ class CompactConnectApp(App):
             environment_context=environment_context,
         )
         # NOTE: for first-time sandbox deployments, ensure you deploy the backend stage successfully first
-        # by running `cdk deploy 'Sandbox/*'`, then if you want to deploy the UI for your sandbox environment, set
-        # the 'deploy_sandbox_ui' field to true and deploy this stack by running `cdk deploy 'SandboxUI/*'. This
-        # ensures the user pool values are configured to be bundled with the UI build artifact.
+        # by running `cdk deploy 'Sandbox/*'`, then if you have a domain name configured and want to deploy the UI for
+        # your sandbox environment, set the 'deploy_sandbox_ui' field to true and deploy this stack by running
+        # `cdk deploy 'SandboxUI/*'. This ensures the user pool values are configured to be bundled with the UI build
+        # artifact.
         if environment_context.get('deploy_sandbox_ui', False):
+            if not environment_context.get('domain_name'):
+                raise ValueError(
+                    'Cannot deploy sandbox UI if domain name is not configured for your environment. '
+                    'You may still run the app from localhost. See README.md in the webroot folder for '
+                    'more information about running the app from localhost.'
+                )
+
             self.sandbox_frontend_stage = FrontendStage(
                 self,
                 'SandboxUI',


### PR DESCRIPTION
If a developer wants to test the UI deployments in their sandbox environment, they must have a domain name configured. This adds the needed check to prevent developers from deploying the UI stack if they are missing a domain name field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified deployment instructions for the sandbox UI, including guidance for running locally when no domain name is configured.

- **Bug Fixes**
  - Added a check to prevent deployment of the sandbox UI without a configured domain name, providing a clear error message and alternative instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->