### PR TITLE
Add Arkansas config file for Counseling Compact

### DIFF
--- a/backend/compact-connect/compact-config/coun.yml
+++ b/backend/compact-connect/compact-config/coun.yml
@@ -8,7 +8,7 @@ compactOperationsTeamEmails: []
 compactAdverseActionsNotificationEmails: []
 compactSummaryReportNotificationEmails: []
 licenseeRegistrationEnabledForEnvironments: ["test"]
-activeEnvironments: ["test"]
+activeEnvironments: ["test", "beta"]
 
 attestations:
   - attestationId: "jurisprudence-confirmation"

--- a/backend/compact-connect/compact-config/coun/arkansas.yml
+++ b/backend/compact-connect/compact-config/coun/arkansas.yml
@@ -13,4 +13,4 @@ jurisdictionSummaryReportNotificationEmails: []
 jurisprudenceRequirements:
     required: false
 licenseeRegistrationEnabledForEnvironments: ["test"]
-activeEnvironments: ["test"]
+activeEnvironments: ["test", "beta"]

--- a/backend/compact-connect/compact-config/coun/arkansas.yml
+++ b/backend/compact-connect/compact-config/coun/arkansas.yml
@@ -1,0 +1,16 @@
+# PLACEHOLDER DATA, NOT FINAL CONFIGURATION.
+jurisdictionName: "Arkansas"
+postalAbbreviation: "ar"
+# deprecated - will be removed as part of https://github.com/csg-org/CompactConnect/issues/636
+jurisdictionFee: 3
+privilegeFees:
+  - licenseTypeAbbreviation: "lpc"
+    amount: 3
+jurisdictionOperationsTeamEmails:
+    - "cloud-team-nonprod-alerts@inspiringapps.com"
+jurisdictionAdverseActionsNotificationEmails: []
+jurisdictionSummaryReportNotificationEmails: []
+jurisprudenceRequirements:
+    required: false
+licenseeRegistrationEnabledForEnvironments: ["test"]
+activeEnvironments: ["test"]

--- a/backend/compact-connect/tests/app/test_pipeline.py
+++ b/backend/compact-connect/tests/app/test_pipeline.py
@@ -91,9 +91,9 @@ class TestBackendPipeline(TstAppABC, TestCase):
                 msg=f'Expected scopes for compact {compact} not found',
             )
 
-    def test_synth_generates_compact_resource_servers_with_expected_scopes_for_staff_users_test_stage(self):
-        persistent_stack = self.app.test_backend_pipeline_stack.test_stage.persistent_stack
-        self._when_testing_compact_resource_servers(persistent_stack, environment_name='test')
+    def test_synth_generates_compact_resource_servers_with_expected_scopes_for_staff_users_beta_stage(self):
+        persistent_stack = self.app.beta_backend_pipeline_stack.beta_backend_stage.persistent_stack
+        self._when_testing_compact_resource_servers(persistent_stack, environment_name='beta')
 
     def test_synth_generates_compact_resource_servers_with_expected_scopes_for_staff_users_prod_stage(self):
         persistent_stack = self.app.prod_backend_pipeline_stack.prod_stage.persistent_stack

--- a/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
+++ b/backend/compact-connect/tests/resources/snapshots/COMPACT_CONFIGURATION_UPLOADER_BETA_ENV_INPUT.json
@@ -108,6 +108,106 @@
       ]
     },
     {
+      "compactAbbr": "coun",
+      "compactName": "Counseling",
+      "compactCommissionFee": {
+        "feeType": "FLAT_RATE",
+        "feeAmount": 3.5
+      },
+      "compactOperationsTeamEmails": [],
+      "compactAdverseActionsNotificationEmails": [],
+      "compactSummaryReportNotificationEmails": [],
+      "licenseeRegistrationEnabledForEnvironments": [
+        "test"
+      ],
+      "activeEnvironments": [
+        "test",
+        "beta"
+      ],
+      "attestations": [
+        {
+          "attestationId": "jurisprudence-confirmation",
+          "displayName": "Jurisprudence Confirmation.",
+          "description": "For displaying the jurisprudence confirmation.",
+          "text": "I understand that an attestation is a legally binding statement. I understand that providing false information on this application could result in a loss of my licenses and/or privileges. I acknowledge that the Commission may audit jurisprudence attestations at their discretion.",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "scope-of-practice-attestation",
+          "displayName": "Scope of Practice Attestation",
+          "description": "For displaying the scope of practice attestation.",
+          "text": "I hereby attest and affirm that I have reviewed, understand, and will abide by this state's scope of practice and all applicable laws and rules when practicing in the state. I understand that the issuance of a Compact Privilege authorizes me to legally practice in the member jurisdiction in accordance with the laws and rules governing practice of my profession in that jurisdiction.\n\nIf I violate the practice act, the appropriate board may take action against my Compact Privilege, which may result in the revocation of other Compact Privileges I may hold. I will also be prohibited from obtaining any other Compact Privileges for a period of at least two (2) years.",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "personal-information-home-state-attestation",
+          "displayName": "Personal Information Home State Attestation",
+          "description": "For declaring that the applicant is a resident of the state they have listed as their home state.",
+          "text": "I hereby attest and affirm that this is my personal and licensure information and that I am a resident of the state listed on this page.*",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "personal-information-address-attestation",
+          "displayName": "Personal Information Address Attestation",
+          "description": "For declaring that the applicant is a resident of the state they have listed as their home state.",
+          "text": "I hereby attest and affirm that the address information provided herein is my current address. I further consent to accept service of process at this address. I will notify the Commission and my former and new Home States of a change in my Home State address or email address. I understand that I am only eligible for a Compact Privilege if I am a licensee in my Home State as defined by the Compact. If I mislead the Compact Commission about my Home State, the appropriate board may take action against my License or Compact Privilege, which may result in the revocation of other Compact Privileges I may hold. I may also be prohibited from obtaining other Compact Privileges for a period of two years.",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "not-under-investigation-attestation",
+          "displayName": "Not Under Investigation Attestation",
+          "description": "For declaring that the applicant is not currently under investigation.",
+          "text": "I hereby attest and affirm that I am not currently under investigation by any board, agency, department, association, certifying body, or other body.",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "under-investigation-attestation",
+          "displayName": "Under Investigation Attestation",
+          "description": "For declaring that the applicant is currently under investigation.",
+          "text": "I hereby attest and affirm that I am currently under investigation by any board, agency, department, association, certifying body, or other body. I understand that if any investigation results in a disciplinary action, my Compact Privileges may be revoked.",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "discipline-no-current-encumbrance-attestation",
+          "displayName": "No Current Discipline Encumbrance Attestation",
+          "description": "For declaring that the applicant has no encumbrances on any state license.",
+          "text": "I hereby attest and affirm that I have no encumbrance (any discipline that restricts my full practice or any unmet condition before returning to a full and unrestricted license, including, but not limited, to probation, supervision, completion of a program, and/or completion of CEs) on ANY state license.",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "discipline-no-prior-encumbrance-attestation",
+          "displayName": "No Discipline Encumbrance For Prior Two Yeats Attestation",
+          "description": "For declaring that the applicant has no encumbrances on any state license within the last two years.",
+          "text": "I hereby attest and affirm that I have not had any encumbrance on ANY state license within the previous two years from date of this application for a Compact Privilege.",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "provision-of-true-information-attestation",
+          "displayName": "Provision of True Information Attestation",
+          "description": "For declaring that the applicant has provided true information.",
+          "text": "I hereby attest and affirm that all information contained in this privilege application is true to the best of my knowledge.",
+          "required": true,
+          "locale": "en"
+        },
+        {
+          "attestationId": "military-affiliation-confirmation-attestation",
+          "displayName": "Military Affiliation Confirmation Attestation",
+          "description": "For declaring that the applicant's military affiliation documentation is accurate.",
+          "text": "I hereby attest and affirm that my current military status documentation as uploaded to CompactConnect is accurate.",
+          "required": true,
+          "locale": "en"
+        }
+      ]
+    },
+    {
       "compactAbbr": "octp",
       "compactName": "Occupational Therapy",
       "compactCommissionFee": {
@@ -393,6 +493,34 @@
         "jurisdictionSummaryReportNotificationEmails": [],
         "jurisprudenceRequirements": {
           "required": true
+        },
+        "licenseeRegistrationEnabledForEnvironments": [
+          "test"
+        ],
+        "activeEnvironments": [
+          "test",
+          "beta"
+        ]
+      }
+    ],
+    "coun": [
+      {
+        "jurisdictionName": "Arkansas",
+        "postalAbbreviation": "ar",
+        "jurisdictionFee": 3,
+        "privilegeFees": [
+          {
+            "licenseTypeAbbreviation": "lpc",
+            "amount": 3
+          }
+        ],
+        "jurisdictionOperationsTeamEmails": [
+          "cloud-team-nonprod-alerts@inspiringapps.com"
+        ],
+        "jurisdictionAdverseActionsNotificationEmails": [],
+        "jurisdictionSummaryReportNotificationEmails": [],
+        "jurisprudenceRequirements": {
+          "required": false
         },
         "licenseeRegistrationEnabledForEnvironments": [
           "test"

--- a/backend/compact-connect/tests/resources/snapshots/JURISDICTION_RESOURCE_SERVER_CONFIGURATION_BETA_ENV.json
+++ b/backend/compact-connect/tests/resources/snapshots/JURISDICTION_RESOURCE_SERVER_CONFIGURATION_BETA_ENV.json
@@ -26,6 +26,22 @@
     "Name": "ar",
     "Scopes": [
       {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
         "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
         "ScopeName": "octp.admin"
       },


### PR DESCRIPTION
We have received a request to add Arkansas as an selectable state for the Counseling Compact in the beta environment. This adds the needed configuration file and adds the Counseling compact to the beta environment as well.


Closes #767 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new configuration for Arkansas, enabling licensee registration and specifying jurisdiction details.
  - Introduced new access scopes related to the Counseling compact for Arkansas.
- **Chores**
  - Included placeholder data for Arkansas to support test and beta environment setups.
- **Tests**
  - Updated tests to cover the beta environment alongside the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->