### PR TITLE
Add full list of active member states for all compacts

### DIFF
--- a/backend/compact-connect/cdk.context.sandbox-example.json
+++ b/backend/compact-connect/cdk.context.sandbox-example.json
@@ -20,10 +20,10 @@
             "justin@example.com"
           ]
         },
-        "jurisdiction_configuration_overrides": {
-          "jurisdictionOperationsTeamEmails": [
-            "justin@example.com"
-          ]
+        "active_compact_member_jurisdictions": {
+          "aslp": ["al", "ak", "ar", "co", "de", "fl", "ga", "id", "in", "ia", "ks", "ky", "la", "me", "md", "mn", "ms", "mo", "ne", "oh"],
+          "octp": ["al", "ar", "ky", "la", "ms", "ne", "oh"],
+          "coun": ["al", "ar", "fl", "ga", "ky", "ne", "oh", "ut"]
         }
       }
     }

--- a/backend/compact-connect/cdk.context.sandbox-example.json
+++ b/backend/compact-connect/cdk.context.sandbox-example.json
@@ -20,8 +20,8 @@
             "justin@example.com"
           ]
         },
-        "active_compact_member_jurisdictions": {
-          "aslp": ["al", "ak", "ar", "co", "de", "fl", "ga", "id", "in", "ia", "ks", "ky", "la", "me", "md", "mn", "ms", "mo", "ne", "oh"],
+        "sandbox_active_compact_member_jurisdictions": {
+          "aslp": ["al", "ak", "ar", "co", "de", "ky", "la", "me", "md", "mn", "ms", "mo", "ne", "oh"],
           "octp": ["al", "ar", "ky", "la", "ms", "ne", "oh"],
           "coun": ["al", "ar", "fl", "ga", "ky", "ne", "oh", "ut"]
         }

--- a/backend/compact-connect/cdk.context.sandbox-example.json
+++ b/backend/compact-connect/cdk.context.sandbox-example.json
@@ -1,6 +1,11 @@
 {
   "sandbox": true,
   "environment_name": "justin",
+  "sandbox_active_compact_member_jurisdictions": {
+    "aslp": ["al", "ak", "ar", "co", "de", "ky", "la", "me", "md", "mn", "ms", "mo", "ne", "oh"],
+    "octp": ["al", "ar", "ky", "la", "ms", "ne", "oh"],
+    "coun": ["al", "ar", "fl", "ga", "ky", "ne", "oh", "ut"]
+  },
   "ssm_context": {
     "github_repo_string": "csg-org/CompactConnect",
     "app_name": "compact-connect",
@@ -19,11 +24,6 @@
           "email": [
             "justin@example.com"
           ]
-        },
-        "sandbox_active_compact_member_jurisdictions": {
-          "aslp": ["al", "ak", "ar", "co", "de", "ky", "la", "me", "md", "mn", "ms", "mo", "ne", "oh"],
-          "octp": ["al", "ar", "ky", "la", "ms", "ne", "oh"],
-          "coun": ["al", "ar", "fl", "ga", "ky", "ne", "oh", "ut"]
         }
       }
     }

--- a/backend/compact-connect/cdk.json
+++ b/backend/compact-connect/cdk.json
@@ -46,9 +46,9 @@
       "coun"
     ],
     "active_compact_member_jurisdictions": {
-      "aslp": ["al", "ak", "ar", "co", "de", "fl", "ga", "id", "in", "ia", "ks", "ky", "la", "me", "md", "mn", "ms", "mo", "ne", "oh"],
-      "octp": ["al", "ar", "ky", "la", "ms", "ne", "oh"],
-      "coun": ["al", "ar", "fl", "ga", "ky", "ne", "oh", "ut"]
+      "aslp": ["al", "ak", "ar", "co", "de", "fl", "ga", "id", "in", "ia", "ks", "ky", "la", "me", "md", "mn", "ms", "mo", "mt", "ne", "nh", "nc", "oh", "ok", "ri", "sc", "tn", "ut", "vt", "va", "vi", "wa", "wv", "wi", "wy"],
+      "octp": ["al", "ar", "az", "co", "de", "ga", "ia", "in", "ky", "la", "me", "md", "mn", "ms", "mo", "mt", "ne", "nh", "nc", "nd", "oh", "ri", "sc", "sd", "tn", "ut", "vt", "va", "wa", "wv", "wi", "wy"],
+      "coun": ["al", "ar", "az", "co", "ct", "dc", "de", "fl", "ga", "ia", "in", "ks", "ky", "la", "me", "md", "mn", "ms", "mo", "mt", "ne", "nh", "nj", "nc", "nd", "oh", "ok", "ri", "sc", "sd", "tn", "ut", "vt", "va", "wa", "wv", "wi", "wy"]
     },
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,

--- a/backend/compact-connect/lambdas/python/common/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/common/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/common/requirements-dev.in
 #
-boto3==1.38.13
+boto3==1.38.33
     # via moto
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.3
+cryptography==45.0.4
     # via moto
 docker==7.1.0
     # via moto
@@ -35,7 +35,7 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto[dynamodb,s3]==5.1.4
+moto[dynamodb,s3]==5.1.5
     # via -r compact-connect/lambdas/python/common/requirements-dev.in
 py-partiql-parser==0.6.1
     # via moto
@@ -50,14 +50,14 @@ pyyaml==6.0.2
     # via
     #   moto
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   docker
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/lambdas/python/common/requirements.txt
+++ b/backend/compact-connect/lambdas/python/common/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/common/requirements.in
 #
-aws-lambda-powertools==3.12.0
+aws-lambda-powertools==3.14.0
     # via -r compact-connect/lambdas/python/common/requirements.in
-boto3==1.38.13
+boto3==1.38.33
     # via -r compact-connect/lambdas/python/common/requirements.in
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   s3transfer
@@ -21,11 +21,11 @@ marshmallow==4.0.0
     # via -r compact-connect/lambdas/python/common/requirements.in
 python-dateutil==2.9.0.post0
     # via botocore
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-typing-extensions==4.13.2
+typing-extensions==4.14.0
     # via aws-lambda-powertools
 urllib3==2.4.0
     # via botocore

--- a/backend/compact-connect/lambdas/python/compact-configuration/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/compact-configuration/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/compact-configuration/requirements-dev.in
 #
-boto3==1.38.13
+boto3==1.38.33
     # via moto
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.3
+cryptography==45.0.4
     # via moto
 docker==7.1.0
     # via moto
@@ -33,7 +33,7 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto[dynamodb,s3]==5.1.4
+moto[dynamodb,s3]==5.1.5
     # via -r compact-connect/lambdas/python/compact-configuration/requirements-dev.in
 py-partiql-parser==0.6.1
     # via moto
@@ -47,14 +47,14 @@ pyyaml==6.0.2
     # via
     #   moto
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   docker
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/lambdas/python/custom-resources/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/custom-resources/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/custom-resources/requirements-dev.in
 #
-boto3==1.38.13
+boto3==1.38.33
     # via moto
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.3
+cryptography==45.0.4
     # via moto
 docker==7.1.0
     # via moto
@@ -33,7 +33,7 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto[dynamodb,s3]==5.1.4
+moto[dynamodb,s3]==5.1.5
     # via -r compact-connect/lambdas/python/custom-resources/requirements-dev.in
 py-partiql-parser==0.6.1
     # via moto
@@ -47,14 +47,14 @@ pyyaml==6.0.2
     # via
     #   moto
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   docker
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/lambdas/python/data-events/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/data-events/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/data-events/requirements-dev.in
 #
-boto3==1.38.13
+boto3==1.38.33
     # via moto
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.3
+cryptography==45.0.4
     # via moto
 docker==7.1.0
     # via moto
@@ -33,7 +33,7 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto[dynamodb,s3]==5.1.4
+moto[dynamodb,s3]==5.1.5
     # via -r compact-connect/lambdas/python/data-events/requirements-dev.in
 py-partiql-parser==0.6.1
     # via moto
@@ -47,14 +47,14 @@ pyyaml==6.0.2
     # via
     #   moto
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   docker
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/lambdas/python/provider-data-v1/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/provider-data-v1/requirements-dev.in
 #
-boto3==1.38.13
+boto3==1.38.33
     # via moto
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.3
+cryptography==45.0.4
     # via moto
 docker==7.1.0
     # via moto
@@ -35,7 +35,7 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto[dynamodb,s3]==5.1.4
+moto[dynamodb,s3]==5.1.5
     # via -r compact-connect/lambdas/python/provider-data-v1/requirements-dev.in
 py-partiql-parser==0.6.1
     # via moto
@@ -50,14 +50,14 @@ pyyaml==6.0.2
     # via
     #   moto
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   docker
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/lambdas/python/provider-data-v1/requirements.txt
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/requirements.txt
@@ -10,7 +10,7 @@ charset-normalizer==3.4.2
     # via requests
 idna==3.10
     # via requests
-requests==2.32.3
+requests==2.32.4
     # via -r compact-connect/lambdas/python/provider-data-v1/requirements.in
 urllib3==2.4.0
     # via requests

--- a/backend/compact-connect/lambdas/python/purchases/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/purchases/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/purchases/requirements-dev.in
 #
-boto3==1.38.13
+boto3==1.38.33
     # via moto
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.3
+cryptography==45.0.4
     # via moto
 docker==7.1.0
     # via moto
@@ -33,7 +33,7 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto[dynamodb,s3]==5.1.4
+moto[dynamodb,s3]==5.1.5
     # via -r compact-connect/lambdas/python/purchases/requirements-dev.in
 py-partiql-parser==0.6.1
     # via moto
@@ -47,14 +47,14 @@ pyyaml==6.0.2
     # via
     #   moto
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   docker
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/lambdas/python/purchases/requirements.txt
+++ b/backend/compact-connect/lambdas/python/purchases/requirements.txt
@@ -16,7 +16,7 @@ lxml==4.9.4
     # via authorizenet
 pyxb-x==1.2.6.3
     # via authorizenet
-requests==2.32.3
+requests==2.32.4
     # via authorizenet
 urllib3==2.4.0
     # via requests

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/staff-user-pre-token/requirements-dev.in
 #
-boto3==1.38.13
+boto3==1.38.33
     # via moto
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.3
+cryptography==45.0.4
     # via moto
 docker==7.1.0
     # via moto
@@ -33,7 +33,7 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto[dynamodb,s3]==5.1.4
+moto[dynamodb,s3]==5.1.5
     # via -r compact-connect/lambdas/python/staff-user-pre-token/requirements-dev.in
 py-partiql-parser==0.6.1
     # via moto
@@ -47,14 +47,14 @@ pyyaml==6.0.2
     # via
     #   moto
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   docker
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/lambdas/python/staff-users/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/staff-users/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url compact-connect/lambdas/python/staff-users/requirements-dev.in
 #
-boto3==1.38.13
+boto3==1.38.33
     # via moto
-botocore==1.38.13
+botocore==1.38.33
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.3
+cryptography==45.0.4
     # via
     #   joserfc
     #   moto
@@ -33,13 +33,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joserfc==1.0.4
+joserfc==1.1.0
     # via moto
 markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto[cognitoidp,dynamodb,s3]==5.1.4
+moto[cognitoidp,dynamodb,s3]==5.1.5
     # via -r compact-connect/lambdas/python/staff-users/requirements-dev.in
 py-partiql-parser==0.6.1
     # via moto
@@ -54,14 +54,14 @@ pyyaml==6.0.2
     # via
     #   moto
     #   responses
-requests==2.32.3
+requests==2.32.4
     # via
     #   docker
     #   moto
     #   responses
 responses==0.25.7
     # via moto
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/requirements-dev.txt
+++ b/backend/compact-connect/requirements-dev.txt
@@ -16,9 +16,9 @@ certifi==2025.4.26
     # via requests
 charset-normalizer==3.4.2
     # via requests
-click==8.2.0
+click==8.2.1
     # via pip-tools
-coverage[toml]==7.8.0
+coverage[toml]==7.8.2
     # via
     #   -r compact-connect/requirements-dev.in
     #   pytest-cov
@@ -42,7 +42,7 @@ mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.1.0
     # via cachecontrol
-packageurl-python==0.16.0
+packageurl-python==0.17.1
     # via cyclonedx-python-lib
 packaging==25.0
     # via
@@ -60,19 +60,21 @@ pip-tools==7.4.1
     # via -r compact-connect/requirements-dev.in
 platformdirs==4.3.8
     # via pip-audit
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 py-serializable==2.0.0
     # via cyclonedx-python-lib
 pygments==2.19.1
-    # via rich
+    # via
+    #   pytest
+    #   rich
 pyparsing==3.2.3
     # via pip-requirements-parser
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.3.5
+pytest==8.4.0
     # via
     #   -r compact-connect/requirements-dev.in
     #   pytest-cov
@@ -80,13 +82,13 @@ pytest-cov==6.1.1
     # via -r compact-connect/requirements-dev.in
 python-dateutil==2.9.0.post0
     # via faker
-requests==2.32.3
+requests==2.32.4
     # via
     #   cachecontrol
     #   pip-audit
 rich==14.0.0
     # via pip-audit
-ruff==0.11.9
+ruff==0.11.13
     # via -r compact-connect/requirements-dev.in
 six==1.17.0
     # via python-dateutil

--- a/backend/compact-connect/requirements.txt
+++ b/backend/compact-connect/requirements.txt
@@ -8,22 +8,22 @@ attrs==25.3.0
     # via
     #   cattrs
     #   jsii
-aws-cdk-asset-awscli-v1==2.2.236
+aws-cdk-asset-awscli-v1==2.2.237
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-aws-lambda-python-alpha==2.195.0a0
+aws-cdk-aws-lambda-python-alpha==2.200.1a0
     # via -r compact-connect/requirements.in
-aws-cdk-cloud-assembly-schema==41.2.0
+aws-cdk-cloud-assembly-schema==44.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.195.0
+aws-cdk-lib==2.200.1
     # via
     #   -r compact-connect/requirements.in
     #   aws-cdk-aws-lambda-python-alpha
     #   cdk-nag
 cattrs==24.1.3
     # via jsii
-cdk-nag==2.35.95
+cdk-nag==2.36.14
     # via -r compact-connect/requirements.in
 constructs==10.4.2
     # via
@@ -68,5 +68,5 @@ typeguard==2.13.3
     #   cdk-nag
     #   constructs
     #   jsii
-typing-extensions==4.13.2
+typing-extensions==4.14.0
     # via jsii

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -536,7 +536,7 @@ class PersistentStack(AppStack):
 
         if is_sandbox:
             # Try to get sandbox-specific configuration
-            active_member_jurisdictions = self.node.try_get_context('sandbox_active_compact_member_jurisdictions')
+            active_member_jurisdictions = self.node.get_context('sandbox_active_compact_member_jurisdictions')
         else:
             # Use regular configuration for non-sandbox environments
             active_member_jurisdictions = self.node.get_context('active_compact_member_jurisdictions')

--- a/backend/compact-connect/tests/resources/snapshots/JURISDICTION_RESOURCE_SERVER_CONFIGURATION.json
+++ b/backend/compact-connect/tests/resources/snapshots/JURISDICTION_RESOURCE_SERVER_CONFIGURATION.json
@@ -130,6 +130,44 @@
     ]
   },
   {
+    "Identifier": "az",
+    "Name": "az",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
     "Identifier": "co",
     "Name": "co",
     "Scopes": [
@@ -148,6 +186,82 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "ct",
+    "Name": "ct",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "dc",
+    "Name": "dc",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
       }
     ]
   },
@@ -170,6 +284,38 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   },
@@ -246,6 +392,22 @@
       {
         "ScopeDescription": "Write access for the coun compact within the jurisdiction",
         "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   },
@@ -268,6 +430,38 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   },
@@ -312,6 +506,38 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   },
@@ -334,6 +560,22 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
       }
     ]
   },
@@ -412,6 +654,22 @@
         "ScopeName": "aslp.write"
       },
       {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
         "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
         "ScopeName": "octp.admin"
       },
@@ -448,6 +706,38 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   },
@@ -470,6 +760,38 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   },
@@ -492,6 +814,38 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   },
@@ -514,6 +868,38 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   },
@@ -536,6 +922,168 @@
       {
         "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
         "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "mt",
+    "Name": "mt",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "nc",
+    "Name": "nc",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "nd",
+    "Name": "nd",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
       },
       {
         "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
@@ -610,8 +1158,322 @@
     ]
   },
   {
+    "Identifier": "nh",
+    "Name": "nh",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "nj",
+    "Name": "nj",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      }
+    ]
+  },
+  {
     "Identifier": "oh",
     "Name": "oh",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "ok",
+    "Name": "ok",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "ri",
+    "Name": "ri",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "sc",
+    "Name": "sc",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "sd",
+    "Name": "sd",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "tn",
+    "Name": "tn",
     "Scopes": [
       {
         "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
@@ -668,6 +1530,22 @@
     "Name": "ut",
     "Scopes": [
       {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
         "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
         "ScopeName": "coun.admin"
       },
@@ -682,6 +1560,368 @@
       {
         "ScopeDescription": "Write access for the coun compact within the jurisdiction",
         "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "va",
+    "Name": "va",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "vi",
+    "Name": "vi",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "vt",
+    "Name": "vt",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "wa",
+    "Name": "wa",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "wi",
+    "Name": "wi",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "wv",
+    "Name": "wv",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
+      }
+    ]
+  },
+  {
+    "Identifier": "wy",
+    "Name": "wy",
+    "Scopes": [
+      {
+        "ScopeDescription": "Admin access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the aslp compact within the jurisdiction",
+        "ScopeName": "aslp.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the coun compact within the jurisdiction",
+        "ScopeName": "coun.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the coun compact within the jurisdiction",
+        "ScopeName": "coun.write"
+      },
+      {
+        "ScopeDescription": "Admin access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.admin"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readPrivate"
+      },
+      {
+        "ScopeDescription": "Read access for SSNs in the octp compact within the jurisdiction",
+        "ScopeName": "octp.readSSN"
+      },
+      {
+        "ScopeDescription": "Write access for the octp compact within the jurisdiction",
+        "ScopeName": "octp.write"
       }
     ]
   }

--- a/backend/multi-account/control-tower/requirements-dev.txt
+++ b/backend/multi-account/control-tower/requirements-dev.txt
@@ -8,7 +8,9 @@ iniconfig==2.1.0
     # via pytest
 packaging==25.0
     # via pytest
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
-pytest==8.3.5
+pygments==2.19.1
+    # via pytest
+pytest==8.4.0
     # via -r multi-account/control-tower/requirements-dev.in

--- a/backend/multi-account/control-tower/requirements.txt
+++ b/backend/multi-account/control-tower/requirements.txt
@@ -8,13 +8,13 @@ attrs==25.3.0
     # via
     #   cattrs
     #   jsii
-aws-cdk-asset-awscli-v1==2.2.236
+aws-cdk-asset-awscli-v1==2.2.237
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-cloud-assembly-schema==41.2.0
+aws-cdk-cloud-assembly-schema==44.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.195.0
+aws-cdk-lib==2.200.1
     # via -r multi-account/control-tower/requirements.in
 cattrs==24.1.3
     # via jsii
@@ -51,5 +51,5 @@ typeguard==2.13.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-typing-extensions==4.13.2
+typing-extensions==4.14.0
     # via jsii

--- a/backend/multi-account/log-aggregation/requirements-dev.txt
+++ b/backend/multi-account/log-aggregation/requirements-dev.txt
@@ -8,7 +8,9 @@ iniconfig==2.1.0
     # via pytest
 packaging==25.0
     # via pytest
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
-pytest==8.3.5
+pygments==2.19.1
+    # via pytest
+pytest==8.4.0
     # via -r multi-account/log-aggregation/requirements-dev.in

--- a/backend/multi-account/log-aggregation/requirements.txt
+++ b/backend/multi-account/log-aggregation/requirements.txt
@@ -8,13 +8,13 @@ attrs==25.3.0
     # via
     #   cattrs
     #   jsii
-aws-cdk-asset-awscli-v1==2.2.236
+aws-cdk-asset-awscli-v1==2.2.237
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-cloud-assembly-schema==41.2.0
+aws-cdk-cloud-assembly-schema==44.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.195.0
+aws-cdk-lib==2.200.1
     # via -r multi-account/log-aggregation/requirements.in
 cattrs==24.1.3
     # via jsii
@@ -51,5 +51,5 @@ typeguard==2.13.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-typing-extensions==4.13.2
+typing-extensions==4.14.0
     # via jsii


### PR DESCRIPTION
Now that the Cognito service team has increased our quota for the number of resource servers within a user pool, we can set the resource servers for all the active member states for each compact.

Closes #808 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the list of active member jurisdictions for multiple compacts, increasing coverage across more states and territories.
  - Enhanced jurisdiction resource server configurations by adding new jurisdictions and extending access control scopes for existing ones.
  - Added sandbox environment support for jurisdiction membership configuration, enabling environment-specific jurisdiction mappings.
- **Chores**
  - Updated configuration files to reflect the expanded membership and scope changes.
  - Upgraded multiple backend and lambda dependencies to newer versions for improved stability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->