### PR TITLE
Chore/remove deprecated jurisdiction fee field

### DIFF
--- a/backend/compact-connect/compact-config/aslp/kentucky.yml
+++ b/backend/compact-connect/compact-config/aslp/kentucky.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "aud"
     amount: 100

--- a/backend/compact-connect/compact-config/aslp/nebraska.yml
+++ b/backend/compact-connect/compact-config/aslp/nebraska.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "aud"
     amount: 100

--- a/backend/compact-connect/compact-config/aslp/ohio.yml
+++ b/backend/compact-connect/compact-config/aslp/ohio.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 25
 privilegeFees:
   - licenseTypeAbbreviation: "aud"
     amount: 25

--- a/backend/compact-connect/compact-config/coun/arkansas.yml
+++ b/backend/compact-connect/compact-config/coun/arkansas.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Arkansas"
 postalAbbreviation: "ar"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 3
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"
     amount: 3

--- a/backend/compact-connect/compact-config/coun/florida.yml
+++ b/backend/compact-connect/compact-config/coun/florida.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Florida"
 postalAbbreviation: "fl"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 15
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"
     amount: 15

--- a/backend/compact-connect/compact-config/coun/kentucky.yml
+++ b/backend/compact-connect/compact-config/coun/kentucky.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"
     amount: 100

--- a/backend/compact-connect/compact-config/coun/nebraska.yml
+++ b/backend/compact-connect/compact-config/coun/nebraska.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"
     amount: 100

--- a/backend/compact-connect/compact-config/coun/ohio.yml
+++ b/backend/compact-connect/compact-config/coun/ohio.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "lpc"
     amount: 100

--- a/backend/compact-connect/compact-config/octp/alabama.yml
+++ b/backend/compact-connect/compact-config/octp/alabama.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Alabama"
 postalAbbreviation: "al"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"
     amount: 100

--- a/backend/compact-connect/compact-config/octp/arkansas.yml
+++ b/backend/compact-connect/compact-config/octp/arkansas.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Arkansas"
 postalAbbreviation: "ar"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 3
 privilegeFees:
   - licenseTypeAbbreviation: "ot"
     amount: 3

--- a/backend/compact-connect/compact-config/octp/kentucky.yml
+++ b/backend/compact-connect/compact-config/octp/kentucky.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Kentucky"
 postalAbbreviation: "ky"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"
     amount: 100

--- a/backend/compact-connect/compact-config/octp/louisiana.yml
+++ b/backend/compact-connect/compact-config/octp/louisiana.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Louisiana"
 postalAbbreviation: "la"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"
     amount: 100

--- a/backend/compact-connect/compact-config/octp/mississippi.yml
+++ b/backend/compact-connect/compact-config/octp/mississippi.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Mississippi"
 postalAbbreviation: "ms"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"
     amount: 100

--- a/backend/compact-connect/compact-config/octp/nebraska.yml
+++ b/backend/compact-connect/compact-config/octp/nebraska.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Nebraska"
 postalAbbreviation: "ne"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"
     amount: 100

--- a/backend/compact-connect/compact-config/octp/ohio.yml
+++ b/backend/compact-connect/compact-config/octp/ohio.yml
@@ -1,8 +1,6 @@
 # PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
 jurisdictionName: "Ohio"
 postalAbbreviation: "oh"
-# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-jurisdictionFee: 100
 privilegeFees:
   - licenseTypeAbbreviation: "ot"
     amount: 100

--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -4410,7 +4410,6 @@
                 },
                 {
                   "required": [
-                    "jurisdictionFee",
                     "jurisdictionName",
                     "jurisprudenceRequirements",
                     "postalAbbreviation",
@@ -4482,10 +4481,6 @@
                     "jurisdictionName": {
                       "type": "string",
                       "description": "The name of the jurisdiction"
-                    },
-                    "jurisdictionFee": {
-                      "type": "number",
-                      "description": "The fee for the jurisdiction"
                     },
                     "type": {
                       "type": "string",

--- a/backend/compact-connect/lambdas/nodejs/tests/lib/jurisdiction-client.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lib/jurisdiction-client.test.ts
@@ -23,10 +23,6 @@ const SAMPLE_JURISDICTION_ITEMS = [
         'jurisdictionAdverseActionsNotificationEmails': {
             'L': []
         },
-        // deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-        'jurisdictionFee': {
-            'N': '100'
-        },
         'privilegeFees': {
             'L': [
                 {
@@ -106,10 +102,6 @@ const SAMPLE_JURISDICTION_ITEMS = [
         },
         'jurisdictionAdverseActionsNotificationEmails': {
             'L': []
-        },
-        // deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-        'jurisdictionFee': {
-            'N': '100'
         },
         'privilegeFees': {
             'L': [

--- a/backend/compact-connect/lambdas/nodejs/tests/sample-records.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/sample-records.ts
@@ -245,10 +245,6 @@ export const SAMPLE_JURISDICTION_CONFIGURATION = {
     'jurisdictionAdverseActionsNotificationEmails': {
         'L': []
     },
-    // deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-    'jurisdictionFee': {
-        'N': '100'
-    },
     'privilegeFees': {
         'L': [
             {
@@ -320,8 +316,6 @@ export const SAMPLE_UNMARSHALLED_JURISDICTION_CONFIGURATION = {
     'compact': 'aslp',
     'dateOfUpdate': '2024-11-14',
     'jurisdictionAdverseActionsNotificationEmails': [],
-    // deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-    'jurisdictionFee': '100',
     'privilegeFees': [
         {
             'licenseTypeAbbreviation': 'aud',

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/__init__.py
@@ -74,12 +74,6 @@ class Jurisdiction(UserDict):
     def compact(self) -> str:
         return self['compact']
 
-    # Deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-    # use privilege_fees instead
-    @property
-    def jurisdiction_fee(self) -> Decimal:
-        return self['jurisdictionFee']
-
     @property
     def privilege_fees(self) -> list[JurisdictionPrivilegeFee]:
         return [JurisdictionPrivilegeFee(fee) for fee in self.data['privilegeFees']]

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/api.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/api.py
@@ -40,9 +40,6 @@ class JurisdictionOptionsResponseSchema(ForgivingSchema):
     jurisprudenceRequirements = Nested(
         JurisdictionJurisprudenceRequirementsResponseSchema(), required=True, allow_none=False
     )
-    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-    jurisdictionFee = Decimal(required=False, allow_none=False)
-
 
 class CompactJurisdictionsStaffUsersResponseSchema(ForgivingSchema):
     """

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
@@ -24,7 +24,6 @@ class JurisdictionPrivilegeFeeRecordSchema(Schema):
     licenseTypeAbbreviation = String(required=True, allow_none=False)
     amount = Decimal(required=True, allow_none=False, places=2)
 
-
 @BaseRecordSchema.register_schema(JURISDICTION_TYPE)
 class JurisdictionRecordSchema(BaseRecordSchema):
     """Schema for the root jurisdiction configuration records"""
@@ -58,8 +57,6 @@ class JurisdictionRecordSchema(BaseRecordSchema):
     jurisprudenceRequirements = Nested(
         JurisdictionJurisprudenceRequirementsRecordSchema(), required=True, allow_none=False
     )
-    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-    jurisdictionFee = Decimal(required=False, allow_none=False, places=2)
 
     # Generated fields
     pk = String(required=True, allow_none=False)

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/jurisdiction/record.py
@@ -24,6 +24,7 @@ class JurisdictionPrivilegeFeeRecordSchema(Schema):
     licenseTypeAbbreviation = String(required=True, allow_none=False)
     amount = Decimal(required=True, allow_none=False, places=2)
 
+
 @BaseRecordSchema.register_schema(JURISDICTION_TYPE)
 class JurisdictionRecordSchema(BaseRecordSchema):
     """Schema for the root jurisdiction configuration records"""

--- a/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/jurisdiction.json
+++ b/backend/compact-connect/lambdas/python/common/tests/resources/dynamo/jurisdiction.json
@@ -5,7 +5,6 @@
   "compact": "aslp",
   "jurisdictionName": "ohio",
   "postalAbbreviation": "oh",
-  "jurisdictionFee": 100,
   "privilegeFees": [
     {
       "licenseTypeAbbreviation": "aud",

--- a/backend/compact-connect/lambdas/python/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
+++ b/backend/compact-connect/lambdas/python/custom-resources/tests/function/test_handlers/test_compact_configuration_uploader.py
@@ -53,8 +53,6 @@ def generate_single_jurisdiction_config(
     return {
         'jurisdictionName': jurisdiction_name,
         'postalAbbreviation': postal_abbreviation,
-        # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-        'jurisdictionFee': 100,
         'privilegeFees': privilege_fees,
         'militaryDiscount': {'active': True, 'discountType': 'FLAT_RATE', 'discountAmount': 10},
         'jurisdictionOperationsTeamEmails': ['cloud-team@example.com'],
@@ -137,8 +135,6 @@ class TestCompactConfigurationUploader(TstFunction):
                     'compact': ASLP_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-                    'jurisdictionFee': Decimal('100.00'),
                     'privilegeFees': [
                         {'licenseTypeAbbreviation': 'aud', 'amount': Decimal('100.00')},
                         {'licenseTypeAbbreviation': 'slp', 'amount': Decimal('100.00')},
@@ -162,8 +158,6 @@ class TestCompactConfigurationUploader(TstFunction):
                     'compact': ASLP_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-                    'jurisdictionFee': Decimal('100.00'),
                     'privilegeFees': [
                         {'licenseTypeAbbreviation': 'aud', 'amount': Decimal('100.00')},
                         {'licenseTypeAbbreviation': 'slp', 'amount': Decimal('100.00')},
@@ -199,8 +193,6 @@ class TestCompactConfigurationUploader(TstFunction):
                     'compact': OT_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-                    'jurisdictionFee': Decimal('100.00'),
                     'privilegeFees': [
                         {'licenseTypeAbbreviation': 'ot', 'amount': Decimal('100.00')},
                         {'licenseTypeAbbreviation': 'ota', 'amount': Decimal('100.00')},
@@ -224,8 +216,6 @@ class TestCompactConfigurationUploader(TstFunction):
                     'compact': OT_COMPACT_ABBREVIATION,
                     'dateOfUpdate': MOCK_CURRENT_TIMESTAMP,
                     'jurisdictionAdverseActionsNotificationEmails': [],
-                    # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-                    'jurisdictionFee': Decimal('100.00'),
                     'privilegeFees': [
                         {'licenseTypeAbbreviation': 'ot', 'amount': Decimal('100.00')},
                         {'licenseTypeAbbreviation': 'ota', 'amount': Decimal('100.00')},

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -829,11 +829,6 @@ class ApiModel:
                             type=JsonSchemaType.STRING,
                             description='The postal abbreviation of the jurisdiction',
                         ),
-                        # deprecated - to be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-                        'jurisdictionFee': JsonSchema(
-                            type=JsonSchemaType.NUMBER,
-                            description='The fee for the jurisdiction',
-                        ),
                         'privilegeFees': JsonSchema(
                             type=JsonSchemaType.ARRAY,
                             description='The fees for the privileges',

--- a/backend/compact-connect/stacks/persistent_stack/compact_configuration_upload.py
+++ b/backend/compact-connect/stacks/persistent_stack/compact_configuration_upload.py
@@ -237,7 +237,7 @@ class CompactConfigurationUpload(Construct):
                     f'defines fees for unknown license types: {", ".join(unknown_license_types)}'
                 )
         else:
-            # Neither privilegeFees nor jurisdictionFee is defined
+            # privilegeFees is not defined
             raise ValueError(
                 f'Jurisdiction {jurisdiction["postalAbbreviation"]} in compact {compact_abbr} must define privilegeFees'
             )

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
@@ -320,7 +320,6 @@
       {
         "jurisdictionName": "Ohio",
         "postalAbbreviation": "oh",
-        "jurisdictionFee": 25,
         "privilegeFees": [
           {
             "licenseTypeAbbreviation": "aud",
@@ -351,7 +350,6 @@
       {
         "jurisdictionName": "Alabama",
         "postalAbbreviation": "al",
-        "jurisdictionFee": 100,
         "privilegeFees": [
           {
             "licenseTypeAbbreviation": "ot",
@@ -381,7 +379,6 @@
       {
         "jurisdictionName": "Arkansas",
         "postalAbbreviation": "ar",
-        "jurisdictionFee": 3,
         "privilegeFees": [
           {
             "licenseTypeAbbreviation": "ot",
@@ -410,7 +407,6 @@
       {
         "jurisdictionName": "Louisiana",
         "postalAbbreviation": "la",
-        "jurisdictionFee": 100,
         "privilegeFees": [
           {
             "licenseTypeAbbreviation": "ot",
@@ -440,7 +436,6 @@
       {
         "jurisdictionName": "Mississippi",
         "postalAbbreviation": "ms",
-        "jurisdictionFee": 100,
         "privilegeFees": [
           {
             "licenseTypeAbbreviation": "ot",
@@ -470,7 +465,6 @@
       {
         "jurisdictionName": "Ohio",
         "postalAbbreviation": "oh",
-        "jurisdictionFee": 100,
         "privilegeFees": [
           {
             "licenseTypeAbbreviation": "ot",

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
@@ -137,7 +137,7 @@
           "attestationId": "scope-of-practice-attestation",
           "displayName": "Scope of Practice Attestation",
           "description": "For displaying the scope of practice attestation.",
-          "text": "I hereby attest and affirm that I have reviewed, understand, and will abide by this state's scope of practice and all applicable laws and rules when practicing in the state. I understand that the issuance of a Compact Privilege authorizes me to legally practice in the member jurisdiction in accordance with the laws and rules governing practice of my profession in that jurisdiction.\n\nIf I violate the practice act, the appropriate board may take action against my Compact Privilege, which may result in the revocation of other Compact Privileges I may hold. I will also be prohibited from obtaining any other Compact Privileges for a period of at least two (2) years.",
+          "text": "I hereby attest and affirm that I have reviewed, understand, and will abide by this state's scope of practice and all applicable laws and rules when practicing in the state. I understand that the issuance of a Compact Privilege authorizes me to legally practice in the member jurisdiction in accordance with the laws and rules governing practice of my profession in that jurisdiction.\n\nIf I violate the practice act, the appropriate board may take action against my Compact Privilege, which may result in the revocation of other Compact Privileges or licenses I may hold. I will also be prohibited from obtaining any other Compact Privileges for a period of at least two (2) years.",
           "required": true,
           "locale": "en"
         },
@@ -501,7 +501,6 @@
       {
         "jurisdictionName": "Arkansas",
         "postalAbbreviation": "ar",
-        "jurisdictionFee": 3,
         "privilegeFees": [
           {
             "licenseTypeAbbreviation": "lpc",

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_OPTIONS_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_OPTIONS_RESPONSE_SCHEMA.json
@@ -96,10 +96,6 @@
                 "description": "The postal abbreviation of the jurisdiction",
                 "type": "string"
               },
-              "jurisdictionFee": {
-                "description": "The fee for the jurisdiction",
-                "type": "number"
-              },
               "privilegeFees": {
                 "description": "The fees for the privileges",
                 "items": {

--- a/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/purchasing_privileges_smoke_tests.py
@@ -63,8 +63,6 @@ def test_purchase_privilege_options():
         'jurisdictionName': 'Kentucky',
         'postalAbbreviation': 'ky',
         'compact': 'aslp',
-        # deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
-        'jurisdictionFee': 100,
         # Note: if these values are ever updated in the compact configuration, the test will need to be updated
         'privilegeFees': [
             {'licenseTypeAbbreviation': 'aud', 'amount': 100},


### PR DESCRIPTION
This branch removes a deprecated field and is to be merged into the frontend changes associated with this ticket: #636 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the deprecated "jurisdictionFee" field from all jurisdiction configurations, API schemas, and documentation.
  - Updated comments and internal references to reflect the removal of the deprecated field.
  - Cleaned up related configuration snapshots and static JSON data.

- **Tests**
  - Updated test fixtures, sample records, and expected results to exclude the "jurisdictionFee" field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->