### PR TITLE
Hot fix/Validate path parameters are valid compacts/jurisdictions

### DIFF
--- a/backend/compact-connect/common_constructs/stack.py
+++ b/backend/compact-connect/common_constructs/stack.py
@@ -66,8 +66,11 @@ class Stack(CdkStack):
     @cached_property
     def license_type_abbreviations(self):
         """Flattened list of all license type names across all compacts"""
-        return [typ['abbreviation'] for compact_license_types
-                in self.node.get_context('license_types').values() for typ in compact_license_types]
+        return [
+            typ['abbreviation']
+            for compact_license_types in self.node.get_context('license_types').values()
+            for typ in compact_license_types
+        ]
 
     @cached_property
     def license_types(self):

--- a/backend/compact-connect/lambdas/python/compact-configuration/handlers/compact_configuration.py
+++ b/backend/compact-connect/lambdas/python/compact-configuration/handlers/compact_configuration.py
@@ -43,7 +43,7 @@ def compact_configuration_api_handler(event: dict, context: LambdaContext):  # n
 def _validate_compact(compact: str) -> None:
     """
     Validate that the provided compact exists in the configured list of compacts.
-    
+
     :param compact: The compact abbreviation to validate
     :raises CCInvalidRequestException: If the compact does not exist
     """
@@ -55,7 +55,7 @@ def _validate_compact(compact: str) -> None:
 def _validate_jurisdiction(jurisdiction: str) -> None:
     """
     Validate that the provided jurisdiction exists in the configured list of jurisdictions.
-    
+
     :param jurisdiction: The jurisdiction postal abbreviation to validate
     :raises CCInvalidRequestException: If the jurisdiction does not exist
     """
@@ -76,7 +76,7 @@ def _get_staff_users_compact_jurisdictions(event: dict, context: LambdaContext):
     :return: The latest version of the attestation record
     """
     compact = event['pathParameters']['compact']
-    
+
     # Validate the compact
     _validate_compact(compact)
 
@@ -103,7 +103,7 @@ def _get_public_compact_jurisdictions(event: dict, context: LambdaContext):  # n
     :return: The latest version of the attestation record
     """
     compact = event['pathParameters']['compact']
-    
+
     # Validate the compact
     _validate_compact(compact)
 
@@ -127,7 +127,7 @@ def _get_staff_users_compact_configuration(event: dict, context: LambdaContext):
     :return: The compact configuration
     """
     compact = event['pathParameters']['compact']
-    
+
     # Validate the compact
     _validate_compact(compact)
 
@@ -229,7 +229,7 @@ def _get_staff_users_jurisdiction_configuration(event: dict, context: LambdaCont
     """
     compact = event['pathParameters']['compact']
     jurisdiction = event['pathParameters']['jurisdiction']
-    
+
     # Validate the compact and jurisdiction
     _validate_compact(compact)
     _validate_jurisdiction(jurisdiction)

--- a/backend/compact-connect/lambdas/python/compact-configuration/handlers/compact_configuration.py
+++ b/backend/compact-connect/lambdas/python/compact-configuration/handlers/compact_configuration.py
@@ -40,6 +40,30 @@ def compact_configuration_api_handler(event: dict, context: LambdaContext):  # n
     raise CCInvalidRequestException('Invalid HTTP method')
 
 
+def _validate_compact(compact: str) -> None:
+    """
+    Validate that the provided compact exists in the configured list of compacts.
+    
+    :param compact: The compact abbreviation to validate
+    :raises CCInvalidRequestException: If the compact does not exist
+    """
+    if compact.lower() not in config.compacts:
+        logger.info('Invalid compact abbreviation', compact=compact)
+        raise CCInvalidRequestException(f'Invalid compact abbreviation: {compact}')
+
+
+def _validate_jurisdiction(jurisdiction: str) -> None:
+    """
+    Validate that the provided jurisdiction exists in the configured list of jurisdictions.
+    
+    :param jurisdiction: The jurisdiction postal abbreviation to validate
+    :raises CCInvalidRequestException: If the jurisdiction does not exist
+    """
+    if jurisdiction.lower() not in config.jurisdictions:
+        logger.info('Invalid jurisdiction postal abbreviation', jurisdiction=jurisdiction)
+        raise CCInvalidRequestException(f'Invalid jurisdiction postal abbreviation: {jurisdiction}')
+
+
 def _get_staff_users_compact_jurisdictions(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
     """
     Endpoint for staff users to get the current active jurisdictions for a compact.
@@ -52,6 +76,9 @@ def _get_staff_users_compact_jurisdictions(event: dict, context: LambdaContext):
     :return: The latest version of the attestation record
     """
     compact = event['pathParameters']['compact']
+    
+    # Validate the compact
+    _validate_compact(compact)
 
     logger.info('Getting active jurisdictions for compact', compact=compact)
 
@@ -76,6 +103,9 @@ def _get_public_compact_jurisdictions(event: dict, context: LambdaContext):  # n
     :return: The latest version of the attestation record
     """
     compact = event['pathParameters']['compact']
+    
+    # Validate the compact
+    _validate_compact(compact)
 
     logger.info('Getting active jurisdictions for compact', compact=compact)
 
@@ -97,6 +127,9 @@ def _get_staff_users_compact_configuration(event: dict, context: LambdaContext):
     :return: The compact configuration
     """
     compact = event['pathParameters']['compact']
+    
+    # Validate the compact
+    _validate_compact(compact)
 
     logger.info('Getting compact configuration', compact=compact)
 
@@ -196,6 +229,10 @@ def _get_staff_users_jurisdiction_configuration(event: dict, context: LambdaCont
     """
     compact = event['pathParameters']['compact']
     jurisdiction = event['pathParameters']['jurisdiction']
+    
+    # Validate the compact and jurisdiction
+    _validate_compact(compact)
+    _validate_jurisdiction(jurisdiction)
 
     logger.info('Getting jurisdiction configuration', compact=compact, jurisdiction=jurisdiction)
 

--- a/backend/compact-connect/lambdas/python/compact-configuration/tests/function/test_compact_configuration.py
+++ b/backend/compact-connect/lambdas/python/compact-configuration/tests/function/test_compact_configuration.py
@@ -53,6 +53,22 @@ class TestGetStaffUsersCompactJurisdictions(TstFunction):
             response_body,
         )
 
+    def test_get_compact_jurisdictions_returns_invalid_exception_if_invalid_compact(self):
+        """Test getting an error if invalid compact is provided."""
+        from handlers.compact_configuration import compact_configuration_api_handler
+
+        event = generate_test_event('GET', STAFF_USERS_COMPACT_JURISDICTION_ENDPOINT_RESOURCE)
+        event['pathParameters']['compact'] = 'invalid_compact'
+
+        response = compact_configuration_api_handler(event, self.mock_context)
+        self.assertEqual(400, response['statusCode'], msg=json.loads(response['body']))
+        response_body = json.loads(response['body'])
+
+        self.assertEqual(
+            {'message': 'Invalid compact abbreviation: invalid_compact'},
+            response_body,
+        )
+
     def test_get_compact_jurisdictions_returns_empty_list_if_no_active_jurisdictions(self):
         """Test getting an empty list if no jurisdictions configured."""
         from handlers.compact_configuration import compact_configuration_api_handler
@@ -109,6 +125,22 @@ class TestGetPublicCompactJurisdictions(TstFunction):
 
         self.assertEqual(
             {'message': 'Invalid HTTP method'},
+            response_body,
+        )
+
+    def test_get_compact_jurisdictions_returns_invalid_exception_if_invalid_compact(self):
+        """Test getting an error if invalid compact is provided."""
+        from handlers.compact_configuration import compact_configuration_api_handler
+
+        event = generate_test_event('GET', PUBLIC_COMPACT_JURISDICTION_ENDPOINT_RESOURCE)
+        event['pathParameters']['compact'] = 'invalid_compact'
+
+        response = compact_configuration_api_handler(event, self.mock_context)
+        self.assertEqual(400, response['statusCode'], msg=json.loads(response['body']))
+        response_body = json.loads(response['body'])
+
+        self.assertEqual(
+            {'message': 'Invalid compact abbreviation: invalid_compact'},
             response_body,
         )
 
@@ -202,6 +234,22 @@ class TestStaffUsersCompactConfiguration(TstFunction):
 
         self.assertEqual(
             {'message': 'Invalid HTTP method'},
+            response_body,
+        )
+
+    def test_get_compact_configuration_returns_invalid_exception_if_invalid_compact(self):
+        """Test getting an error if invalid compact is provided."""
+        from handlers.compact_configuration import compact_configuration_api_handler
+
+        event = generate_test_event('GET', COMPACT_CONFIGURATION_ENDPOINT_RESOURCE)
+        event['pathParameters']['compact'] = 'invalid_compact'
+
+        response = compact_configuration_api_handler(event, self.mock_context)
+        self.assertEqual(400, response['statusCode'], msg=json.loads(response['body']))
+        response_body = json.loads(response['body'])
+
+        self.assertEqual(
+            {'message': 'Invalid compact abbreviation: invalid_compact'},
             response_body,
         )
 
@@ -377,6 +425,39 @@ class TestStaffUsersJurisdictionConfiguration(TstFunction):
 
         self.assertEqual(
             {'message': 'Invalid HTTP method'},
+            response_body,
+        )
+
+    def test_get_jurisdiction_configuration_returns_invalid_exception_if_invalid_compact(self):
+        """Test getting an error if invalid compact is provided."""
+        from handlers.compact_configuration import compact_configuration_api_handler
+
+        event = generate_test_event('GET', JURISDICTION_CONFIGURATION_ENDPOINT_RESOURCE)
+        event['pathParameters']['compact'] = 'invalid_compact'
+        event['pathParameters']['jurisdiction'] = 'ky'
+
+        response = compact_configuration_api_handler(event, self.mock_context)
+        self.assertEqual(400, response['statusCode'], msg=json.loads(response['body']))
+        response_body = json.loads(response['body'])
+
+        self.assertEqual(
+            {'message': 'Invalid compact abbreviation: invalid_compact'},
+            response_body,
+        )
+
+    def test_get_jurisdiction_configuration_returns_invalid_exception_if_invalid_jurisdiction(self):
+        """Test getting an error if invalid jurisdiction is provided."""
+        from handlers.compact_configuration import compact_configuration_api_handler
+
+        event = generate_test_event('GET', JURISDICTION_CONFIGURATION_ENDPOINT_RESOURCE)
+        event['pathParameters']['jurisdiction'] = 'invalid_jurisdiction'
+
+        response = compact_configuration_api_handler(event, self.mock_context)
+        self.assertEqual(400, response['statusCode'], msg=json.loads(response['body']))
+        response_body = json.loads(response['body'])
+
+        self.assertEqual(
+            {'message': 'Invalid jurisdiction postal abbreviation: invalid_jurisdiction'},
             response_body,
         )
 


### PR DESCRIPTION
Our ZAP scan tests failed due to invalid compact/jurisdiction path parameters causing 502s in our API. This adds needed validation for those path parameters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input validation for compact and jurisdiction abbreviations in several API endpoints, ensuring more informative error messages and consistent error handling for invalid inputs.

- **Tests**
  - Added new tests to verify that API endpoints correctly return errors when provided with invalid compact or jurisdiction abbreviations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->