### PR TITLE
Frontend/move military status

### DIFF
--- a/webroot/src/components/UserAccount/UserAccount.less
+++ b/webroot/src/components/UserAccount/UserAccount.less
@@ -39,6 +39,7 @@
         .form-title {
             margin-bottom: 2rem;
             font-weight: @fontWeightBold;
+            font-size: @fontSizeLarge;
         }
     }
 }

--- a/webroot/src/components/UserAccount/UserAccount.less
+++ b/webroot/src/components/UserAccount/UserAccount.less
@@ -30,4 +30,15 @@
             .visually-hidden();
         }
     }
+
+    .military-status-container {
+        margin-top: 2rem;
+        padding-top: 3rem;
+        border-top: 1px solid @lightGrey;
+
+        .form-title {
+            margin-bottom: 2rem;
+            font-weight: @fontWeightBold;
+        }
+    }
 }

--- a/webroot/src/components/UserAccount/UserAccount.less
+++ b/webroot/src/components/UserAccount/UserAccount.less
@@ -21,6 +21,7 @@
         flex-direction: column;
         flex-grow: 1;
         width: 100%;
+        margin-bottom: 2rem;
 
         @media @desktopWidth {
             max-width: 60rem;

--- a/webroot/src/components/UserAccount/UserAccount.spec.ts
+++ b/webroot/src/components/UserAccount/UserAccount.spec.ts
@@ -16,4 +16,11 @@ describe('UserAccount component', async () => {
         expect(wrapper.exists()).to.equal(true);
         expect(wrapper.findComponent(UserAccount).exists()).to.equal(true);
     });
+
+    it('should render the military status container', async () => {
+        const wrapper = await mountShallow(UserAccount);
+        const militaryStatusContainer = wrapper.find('.military-status-container');
+
+        expect(militaryStatusContainer.exists()).to.equal(true);
+    });
 });

--- a/webroot/src/components/UserAccount/UserAccount.ts
+++ b/webroot/src/components/UserAccount/UserAccount.ts
@@ -13,6 +13,7 @@ import {
 } from 'vue-facing-decorator';
 import { reactive, computed } from 'vue';
 import { AuthTypes } from '@/app.config';
+import InputButton from '@components/Forms/InputButton/InputButton.vue';
 import MixinForm from '@components/Forms/_mixins/form.mixin';
 import Card from '@components/Card/Card.vue';
 import InputText from '@components/Forms/InputText/InputText.vue';
@@ -28,6 +29,7 @@ import Joi from 'joi';
 @Component({
     name: 'UserAccount',
     components: {
+        InputButton,
         Card,
         InputText,
         InputSubmit,
@@ -86,6 +88,14 @@ class UserAccount extends mixins(MixinForm) {
         });
 
         return enabledInputKeys.length > 0;
+    }
+
+    get militaryStatusLabel(): string {
+        return `${this.$t('common.add')}/${this.$t('common.edit')}`;
+    }
+
+    get currentCompactType(): string | null {
+        return this.userStore?.currentCompact?.type || null;
     }
 
     //
@@ -165,6 +175,13 @@ class UserAccount extends mixins(MixinForm) {
                     this.setError(err.message);
                 });
         }
+    }
+
+    viewMilitaryStatus() {
+        this.$router.push({
+            name: 'MilitaryStatus',
+            params: { compact: this.currentCompactType }
+        });
     }
 
     //

--- a/webroot/src/components/UserAccount/UserAccount.vue
+++ b/webroot/src/components/UserAccount/UserAccount.vue
@@ -23,6 +23,18 @@
                 />
             </form>
             <ChangePassword />
+            <div class="military-status-container">
+                <div class="form-title">{{ $t('military.militaryStatusTitle') }}</div>
+                <div class="btn-container military-status-btn">
+                    <InputButton
+                        :label="militaryStatusLabel"
+                        :aria-label="militaryStatusLabel"
+                        :isTransparent="false"
+                        class="btn view-military-btn"
+                        @click="viewMilitaryStatus"
+                    />
+                </div>
+            </div>
         </Card>
     </div>
 </template>

--- a/webroot/src/pages/LicenseeDashboard/LicenseeDashboard.ts
+++ b/webroot/src/pages/LicenseeDashboard/LicenseeDashboard.ts
@@ -98,13 +98,6 @@ export default class LicenseeDashboard extends Vue {
         });
     }
 
-    viewMilitaryStatus() {
-        this.$router.push({
-            name: 'MilitaryStatus',
-            params: { compact: this.currentCompactType }
-        });
-    }
-
     viewLicenseeProof() {
         this.$router.push({
             name: 'LicenseeVerification',

--- a/webroot/src/pages/LicenseeDashboard/LicenseeDashboard.vue
+++ b/webroot/src/pages/LicenseeDashboard/LicenseeDashboard.vue
@@ -23,15 +23,6 @@
                 </div>
                 <div class="btn-container">
                     <InputButton
-                        :label="$t('military.viewMilitaryStatus')"
-                        :aria-label="$t('military.viewMilitaryStatus')"
-                        :isTransparent="true"
-                        class="btn view-military-btn"
-                        @click="viewMilitaryStatus"
-                    />
-                </div>
-                <div class="btn-container">
-                    <InputButton
                         :label="`+ ${this.$t('licensing.obtainPrivileges')}`"
                         :aria-label="$t('licensing.obtainPrivileges')"
                         class="btn obtain-priv-btn"

--- a/webroot/src/pages/MilitaryStatus/MilitaryStatus.ts
+++ b/webroot/src/pages/MilitaryStatus/MilitaryStatus.ts
@@ -63,8 +63,7 @@ export default class MilitaryStatus extends mixins(MixinForm) {
     goBack() {
         if (this.currentCompactType) {
             this.$router.push({
-                name: 'LicenseeDashboard',
-                params: { compact: this.currentCompactType }
+                name: 'Account'
             });
         }
     }


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Move military status button from dashboard to account screen matching latest [Figma designs](https://www.figma.com/design/SYM0uWszsu8Sf0YfxAhIMY/JCC?node-id=1-12&p=f&t=4aWemQs57euP96qd-0)
- Update button label
- Update back link on military status to return to account screen
- Add test to check the section exists on the account component

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - Log in as practitioner, go to the dashboard screen, and confirm that the military status button is no longer present anywhere
    - Go to the account screen and confirm that there is a military status section below the change password and overall appearance matches Figma designs above
        - Confirm that clicking the button will take you to the military status screen
            - Confirm that clicking the back link in the screen will redirect you back to the account screen 
        - Confirm that the military status flow works as expected and there are no redirects back to the dashboard 

Closes #838 
