### PR TITLE
Fix/remove uneeded cognito fields

### DIFF
--- a/backend/compact-connect/common_constructs/frontend_app_config_utility.py
+++ b/backend/compact-connect/common_constructs/frontend_app_config_utility.py
@@ -9,6 +9,8 @@ HTTPS_PREFIX = 'https://'
 COGNITO_AUTH_DOMAIN_SUFFIX = '.auth.us-east-1.amazoncognito.com'
 
 PERSISTENT_STACK_FRONTEND_APP_CONFIGURATION_PARAMETER_NAME = '/deployment/persistent-stack/frontend_app_configuration'
+PROVIDER_USERS_STACK_FRONTEND_APP_CONFIGURATION_PARAMETER_NAME = '/deployment/provider-users-stack/frontend_app_configuration'
+
 
 
 class PersistentStackFrontendAppConfigUtility:
@@ -35,6 +37,9 @@ class PersistentStackFrontendAppConfigUtility:
     def set_provider_cognito_values(self, domain_name: str, client_id: str) -> None:
         """
         Set Cognito configuration values for provider users.
+        
+        NOTE: This method is deprecated. Provider cognito values should now be set 
+        via ProviderUsersStackFrontendAppConfigUtility.
 
         :param domain_name: The Cognito domain name for provider users
         :param client_id: The UI client ID for provider users
@@ -91,6 +96,53 @@ class PersistentStackFrontendAppConfigUtility:
             parameter_name=PERSISTENT_STACK_FRONTEND_APP_CONFIGURATION_PARAMETER_NAME,
             string_value=self.get_config_json(),
             description='UI application configuration values',
+        )
+
+
+class ProviderUsersStackFrontendAppConfigUtility:
+    """
+    Utility class for managing provider user pool configuration values in SSM Parameter Store.
+
+    This class provides helper methods for generating and storing provider user pool configuration
+    values that need to be shared between the Provider Users stack and Frontend Deployment Stack.
+    """
+
+    def __init__(self):
+        self._config: dict[str, str] = {}
+
+    def set_provider_cognito_values(self, domain_name: str, client_id: str) -> None:
+        """
+        Set Cognito configuration values for provider users.
+
+        :param domain_name: The Cognito domain name for provider users
+        :param client_id: The UI client ID for provider users
+        """
+        self._config['provider_cognito_domain'] = domain_name
+        self._config['provider_cognito_client_id'] = client_id
+
+    def get_config_json(self) -> str:
+        """
+        Generate JSON string representation of the configuration.
+
+        :return: A JSON string containing all configuration values
+        """
+        return json.dumps(self._config)
+
+    def generate_ssm_parameter(self, scope: Construct, resource_id: str) -> StringParameter:
+        """
+        Create an SSM Parameter with the current configuration.
+
+        :param scope: The CDK construct scope
+        :param resource_id: The ID for the SSM Parameter construct
+
+        :return: The created StringParameter construct
+        """
+        return StringParameter(
+            scope,
+            resource_id,
+            parameter_name=PROVIDER_USERS_STACK_FRONTEND_APP_CONFIGURATION_PARAMETER_NAME,
+            string_value=self.get_config_json(),
+            description='Provider user pool configuration values',
         )
 
 
@@ -213,3 +265,73 @@ class PersistentStackFrontendAppConfigValues:
         value here to True, since if the key is not present the config is likely coming from the real parameter
         """
         return self._config.get('should_bundle', True)
+
+
+class ProviderUsersStackFrontendAppConfigValues:
+    """
+    Class to access provider user pool configuration values loaded from SSM.
+    """
+
+    def __init__(self, config_json: str):
+        """
+        Initialize with configuration JSON from SSM.
+
+        :param config_json: JSON string containing configuration values
+        """
+        if not config_json:
+            raise ValueError('Provider Users Stack App Configuration Parameter is required.')
+
+        self._config: dict[str, str] = json.loads(config_json)
+
+    @staticmethod
+    def load_provider_users_stack_values_from_ssm_parameter(
+        stack: Stack,
+    ) -> Optional['ProviderUsersStackFrontendAppConfigValues']:
+        """
+        Load provider user pool configuration values from an existing SSM Parameter.
+
+        :param stack: The CDK stack
+
+        :return: An instance of ProviderUsersStackFrontendAppConfigValues with loaded configuration if the parameter exists, otherwise None
+        """
+        config_value = StringParameter.value_from_lookup(
+            stack, PROVIDER_USERS_STACK_FRONTEND_APP_CONFIGURATION_PARAMETER_NAME, default_value=None
+        )
+        # The first time synth is run, CDK returns a dummy value without actually looking up the value.
+        # The second time it's run, it will either return a value if the parameter exists, or None. So we check for
+        # both of those cases here.
+        if (
+            config_value is not None
+            and config_value != f'dummy-value-for-{PROVIDER_USERS_STACK_FRONTEND_APP_CONFIGURATION_PARAMETER_NAME}'
+        ):
+            return ProviderUsersStackFrontendAppConfigValues(config_value)
+        if config_value == f'dummy-value-for-{PROVIDER_USERS_STACK_FRONTEND_APP_CONFIGURATION_PARAMETER_NAME}':
+            return ProviderUsersStackFrontendAppConfigValues._create_dummy_values()
+
+        return None
+
+    @staticmethod
+    def _create_dummy_values() -> 'ProviderUsersStackFrontendAppConfigValues':
+        """
+        Create a mock instance with default values for testing.
+
+        This method is intended for use where bundling is not required (ie unit tests) or CDK returns a dummy parameter
+        value, and we just populate the config with dummy values.
+
+        :return: An instance of ProviderUsersStackFrontendAppConfigValues with default test values
+        """
+        test_config = {
+            'provider_cognito_domain': 'test-provider-domain',
+            'provider_cognito_client_id': 'test-provider-client-id',
+        }
+        return ProviderUsersStackFrontendAppConfigValues(json.dumps(test_config))
+
+    @property
+    def provider_cognito_domain(self) -> str:
+        """Get the Cognito domain name for provider users."""
+        return self._config['provider_cognito_domain']
+
+    @property
+    def provider_cognito_client_id(self) -> str:
+        """Get the UI client ID for provider users."""
+        return self._config['provider_cognito_client_id']

--- a/backend/compact-connect/lambdas/python/migration/provider_user_pool_migration_551/main.py
+++ b/backend/compact-connect/lambdas/python/migration/provider_user_pool_migration_551/main.py
@@ -1,0 +1,71 @@
+import os
+from botocore.exceptions import ClientError
+from cc_common.config import config, logger
+from custom_resource_handler import CustomResourceHandler, CustomResourceResponse
+
+
+class ProviderUserPoolMigration(CustomResourceHandler):
+    """Migration for deleting the cognito domain from the deprecated user pool."""
+
+    def on_create(self, properties: dict) -> None:
+        do_migration(properties)
+
+    def on_update(self, properties: dict) -> None:
+        do_migration(properties)
+
+    def on_delete(self, _properties: dict) -> CustomResourceResponse | None:
+        """
+        No roll-back on delete.
+        """
+
+
+on_event = ProviderUserPoolMigration('provider-user-pool-migration-551')
+
+
+def do_migration(_properties: dict) -> None:
+    """
+    This migration deletes the user pool domain from the deprecated user pool
+    to allow the new user pool to use the same domain prefix.
+    """
+    logger.info('Starting provider user pool migration - deleting user pool domain from deprecated user pool')
+    
+    # Validate required environment variables
+    user_pool_id = os.environ.get('PROVIDER_USER_POOL_ID')
+    user_pool_domain = os.environ.get('PROVIDER_USER_POOL_DOMAIN')
+    
+    if not user_pool_id:
+        raise ValueError('PROVIDER_USER_POOL_ID environment variable is required')
+    if not user_pool_domain:
+        raise ValueError('PROVIDER_USER_POOL_DOMAIN environment variable is required')
+    
+    logger.info(f'Attempting to delete domain "{user_pool_domain}" from user pool "{user_pool_id}"')
+    
+    try:
+        config.cognito_client.delete_user_pool_domain(
+            UserPoolId=user_pool_id,
+            Domain=user_pool_domain
+        )
+        logger.info(f'Successfully deleted domain "{user_pool_domain}" from user pool "{user_pool_id}"')
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        
+        if error_code == 'ResourceNotFoundException':
+            # Domain doesn't exist - this is OK, migration is idempotent
+            logger.info(f'Domain "{user_pool_domain}" not found for user pool "{user_pool_id}" - '
+                       'assuming already deleted (idempotent operation)')
+        elif error_code == 'InvalidParameterException':
+            # This could mean the domain doesn't exist or the user pool doesn't exist
+            logger.info(f'Invalid parameter when deleting domain "{user_pool_domain}" from user pool "{user_pool_id}" - '
+                       'assuming already deleted (idempotent operation)')
+        else:
+            # Unexpected error - re-raise
+            logger.error(f'Unexpected error deleting domain "{user_pool_domain}" from user pool "{user_pool_id}": {e}')
+            raise
+    except Exception as e:
+        logger.error(f'Unexpected error deleting domain "{user_pool_domain}" from user pool "{user_pool_id}": {e}')
+        raise
+    
+    logger.info('Provider user pool domain cleanup completed successfully')
+
+
+

--- a/backend/compact-connect/pipeline/backend_stage.py
+++ b/backend/compact-connect/pipeline/backend_stage.py
@@ -6,6 +6,7 @@ from stacks.ingest_stack import IngestStack
 from stacks.managed_login_stack import ManagedLoginStack
 from stacks.notification_stack import NotificationStack
 from stacks.persistent_stack import PersistentStack
+from stacks.provider_users import ProviderUsersStack
 from stacks.reporting_stack import ReportingStack
 from stacks.transaction_monitoring_stack import TransactionMonitoringStack
 
@@ -37,6 +38,17 @@ class BackendStage(Stage):
             environment_name=environment_name,
         )
 
+        self.provider_users_stack = ProviderUsersStack(
+            self,
+            'ProviderUsersStack',
+            env=environment,
+            environment_context=environment_context,
+            standard_tags=standard_tags,
+            app_name=app_name,
+            environment_name=environment_name,
+            persistent_stack=self.persistent_stack,
+        )
+
         self.managed_login_stack = ManagedLoginStack(
             self,
             'ManagedLoginStack',
@@ -65,6 +77,7 @@ class BackendStage(Stage):
             standard_tags=standard_tags,
             environment_name=environment_name,
             persistent_stack=self.persistent_stack,
+            provider_user_pool_stack=self.provider_users_stack,
         )
 
         # Reporting and notifications depend on emails, which depend on having a domain name. If we don't configure

--- a/backend/compact-connect/stacks/api_stack/__init__.py
+++ b/backend/compact-connect/stacks/api_stack/__init__.py
@@ -6,6 +6,7 @@ from constructs import Construct
 
 from stacks import persistent_stack as ps
 from stacks.api_stack.cc_api import CCApi
+from stacks.provider_users import ProviderUsersStack
 
 
 class ApiStack(AppStack):
@@ -17,6 +18,7 @@ class ApiStack(AppStack):
         environment_name: str,
         environment_context: dict,
         persistent_stack: ps.PersistentStack,
+        provider_user_pool_stack: ProviderUsersStack,
         **kwargs,
     ):
         super().__init__(
@@ -31,4 +33,5 @@ class ApiStack(AppStack):
             environment_name=environment_name,
             security_profile=security_profile,
             persistent_stack=persistent_stack,
+            provider_user_pool_stack=provider_user_pool_stack,
         )

--- a/backend/compact-connect/stacks/api_stack/cc_api.py
+++ b/backend/compact-connect/stacks/api_stack/cc_api.py
@@ -34,6 +34,7 @@ from constructs import Construct
 
 from stacks import persistent_stack as ps
 from stacks.api_stack.v1_api import V1Api
+from stacks.provider_users import ProviderUsersStack
 
 MD_FORMAT = '^[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$'
 YMD_FORMAT = '^[12]{1}[0-9]{3}-[01]{1}[0-9]{1}-[0-3]{1}[0-9]{1}$'
@@ -73,6 +74,7 @@ class CCApi(RestApi):
         environment_name: str,
         security_profile: SecurityProfile = SecurityProfile.RECOMMENDED,
         persistent_stack: ps.PersistentStack,
+        provider_users_stack: ProviderUsersStack,
         **kwargs,
     ):
         stack: AppStack = AppStack.of(scope)
@@ -169,6 +171,7 @@ class CCApi(RestApi):
         self.alarm_topic = persistent_stack.alarm_topic
 
         self._persistent_stack = persistent_stack
+        self._provider_users_stack = provider_users_stack
 
         self.web_acl = WebACL(self, 'WebACL', acl_scope=WebACLScope.REGIONAL, security_profile=security_profile)
         self.web_acl.associate_stage(self.deployment_stage)
@@ -200,7 +203,7 @@ class CCApi(RestApi):
             templates={'application/json': '{"message": "Access denied"}'},
         )
 
-        self.v1_api = V1Api(self.root, persistent_stack=persistent_stack)
+        self.v1_api = V1Api(self.root, persistent_stack=persistent_stack, provider_users_stack=provider_users_stack)
 
         QueryDefinition(
             self,
@@ -255,7 +258,7 @@ class CCApi(RestApi):
     @cached_property
     def provider_users_authorizer(self):
         return CognitoUserPoolsAuthorizer(
-            self, 'ProviderUsersPoolAuthorizer', cognito_user_pools=[self._persistent_stack.provider_users]
+            self, 'ProviderUsersPoolAuthorizer', cognito_user_pools=[self._provider_users_stack.provider_users]
         )
 
     @cached_property

--- a/backend/compact-connect/stacks/api_stack/v1_api/api.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api.py
@@ -11,6 +11,7 @@ from stacks.api_stack.v1_api.bulk_upload_url import BulkUploadUrl
 from stacks.api_stack.v1_api.provider_management import ProviderManagement
 from stacks.api_stack.v1_api.provider_users import ProviderUsers
 from stacks.api_stack.v1_api.purchases import Purchases
+from stacks.provider_users import ProviderUsersStack
 
 from .api_model import ApiModel
 from .compact_configuration_api import CompactConfigurationApi
@@ -23,7 +24,7 @@ from .staff_users import StaffUsers
 class V1Api:
     """v1 of the Provider Data API"""
 
-    def __init__(self, root: IResource, persistent_stack: ps.PersistentStack):
+    def __init__(self, root: IResource, persistent_stack: ps.PersistentStack, provider_users_stack: ProviderUsersStack):
         super().__init__()
         self.root = root
         self.resource = root.add_resource('v1')
@@ -101,6 +102,7 @@ class V1Api:
         self.provider_users = ProviderUsers(
             resource=self.provider_users_resource,
             persistent_stack=persistent_stack,
+            provider_users_stack=provider_users_stack,
             api_model=self.api_model,
         )
 

--- a/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
@@ -17,6 +17,7 @@ from stacks import persistent_stack as ps
 # Importing module level to allow lazy loading for typing
 from stacks.api_stack import cc_api
 from stacks.persistent_stack import ProviderTable
+from stacks.provider_users import ProviderUsersStack
 
 from .api_model import ApiModel
 
@@ -27,6 +28,7 @@ class ProviderUsers:
         *,
         resource: Resource,
         persistent_stack: ps.PersistentStack,
+        provider_users_stack: ProviderUsersStack,
         api_model: ApiModel,
     ):
         super().__init__()
@@ -42,7 +44,7 @@ class ProviderUsers:
             'PROV_DATE_OF_UPDATE_INDEX_NAME': 'providerDateOfUpdate',
             'PROVIDER_USER_BUCKET_NAME': persistent_stack.provider_users_bucket.bucket_name,
             'LICENSE_GSI_NAME': persistent_stack.provider_table.license_gsi_name,
-            'PROVIDER_USER_POOL_ID': persistent_stack.provider_users.user_pool_id,
+            'PROVIDER_USER_POOL_ID': provider_users_stack.provider_users.user_pool_id,
             'RATE_LIMITING_TABLE_NAME': persistent_stack.rate_limiting_table.table_name,
             'COMPACT_CONFIGURATION_TABLE_NAME': persistent_stack.compact_configuration_table.table_name,
             **stack.common_env_vars,
@@ -53,6 +55,7 @@ class ProviderUsers:
         self._add_provider_registration(
             provider_data_table=persistent_stack.provider_table,
             persistent_stack=persistent_stack,
+            provider_users_stack=provider_users_stack,
             lambda_environment=lambda_environment,
         )
 
@@ -193,6 +196,7 @@ class ProviderUsers:
         self,
         provider_data_table: ProviderTable,
         persistent_stack: ps.PersistentStack,
+        provider_users_stack: ProviderUsersStack,
         lambda_environment: dict,
     ):
         stack = Stack.of(self.provider_users_resource)
@@ -219,7 +223,7 @@ class ProviderUsers:
         provider_data_table.grant_read_write_data(self.provider_registration_handler)
         persistent_stack.compact_configuration_table.grant_read_data(self.provider_registration_handler)
         recaptcha_secret.grant_read(self.provider_registration_handler)
-        persistent_stack.provider_users.grant(self.provider_registration_handler, 'cognito-idp:AdminCreateUser')
+        provider_users_stack.provider_users.grant(self.provider_registration_handler, 'cognito-idp:AdminCreateUser')
         persistent_stack.rate_limiting_table.grant_read_write_data(self.provider_registration_handler)
         self.api.log_groups.append(self.provider_registration_handler.log_group)
 

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -179,34 +179,34 @@ class PersistentStack(AppStack):
         )
 
         # PROVIDER USER POOL MIGRATION PLAN:
-        # 1. ✓ Create the blue user pool in all environments. (Deploy 1 of 3)
-        # 2. Cut over to the blue user pool by: (Deploy 2 of 3)
-        #   a. ✓ Update the API stack to use the blue user pool (just rename
-        #      self.provider_users->self.provider_users_deprecated and
-        #      self.provider_users_standby->self.provider_users below)
-        #   b. ✓ Move the main provider prefix to the blue user pool (just use the provider_prefix in the other
-        #      ProviderUsers constructor below)
-        #   c. Deploy to all environments. You will have to manually delete the original user pool domain right before
-        #      deploying to each environment. This will result in a deletion failure in the CFn events, but the overall
-        #      deployment will succeed.
-        # 3. Testers/users will need to re-register to get a new provider user in the blue user pool.
-        # 4. Remove the original user pool. (Deploy 3 of 3)
+        # 1. ✓ Create the green user pool (ProviderUsersGreen) with correct standard attributes in all environments.
+        # 2. ✓ Deploy migration custom resource that deletes the domain from the deprecated user pool 
+        #      (ProviderUsersBlue) so the green user pool can use the main provider domain prefix.
+        #      This will result in a deletion failure in the CFN events, but the overall deployment will succeed.
+        # 3. ✓ Set up dependency so green user pool creation waits for domain migration to complete.
+        # 4. After deployment, users will need to re-register in the new green user pool since user 
+        #      accounts cannot be migrated between pools with different standard attribute schemas.
+        # 5. Once migration is complete and green user pool is fully operational, remove the deprecated 
+        #      user pool (ProviderUsersBlue) in a future deployment.
 
-        # This user pool is deprecated and will be removed once we've cut over to the blue user pool
+        # This user pool is deprecated and will be removed once we've cut over to the green user pool
         # across all environments.
         provider_prefix = f'{app_name}-provider'
         provider_prefix = provider_prefix if environment_name == 'prod' else f'{provider_prefix}-{environment_name}'
+
+        # We have to use a different prefix so we don't have a naming conflict with the original user pool
         self.provider_users_deprecated = ProviderUsers(
             self,
-            'ProviderUsers',
+            'ProviderUsersBlue',
             cognito_domain_prefix=None,
             environment_name=environment_name,
             environment_context=environment_context,
             encryption_key=self.shared_encryption_key,
-            sign_in_aliases=None,
+            sign_in_aliases=SignInAliases(email=True, username=False),
             user_pool_email=user_pool_email_settings,
             security_profile=security_profile,
             removal_policy=removal_policy,
+            deprecated_pool=True
         )
         # We explicitly export the user pool values so we can later move the API stack over to the
         # new user pool without putting our app into a cross-stack dependency 'deadly embrace':
@@ -214,10 +214,35 @@ class PersistentStack(AppStack):
         self.export_value(self.provider_users_deprecated.user_pool_id)
         self.export_value(self.provider_users_deprecated.user_pool_arn)
 
+        self.provider_user_pool_migration = DataMigration(
+            self,
+            'ProviderUserPoolMigration',
+            migration_dir='provider_user_pool_migration_551',
+            lambda_environment={
+                'PROVIDER_USER_POOL_ID': self.provider_users_deprecated.user_pool_id,
+                'PROVIDER_USER_POOL_DOMAIN': provider_prefix,
+                **self.common_env_vars,
+            },
+        )
+        self.provider_users_deprecated.grant(self.provider_user_pool_migration,
+                                             'cognito-idp:DeleteUserPoolDomain')
+        NagSuppressions.add_resource_suppressions_by_path(
+            self,
+            f'{self.provider_user_pool_migration.migration_function.node.path}/ServiceRole/DefaultPolicy/Resource',
+            suppressions=[
+                {
+                    'id': 'AwsSolutions-IAM5',
+                    'reason': 'This policy contains wild-carded actions and resources but they are scoped to the '
+                    'specific action that this lambda needs access to in order to perform the user pool domain '
+                    'migration.',
+                },
+            ],
+        )
+
         # We have to use a different prefix so we don't have a naming conflict with the original user pool
         self.provider_users = ProviderUsers(
             self,
-            'ProviderUsersBlue',
+            'ProviderUsersGreen',
             cognito_domain_prefix=provider_prefix,
             environment_name=environment_name,
             environment_context=environment_context,
@@ -226,7 +251,10 @@ class PersistentStack(AppStack):
             user_pool_email=user_pool_email_settings,
             security_profile=security_profile,
             removal_policy=removal_policy,
+            deprecated_pool=False
         )
+        # ensure the migration process removes the domain before we create the new user pool.
+        self.provider_users.node.add_dependency(self.provider_user_pool_migration)
 
         QueryDefinition(
             self,

--- a/backend/compact-connect/stacks/provider_users/__init__.py
+++ b/backend/compact-connect/stacks/provider_users/__init__.py
@@ -1,0 +1,119 @@
+from aws_cdk import RemovalPolicy
+from aws_cdk.aws_cognito import SignInAliases, UserPoolEmail
+from aws_cdk.aws_logs import QueryDefinition, QueryString
+from common_constructs.security_profile import SecurityProfile
+from common_constructs.stack import AppStack
+from constructs import Construct
+
+from stacks.persistent_stack import PersistentStack
+from stacks.provider_users.provider_users import ProviderUsers
+
+
+class ProviderUsersStack(AppStack):
+    """
+    Stack containing the provider user resources (ie provider user pool resources).
+
+    This stack is separate from the persistent stack to allow for easier management
+    and reduce risk of cognito putting our persistent stack in an irrecoverable state.
+    """
+
+    def __init__(
+            self,
+            scope: Construct,
+            construct_id: str,
+            *,
+            app_name: str,
+            environment_name: str,
+            environment_context: dict,
+            persistent_stack: PersistentStack,
+            **kwargs,
+    ) -> None:
+        super().__init__(
+            scope,
+            construct_id,
+            environment_context=environment_context,
+            environment_name=environment_name,
+            **kwargs
+        )
+
+        self.persistent_stack = persistent_stack
+
+        # If we delete this stack, retain the resource (orphan but prevent data loss) or destroy it (clean up)?
+        removal_policy = RemovalPolicy.RETAIN if environment_name == 'prod' else RemovalPolicy.DESTROY
+
+        # Get user pool email settings from persistent stack
+        if persistent_stack.hosted_zone:
+            user_pool_email_settings = UserPoolEmail.with_ses(
+                from_email=f'no-reply@{persistent_stack.hosted_zone.zone_name}',
+                ses_verified_domain=persistent_stack.hosted_zone.zone_name,
+                configuration_set_name=persistent_stack.user_email_notifications.config_set.configuration_set_name,
+            )
+        else:
+            user_pool_email_settings = UserPoolEmail.with_cognito()
+
+        # Get security profile from environment context
+        security_profile = SecurityProfile[environment_context.get('security_profile', 'RECOMMENDED')]
+
+        # Set up provider domain prefix
+        provider_prefix = f'{app_name}-provider'
+        provider_prefix = provider_prefix if environment_name == 'prod' else f'{provider_prefix}-{environment_name}'
+
+        # Create the new green provider user pool
+        self.provider_users = ProviderUsers(
+            self,
+            'ProviderUsersGreen',
+            cognito_domain_prefix=provider_prefix,
+            environment_name=environment_name,
+            environment_context=environment_context,
+            encryption_key=persistent_stack.shared_encryption_key,
+            sign_in_aliases=SignInAliases(email=True, username=False),
+            user_pool_email=user_pool_email_settings,
+            security_profile=security_profile,
+            removal_policy=removal_policy,
+        )
+
+        # Add SES dependencies if hosted zone exists
+        if persistent_stack.hosted_zone:
+            self.provider_users.node.add_dependency(persistent_stack.user_email_notifications.email_identity)
+            self.provider_users.node.add_dependency(persistent_stack.user_email_notifications.dmarc_record)
+            self.provider_users.node.add_dependency(
+                persistent_stack.user_email_notifications.verification_custom_resource
+            )
+
+        # Create query definition for provider user pool logs
+        QueryDefinition(
+            self,
+            'ProviderUserCustomEmails',
+            query_definition_name='ProviderUserCustomEmails/Lambdas',
+            query_string=QueryString(
+                fields=['@timestamp', '@log', 'level', 'message', '@message'],
+                filter_statements=['level in ["INFO", "WARNING", "ERROR"]'],
+                sort='@timestamp desc',
+            ),
+            log_groups=[
+                self.provider_users.custom_message_lambda.log_group,
+            ],
+        )
+
+        # Create frontend app config parameter for this stack's values
+        self._create_frontend_app_config_parameter()
+
+    def _create_frontend_app_config_parameter(self):
+        """
+        Creates and stores provider user pool configuration in SSM Parameter Store
+        for use in the frontend deployment stack.
+        """
+        from common_constructs.frontend_app_config_utility import ProviderUsersStackFrontendAppConfigUtility
+
+        provider_app_config = ProviderUsersStackFrontendAppConfigUtility()
+
+        # Add provider user pool Cognito configuration
+        provider_app_config.set_provider_cognito_values(
+            domain_name=self.provider_users.user_pool_domain.domain_name,
+            client_id=self.provider_users.ui_client.user_pool_client_id,
+        )
+
+        # Generate the SSM parameter
+        self.provider_frontend_app_config_parameter = provider_app_config.generate_ssm_parameter(
+            self, 'ProviderFrontendAppConfigParameter'
+        )

--- a/backend/compact-connect/stacks/provider_users/provider_users.py
+++ b/backend/compact-connect/stacks/provider_users/provider_users.py
@@ -65,10 +65,11 @@ class ProviderUsers(UserPool):
             # we only allow the user to be able to see their providerId and compact, which are custom attributes.
             # If we ever want other attributes to be read or written, they must be added here.
             read_attributes=ClientAttributes()
-            .with_standard_attributes(email=True, given_name=True, family_name=True)
+            .with_standard_attributes(email=True)
             .with_custom_attributes('providerId', 'compact'),
-            write_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True),
+            write_attributes=ClientAttributes().with_standard_attributes(email=True),
         )
+
         self._add_custom_message_lambda(stack=stack, environment_name=environment_name)
 
     @staticmethod
@@ -84,14 +85,14 @@ class ProviderUsers(UserPool):
         intend to use them for authentication purposes or for back-end processing.
         """
         return StandardAttributes(
-            # We are requiring the following attributes for all users
+            # We require the email attributes for all users
             # that are registered in the provider user pool.
             email=StandardAttribute(mutable=True, required=True),
-            given_name=StandardAttribute(mutable=True, required=True),
-            family_name=StandardAttribute(mutable=True, required=True),
             # The following attributes are not required, but we are including them because
             # Cognito does not allow you to add them after the user pool is created, and we
             # may want to use them in the future.
+            given_name=StandardAttribute(mutable=True, required=False),
+            family_name=StandardAttribute(mutable=True, required=False),
             address=StandardAttribute(mutable=True, required=False),
             birthdate=StandardAttribute(mutable=True, required=False),
             fullname=StandardAttribute(mutable=True, required=False),


### PR DESCRIPTION
Previously, the givenName and familyName attributes were set as required on the provider users cognito user pool, unfortunately, these attributes cannot be changed without creating an entirely new user pool, and can actually put your CFN stack into a failed state requiring deletion of the full stack.

This presents a risk that we want to avoid, to work around this, we are moving out the provider user pool resources into its own CDK stack, since we have to create a new user pool anyway. This should reduce risk of issues with Cognito putting us in a state where we have to delete our persistent Stack.

Closes #551 
