### PR TITLE
frontend/privilege purchase checkbox color update

### DIFF
--- a/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.less
+++ b/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.less
@@ -79,7 +79,7 @@
                             }
 
                             &::after {
-                                background-color: @white;
+                                background-color: @tersiaryColor;
                             }
                         }
 

--- a/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.less
+++ b/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.less
@@ -30,7 +30,7 @@
                     }
 
                     &::after {
-                        background-color: @white;
+                        background-color: @tersiaryColor;
                     }
                 }
             }

--- a/webroot/src/styles.common/_colors.less
+++ b/webroot/src/styles.common/_colors.less
@@ -75,5 +75,5 @@
 //==============================
 @primaryColor: @midBlue;
 @secondaryColor: @midOrange;
-@tersiaryColor: @midBlue;
+@tersiaryColor: #59bfe6;
 @rowHighlight: #fafbff;


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Update checkbox input colors on dark backgrounds in the privilege purchase workflow to increase differentiation for users to have a clearer visual cue when a checkbox is checked

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- Code review
- Testing
    - Go through the privilege purchase workflow from beginning to end and confirm that all checkboxes on dark backgrounds when checked now display a light blue background
        - When focused, the border remains an extra 1px white border to indicate focus 

Closes #839 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the background color of checkbox indicators to use a new shade of blue for improved visual consistency.
  - Refined the color palette by assigning a specific hex value to the tertiary color used across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->