### PR TITLE
set nodejs version used by CDK pipeline

### DIFF
--- a/backend/compact-connect/pipeline/backend_pipeline.py
+++ b/backend/compact-connect/pipeline/backend_pipeline.py
@@ -99,7 +99,13 @@ class BackendPipeline(CdkCodePipeline):
             ),
             synth_code_build_defaults=CodeBuildOptions(
                 partial_build_spec=BuildSpec.from_object(
-                    {'phases': {'install': {'runtime-versions': {'python': '3.12'}}}},
+                    {
+                        'phases': {
+                            'install': {
+                                'runtime-versions': {'python': '3.12', 'nodejs': '22.x'},
+                            }
+                        }
+                    }
                 ),
             ),
             cross_account_keys=True,

--- a/backend/compact-connect/pipeline/frontend_pipeline.py
+++ b/backend/compact-connect/pipeline/frontend_pipeline.py
@@ -105,7 +105,13 @@ class FrontendPipeline(CdkCodePipeline):
             ),
             synth_code_build_defaults=CodeBuildOptions(
                 partial_build_spec=BuildSpec.from_object(
-                    {'phases': {'install': {'runtime-versions': {'python': '3.12'}}}},
+                    {
+                        'phases': {
+                            'install': {
+                                'runtime-versions': {'python': '3.12', 'nodejs': '22.x'},
+                            }
+                        }
+                    }
                 ),
             ),
             cross_account_keys=True,


### PR DESCRIPTION
The Docker image that is used to build the project uses Node version 18 by default, which will reach end-of-life support on 2025-04-30. 

```
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
--
106 | b'!!                                                                                                                  !!\n'
107 | b'!!  Node 18 is approaching end-of-life and will no longer be supported in new releases after 2025-04-30.            !!\n'
108 | b'!!  Please upgrade to a supported node version as soon as possible.                                                 !!\n'
109 | b'!!                                                                                                                  !!\n'
110 | b'!!  This software is currently running on node v18.20.6.                                                            !!\n'
111 | b'!!  As of the current release of this software, supported node releases are:                                        !!\n'
112 | b'!!  - ^22.0.0 (Planned end-of-life: 2027-04-30)                                                                     !!\n'
113 | b'!!  - ^20.0.0 (Planned end-of-life: 2026-04-30)                                                                     !!\n'
114 | b'!!  - ^18.0.0 (Planned end-of-life: 2025-04-30) [DEPRECATED]                                                        !!\n'
115 | b'!!                                                                                                                  !!\n'
116 | b'!!  This warning can be silenced by setting the JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION environment variable.  !!\n'
117 | b'!!                                                                                                                  !!\n'
118 | b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
```

This updates the CodeBuild buildspec configuration to install Node version 22

### Testing List
- Verified pipeline synth in test environment

Closes #750 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build environment to include both Python 3.12 and Node.js 22.x during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->