### PR TITLE
Handle JSON Decoder errors

### DIFF
--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider/api.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/schema/provider/api.py
@@ -1,4 +1,5 @@
 # ruff: noqa: N801, N815, ARG002  invalid-name unused-argument
+from marshmallow import Schema
 from marshmallow.fields import Date, Email, List, Nested, Raw, String
 from marshmallow.validate import Length, Regexp
 
@@ -115,7 +116,8 @@ class ProviderPublicResponseSchema(ForgivingSchema):
     privileges = List(Nested(PrivilegePublicResponseSchema(), required=False, allow_none=False))
 
 
-class ProviderRegistrationRequestSchema(ForgivingSchema):
+# We set this to a strict schema, to avoid extra values from entering the system.
+class ProviderRegistrationRequestSchema(Schema):
     """
     Schema for provider registration requests.
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/exceptions.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/exceptions.py
@@ -20,6 +20,10 @@ class CCNotFoundException(CCInvalidRequestException):
     """Requested resource is not found, corresponds to a 404 response"""
 
 
+class CCUnsupportedMediaTypeException(CCInvalidRequestException):
+    """Unsupported media type, corresponds to a 415 response"""
+
+
 class CCRateLimitingException(CCInvalidRequestException):
     """Client is rate limited, corresponds to a 429 response"""
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -153,6 +153,13 @@ def api_handler(fn: Callable):
                     'statusCode': 400,
                     'body': json.dumps({'message': e.message}),
                 }
+            except json.JSONDecodeError as e:
+                logger.warning('Invalid JSON in request body', exc_info=e)
+                return {
+                    'headers': {'Access-Control-Allow-Origin': cors_origin, 'Vary': 'Origin'},
+                    'statusCode': 400,
+                    'body': json.dumps({'message': 'Invalid request: Malformed JSON'}),
+                }
             except ClientError as e:
                 # Any boto3 ClientErrors we haven't already caught and transformed are probably on us
                 logger.error('boto3 ClientError', response=e.response, exc_info=e)

--- a/backend/compact-connect/lambdas/python/common/tests/resources/api-event.json
+++ b/backend/compact-connect/lambdas/python/common/tests/resources/api-event.json
@@ -7,6 +7,7 @@
         "Accept-Encoding": "gzip, deflate, br",
         "Authorization": "Bearer eyfoofoo",
         "Cache-Control": "no-cache",
+        "Content-Type": "application/json",
         "CloudFront-Forwarded-Proto": "https",
         "CloudFront-Is-Desktop-Viewer": "true",
         "CloudFront-Is-Mobile-Viewer": "false",

--- a/backend/compact-connect/lambdas/python/common/tests/unit/test_api_handler.py
+++ b/backend/compact-connect/lambdas/python/common/tests/unit/test_api_handler.py
@@ -144,3 +144,36 @@ class TestApiHandler(TstLambdas):
         resp = lambda_handler(event, self.mock_context)
         self.assertEqual(200, resp['statusCode'])
         self.assertEqual('https://example.org', resp['headers']['Access-Control-Allow-Origin'])
+
+    def test_unsupported_media_type(self):
+        from cc_common.utils import api_handler
+
+        @api_handler
+        def lambda_handler(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
+            return {'message': 'OK'}
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # We only accept json
+        event['headers']['Content-Type'] = 'text/plain'
+        event['body'] = 'not json'
+
+        resp = lambda_handler(event, self.mock_context)
+        self.assertEqual(415, resp['statusCode'])
+
+    def test_json_decode_error(self):
+        from cc_common.utils import api_handler
+
+        @api_handler
+        def lambda_handler(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
+            return json.loads(event['body'])
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        event['headers']['Content-Type'] = 'application/json'
+        event['body'] = 'not json'
+
+        resp = lambda_handler(event, self.mock_context)
+        self.assertEqual(400, resp['statusCode'])

--- a/backend/compact-connect/lambdas/python/staff-users/tests/resources/api-event.json
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/resources/api-event.json
@@ -7,6 +7,7 @@
         "Accept-Encoding": "gzip, deflate, br",
         "Authorization": "Bearer eyfoofoo",
         "Cache-Control": "no-cache",
+        "Content-Type": "application/json",
         "CloudFront-Forwarded-Proto": "https",
         "CloudFront-Is-Desktop-Viewer": "true",
         "CloudFront-Is-Mobile-Viewer": "false",

--- a/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from aws_cdk import Duration
-from aws_cdk.aws_apigateway import LambdaIntegration, MethodResponse, Resource, PassthroughBehavior
+from aws_cdk.aws_apigateway import LambdaIntegration, MethodResponse, PassthroughBehavior, Resource
 from aws_cdk.aws_cloudwatch import Alarm, ComparisonOperator, MathExpression, Metric, Stats, TreatMissingData
 from aws_cdk.aws_cloudwatch_actions import SnsAction
 from aws_cdk.aws_kms import IKey
@@ -350,7 +350,7 @@ class ProviderUsers:
             integration=LambdaIntegration(
                 self.provider_registration_handler,
                 timeout=Duration.seconds(29),
-                passthrough_behavior=PassthroughBehavior.NEVER
+                passthrough_behavior=PassthroughBehavior.NEVER,
             ),
         )
 

--- a/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from aws_cdk import Duration
-from aws_cdk.aws_apigateway import LambdaIntegration, MethodResponse, PassthroughBehavior, Resource
+from aws_cdk.aws_apigateway import LambdaIntegration, MethodResponse, Resource
 from aws_cdk.aws_cloudwatch import Alarm, ComparisonOperator, MathExpression, Metric, Stats, TreatMissingData
 from aws_cdk.aws_cloudwatch_actions import SnsAction
 from aws_cdk.aws_kms import IKey
@@ -350,7 +350,6 @@ class ProviderUsers:
             integration=LambdaIntegration(
                 self.provider_registration_handler,
                 timeout=Duration.seconds(29),
-                passthrough_behavior=PassthroughBehavior.NEVER,
             ),
         )
 

--- a/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from aws_cdk import Duration
-from aws_cdk.aws_apigateway import LambdaIntegration, MethodResponse, Resource
+from aws_cdk.aws_apigateway import LambdaIntegration, MethodResponse, Resource, PassthroughBehavior
 from aws_cdk.aws_cloudwatch import Alarm, ComparisonOperator, MathExpression, Metric, Stats, TreatMissingData
 from aws_cdk.aws_cloudwatch_actions import SnsAction
 from aws_cdk.aws_kms import IKey
@@ -347,7 +347,11 @@ class ProviderUsers:
                     response_models={'application/json': self.api_model.message_response_model},
                 ),
             ],
-            integration=LambdaIntegration(self.provider_registration_handler, timeout=Duration.seconds(29)),
+            integration=LambdaIntegration(
+                self.provider_registration_handler,
+                timeout=Duration.seconds(29),
+                passthrough_behavior=PassthroughBehavior.NEVER
+            ),
         )
 
         NagSuppressions.add_resource_suppressions_by_path(


### PR DESCRIPTION
In the event that a request is malformed JSON, we want to handle this issue gracefully and return a 400

This also sets the registration endpoint request schema to strict, to avoid allowing the user to specify any unrecognized fields.


Closes https://github.com/csg-org/CompactConnect/issues/761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation of provider registration requests by strictly enforcing accepted fields.
	- Enhanced API request handling to reject unsupported media types and malformed JSON payloads, returning clear error responses for each case.
- **New Features**
	- Introduced specific error messaging for unsupported media types in API requests.
- **Tests**
	- Added unit tests to verify error handling for unsupported media types and malformed JSON in API requests.
- **Style**
	- Reformatted code for improved readability without affecting functionality.
- **Chores**
	- Updated test resources to include the "Content-Type: application/json" header for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->