### PR TITLE
Frontend/form submission validation visibility

### DIFF
--- a/webroot/src/components/Forms/InputDate/InputDate.vue
+++ b/webroot/src/components/Forms/InputDate/InputDate.vue
@@ -17,7 +17,7 @@
     >
         <label
             v-if="!formInput.shouldHideLabel"
-            :for="`dp-input-${formInput.id}`"
+            :for="formInput.id"
         >
             {{ formInput.label }}
             <span v-if="isRequired" class="required-indicator">*</span>
@@ -63,7 +63,7 @@
             >
                 <div class="dp__input_wrap">
                     <input
-                        :id="`dp-input-${formInput.id}`"
+                        :id="formInput.id"
                         type="text"
                         v-model="localValue"
                         @input="onInput"

--- a/webroot/src/components/Forms/InputRadioGroup/InputRadioGroup.vue
+++ b/webroot/src/components/Forms/InputRadioGroup/InputRadioGroup.vue
@@ -12,6 +12,7 @@
             'has-error': !!formInput.errorMessage,
             'disabled': formInput.isDisabled,
         }"
+        :id="formInput.id"
     >
         <div
             v-if="!formInput.shouldHideLabel"

--- a/webroot/src/components/Forms/_mixins/form.mixin.ts
+++ b/webroot/src/components/Forms/_mixins/form.mixin.ts
@@ -211,6 +211,67 @@ class MixinForm extends Vue {
         this.updateFormSubmitError(errorMessage);
     }
 
+    showInvalidFormError(): void {
+        const { formData } = this;
+
+        // Find the first required invalid input
+        const firstInvalidKey = this.formKeys.find((key) => {
+            const formInput = formData[key];
+
+            // Skip submit inputs
+            if (formInput.isSubmitInput) {
+                return false;
+            }
+
+            const isInvalid = !formInput.isValid;
+
+            return isInvalid;
+        });
+
+        // If we found an invalid input, scroll to it
+        if (firstInvalidKey) {
+            this.scrollToInput(formData[firstInvalidKey]);
+        }
+    }
+
+    protected scrollToInput(formInput: FormInput): void {
+        const element = document.getElementById(formInput.id);
+
+        if (element) {
+            // Scroll to the element
+            element.scrollIntoView({
+                behavior: 'smooth',
+                block: 'center'
+            });
+
+            // Check if this is a radio button group by looking for radio inputs inside
+            const radioInputs = element.querySelectorAll('input[type="radio"]');
+
+            console.log('radioInputs', radioInputs);
+
+            if (radioInputs.length > 0) {
+                // This is a radio button group, focus on the first radio input
+                const firstRadioInput = document.getElementById(`${formInput.id}-1`);
+
+                if (firstRadioInput) {
+                    console.log('firstRadioInput', firstRadioInput);
+
+                    firstRadioInput.focus();
+                } else {
+                    console.log('fallback to first radio input');
+
+                    // Fallback to the first radio input found
+                    (radioInputs[0] as HTMLElement).focus();
+                }
+            } else {
+                console.log('non-radio button group, focus on the input');
+
+                // Non-radio button group, focus on the input
+                element.focus();
+            }
+        }
+    }
+
     @Watch('locale') localeChanged() {
         // @TODO: For now we just brute force the form re-init on language change. Making all the layers reactive (messages inside Joi schemas, etc) was messy.
         this.initFormInputs();

--- a/webroot/src/components/Forms/_mixins/form.mixin.ts
+++ b/webroot/src/components/Forms/_mixins/form.mixin.ts
@@ -247,26 +247,17 @@ class MixinForm extends Vue {
             // Check if this is a radio button group by looking for radio inputs inside
             const radioInputs = element.querySelectorAll('input[type="radio"]');
 
-            console.log('radioInputs', radioInputs);
-
             if (radioInputs.length > 0) {
                 // This is a radio button group, focus on the first radio input
                 const firstRadioInput = document.getElementById(`${formInput.id}-1`);
 
                 if (firstRadioInput) {
-                    console.log('firstRadioInput', firstRadioInput);
-
                     firstRadioInput.focus();
                 } else {
-                    console.log('fallback to first radio input');
-
                     // Fallback to the first radio input found
                     (radioInputs[0] as HTMLElement).focus();
                 }
             } else {
-                console.log('non-radio button group, focus on the input');
-
-                // Non-radio button group, focus on the input
                 element.focus();
             }
         }

--- a/webroot/src/components/Forms/_mixins/mixins.spec.ts
+++ b/webroot/src/components/Forms/_mixins/mixins.spec.ts
@@ -124,6 +124,185 @@ describe('Form mixin', async () => {
 
         expect(component.isFormError).to.equal(true);
     });
+    it('should show invalid form error when there is an invalid input', async () => {
+        const wrapper = await mountShallow(FormMixin);
+        const component = wrapper.vm;
+        const formInput = new FormInput();
+
+        formInput.id = 'test-input';
+        formInput.isValid = false;
+        formInput.isSubmitInput = false;
+        component.formData.testInput = formInput;
+
+        // Mock scrollToInput method to verify it gets called
+        let scrollToInputCalled = false;
+
+        component.scrollToInput = () => {
+            scrollToInputCalled = true;
+        };
+
+        component.showInvalidFormError();
+
+        expect(scrollToInputCalled).to.equal(true);
+    });
+    it('should not call scrollToInput when all inputs are valid', async () => {
+        const wrapper = await mountShallow(FormMixin);
+        const component = wrapper.vm;
+        const formInput = new FormInput();
+
+        formInput.id = 'test-input';
+        formInput.isValid = true;
+        formInput.isSubmitInput = false;
+        component.formData.testInput = formInput;
+
+        // Mock scrollToInput method to verify it doesn't get called
+        let scrollToInputCalled = false;
+
+        component.scrollToInput = () => {
+            scrollToInputCalled = true;
+        };
+
+        component.showInvalidFormError();
+
+        expect(scrollToInputCalled).to.equal(false);
+    });
+    it('should skip submit inputs when finding invalid form inputs', async () => {
+        const wrapper = await mountShallow(FormMixin);
+        const component = wrapper.vm;
+        const submitInput = new FormInput();
+        const regularInput = new FormInput();
+
+        submitInput.id = 'submit-input';
+        submitInput.isValid = false;
+        submitInput.isSubmitInput = true;
+
+        regularInput.id = 'regular-input';
+        regularInput.isValid = false;
+        regularInput.isSubmitInput = false;
+
+        component.formData.submitInput = submitInput;
+        component.formData.regularInput = regularInput;
+
+        // Mock scrollToInput method to verify it gets called with the regular input
+        let scrollToInputCalledWith = null;
+
+        component.scrollToInput = (input) => {
+            scrollToInputCalledWith = input;
+        };
+
+        component.showInvalidFormError();
+
+        expect(scrollToInputCalledWith).to.not.be.null;
+        expect((scrollToInputCalledWith as any).id).to.equal(regularInput.id);
+    });
+    it('should scroll to input element when element exists', async () => {
+        const wrapper = await mountShallow(FormMixin);
+        const component = wrapper.vm;
+        const formInput = new FormInput();
+
+        formInput.id = 'test-input';
+
+        // Mock DOM element and its methods
+        const mockElement = {
+            scrollIntoView: () => { /* mock implementation */ },
+            querySelectorAll: () => [],
+            focus: () => { /* mock implementation */ }
+        } as unknown as HTMLElement;
+
+        // Mock document.getElementById
+        const originalGetElementById = document.getElementById;
+
+        document.getElementById = (id: string): HTMLElement | null => {
+            if (id === 'test-input') {
+                return mockElement;
+            }
+            return null;
+        };
+
+        let scrollIntoViewCalled = false;
+        let focusCalled = false;
+
+        (mockElement as any).scrollIntoView = () => {
+            scrollIntoViewCalled = true;
+        };
+        (mockElement as any).focus = () => {
+            focusCalled = true;
+        };
+
+        component.scrollToInput(formInput);
+
+        expect(scrollIntoViewCalled).to.equal(true);
+        expect(focusCalled).to.equal(true);
+
+        // Restore original method
+        document.getElementById = originalGetElementById;
+    });
+    it('should handle radio button group when scrolling to input', async () => {
+        const wrapper = await mountShallow(FormMixin);
+        const component = wrapper.vm;
+        const formInput = new FormInput();
+
+        formInput.id = 'test-radio-group';
+
+        // Mock radio input element
+        const mockRadioInput = {
+            focus: () => { /* mock implementation */ }
+        } as unknown as HTMLElement;
+
+        // Mock main element with radio inputs
+        const mockElement = {
+            scrollIntoView: () => { /* mock implementation */ },
+            querySelectorAll: () => [mockRadioInput],
+            focus: () => { /* mock implementation */ }
+        } as unknown as HTMLElement;
+
+        // Mock document.getElementById
+        const originalGetElementById = document.getElementById;
+
+        document.getElementById = (id: string): HTMLElement | null => {
+            if (id === 'test-radio-group') {
+                return mockElement;
+            }
+            if (id === 'test-radio-group-1') {
+                return mockRadioInput;
+            }
+            return null;
+        };
+
+        let radioFocusCalled = false;
+
+        (mockRadioInput as any).focus = () => {
+            radioFocusCalled = true;
+        };
+
+        component.scrollToInput(formInput);
+
+        expect(radioFocusCalled).to.equal(true);
+
+        // Restore original method
+        document.getElementById = originalGetElementById;
+    });
+    it('should handle case when element does not exist for scrollToInput', async () => {
+        const wrapper = await mountShallow(FormMixin);
+        const component = wrapper.vm;
+        const formInput = new FormInput();
+
+        formInput.id = 'non-existent-input';
+
+        // Mock document.getElementById to return null
+        const originalGetElementById = document.getElementById;
+
+        document.getElementById = (): HTMLElement | null => null;
+
+        // This should not throw an error
+        component.scrollToInput(formInput);
+
+        // Restore original method
+        document.getElementById = originalGetElementById;
+
+        // Test passes if no error is thrown
+        expect(true).to.equal(true);
+    });
 });
 describe('Input mixin', async () => {
     it('should mount the component', async () => {

--- a/webroot/src/components/Page/PageMainNav/PageMainNav.less
+++ b/webroot/src/components/Page/PageMainNav/PageMainNav.less
@@ -11,7 +11,7 @@
     position: fixed;
     top: @appHeaderHeight;
     left: 0;
-    z-index: 1;
+    z-index: 4;
     display: flex;
     flex-direction: column;
     width: 0;

--- a/webroot/src/components/PrivilegePurchaseAttestation/PrivilegePurchaseAttestation.ts
+++ b/webroot/src/components/PrivilegePurchaseAttestation/PrivilegePurchaseAttestation.ts
@@ -257,6 +257,8 @@ export default class PrivilegePurchaseAttestation extends mixins(MixinForm) {
             }
 
             this.endFormLoading();
+        } else {
+            this.showInvalidFormError();
         }
     }
 

--- a/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.ts
+++ b/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.ts
@@ -265,7 +265,7 @@ export default class PrivilegePurchaseFinalize extends mixins(MixinForm) {
                 id: 'no-refunds-check',
                 name: 'no-refunds-check',
                 label: this.$t('licensing.noRefundsMessage'),
-                validation: Joi.boolean().required(),
+                validation: Joi.boolean().invalid(false).messages(this.joiMessages.boolean),
                 value: false,
                 isDisabled: false
             }),
@@ -381,5 +381,14 @@ export default class PrivilegePurchaseFinalize extends mixins(MixinForm) {
         const formButtons = document.getElementById('button-row');
 
         formButtons?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    handlePaymentButtonClick(): void {
+        // Validate all inputs first to ensure we have current validation state
+        this.validateAll({ asTouched: true });
+
+        if (!this.isFormValid) {
+            this.showInvalidFormError();
+        }
     }
 }

--- a/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.vue
+++ b/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.vue
@@ -55,14 +55,23 @@
             <div v-if="formErrorMessage" class="form-error-message">{{formErrorMessage}}</div>
             <div id="button-row" class="button-row">
                 <div class="form-nav-buttons">
-                    <PrivilegePurchaseAcceptUI
-                        class="form-nav-button accept-ui"
-                        :paymentSdkConfig="currentCompactPaymentSdkConfig"
-                        :buttonLabel="$t('common.next')"
-                        :isEnabled="!isFormLoading && isSubmitEnabled"
-                        @success="acceptUiSuccessResponse"
-                        @error="acceptUiErrorResponse"
-                    />
+                    <div class="payment-button-container" style="position: relative;">
+                        <InputButton
+                            v-if="!isSubmitEnabled"
+                            :label="$t('payment.payment')"
+                            :isDisabled="isFormLoading || !isSubmitEnabled"
+                            class="payment-overlay-button"
+                            @click="handlePaymentButtonClick"
+                        />
+                        <PrivilegePurchaseAcceptUI
+                            class="form-nav-button accept-ui"
+                            :paymentSdkConfig="currentCompactPaymentSdkConfig"
+                            :buttonLabel="$t('payment.payment')"
+                            :isEnabled="!isFormLoading && isSubmitEnabled"
+                            @success="acceptUiSuccessResponse"
+                            @error="acceptUiErrorResponse"
+                        />
+                    </div>
                     <InputButton
                         :label="$t('common.back')"
                         :isTransparent="true"

--- a/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.vue
+++ b/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.vue
@@ -55,7 +55,7 @@
             <div v-if="formErrorMessage" class="form-error-message">{{formErrorMessage}}</div>
             <div id="button-row" class="button-row">
                 <div class="form-nav-buttons">
-                    <div class="payment-button-container" style="position: relative;">
+                    <div class="payment-button-container">
                         <InputButton
                             v-if="!isSubmitEnabled"
                             :label="$t('payment.payment')"

--- a/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.ts
+++ b/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.ts
@@ -222,6 +222,8 @@ export default class PrivilegePurchaseInformationConfirmation extends mixins(Mix
             }
 
             this.endFormLoading();
+        } else {
+            this.showInvalidFormError();
         }
     }
 

--- a/webroot/src/components/PrivilegePurchaseLicense/PrivilegePurchaseLicense.ts
+++ b/webroot/src/components/PrivilegePurchaseLicense/PrivilegePurchaseLicense.ts
@@ -171,6 +171,8 @@ class PrivilegePurchaseLicense extends mixins(MixinForm) {
             });
 
             this.endFormLoading();
+        } else {
+            this.showInvalidFormError();
         }
     }
 

--- a/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
+++ b/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
@@ -90,7 +90,7 @@
                             :formInput="formData.submit"
                             class="form-nav-button"
                             :label="submitLabel"
-                            :isEnabled="!isFormLoading && isAtLeastOnePrivilegeChosen && areAllAttesationsConfirmed"
+                            :isEnabled="!isFormLoading && isAtLeastOnePrivilegeChosen"
                         />
                         <InputButton
                             :label="backText"

--- a/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.less
+++ b/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.less
@@ -45,6 +45,14 @@
                     font-size: 1.5rem;
                 }
             }
+
+            .form-field-error {
+                align-self: flex-start;
+                width: fit-content;
+                padding: 0.25rem 0.5rem;
+                border-radius: @borderRadiusSmall;
+                background-color: rgba(@white, 0.9);
+            }
         }
     }
 

--- a/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.ts
+++ b/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.ts
@@ -312,12 +312,22 @@ class SelectedStatePurchaseInformation extends mixins(MixinForm) {
     setJurisprudenceInputValue(newValue): void {
         if (this.jurisprudenceCheckInput) {
             (this.jurisprudenceCheckInput.value as any) = newValue; // any use required here because of outstanding ts bug regarding union type inference
+
+            // Clear error message when checkbox becomes valid
+            if (newValue) {
+                this.jurisprudenceCheckInput.errorMessage = '';
+            }
         }
     }
 
     setScopeInputValue(newValue): void {
         if (this.scopeOfPracticeCheckInput) {
             (this.scopeOfPracticeCheckInput.value as any) = newValue; // any use required here because of outstanding ts bug regarding union type inference
+
+            // Clear error message when checkbox becomes valid
+            if (newValue) {
+                this.scopeOfPracticeCheckInput.errorMessage = '';
+            }
         }
     }
 

--- a/webroot/src/models/_formatters/formatters.spec.ts
+++ b/webroot/src/models/_formatters/formatters.spec.ts
@@ -16,7 +16,10 @@ import {
     dateDisplay,
     datetimeDisplay,
     relativeFromNowDisplay,
-    dateDiff
+    dateDiff,
+    formatDateInput,
+    dateInputToServerFormat,
+    serverFormatToDateInput
 } from '@models/_formatters/date';
 import { singleDelimeterPhoneFormatter, formatPhoneNumber, stripPhoneNumber } from '@models/_formatters/phone';
 import { formatCurrencyInput, formatCurrencyBlur } from '@models/_formatters/currency';
@@ -61,6 +64,78 @@ describe('Date formatters', () => {
         const diff = Math.round(dateDiff(date1, date2, 'days'));
 
         expect(diff).to.equal(5);
+    });
+    it('should format raw date input to MM/dd/yyyy display format', () => {
+        const formatted = formatDateInput('12252024');
+
+        expect(formatted).to.equal('12/25/2024');
+    });
+    it('should format partial date input correctly', () => {
+        const formatted1 = formatDateInput('12');
+        const formatted2 = formatDateInput('1225');
+        const formatted3 = formatDateInput('122520');
+
+        expect(formatted1).to.equal('12/');
+        expect(formatted2).to.equal('12/25/');
+        expect(formatted3).to.equal('12/25/20');
+    });
+    it('should format already formatted date input', () => {
+        const formatted = formatDateInput('12/25/2024');
+
+        expect(formatted).to.equal('12/25/2024');
+    });
+    it('should handle empty input for formatDateInput', () => {
+        const formatted = formatDateInput('');
+
+        expect(formatted).to.equal('');
+    });
+    it('should strip non-numeric characters from date input', () => {
+        const formatted = formatDateInput('12a25b2024c');
+
+        expect(formatted).to.equal('12/25/2024');
+    });
+    it('should convert valid date input to server format', () => {
+        const serverFormat = dateInputToServerFormat('12252024');
+
+        expect(serverFormat).to.equal('2024-12-25');
+    });
+    it('should convert formatted date input to server format', () => {
+        const serverFormat = dateInputToServerFormat('12/25/2024');
+
+        expect(serverFormat).to.equal('2024-12-25');
+    });
+    it('should return empty string for invalid date input to server format', () => {
+        const serverFormat1 = dateInputToServerFormat('13252024'); // Invalid month
+        const serverFormat2 = dateInputToServerFormat('12322024'); // Invalid day
+        const serverFormat3 = dateInputToServerFormat('1225'); // Incomplete date
+
+        expect(serverFormat1).to.equal('');
+        expect(serverFormat2).to.equal('');
+        expect(serverFormat3).to.equal('');
+    });
+    it('should handle empty input for dateInputToServerFormat', () => {
+        const serverFormat = dateInputToServerFormat('');
+
+        expect(serverFormat).to.equal('');
+    });
+    it('should convert server format date to numeric input format', () => {
+        const dateInput = serverFormatToDateInput('2024-12-25');
+
+        expect(dateInput).to.equal('12252024');
+    });
+    it('should handle invalid server format date', () => {
+        const dateInput1 = serverFormatToDateInput('2024-13-25'); // Invalid month
+        const dateInput2 = serverFormatToDateInput('invalid-date');
+        const dateInput3 = serverFormatToDateInput('2024/12/25'); // Wrong format
+
+        expect(dateInput1).to.equal('');
+        expect(dateInput2).to.equal('');
+        expect(dateInput3).to.equal('');
+    });
+    it('should handle empty input for serverFormatToDateInput', () => {
+        const dateInput = serverFormatToDateInput('');
+
+        expect(dateInput).to.equal('');
     });
 });
 describe('Phone formatters', () => {

--- a/webroot/src/pages/RegisterLicensee/RegisterLicensee.ts
+++ b/webroot/src/pages/RegisterLicensee/RegisterLicensee.ts
@@ -172,13 +172,6 @@ class RegisterLicensee extends mixins(MixinForm) {
                 autocomplete: 'family-name',
                 validation: Joi.string().required().messages(this.joiMessages.string),
             }),
-            email: new FormInput({
-                id: 'email',
-                name: 'email',
-                label: computed(() => this.$t('common.emailAddress')),
-                autocomplete: 'email',
-                validation: Joi.string().required().email({ tlds: false }).messages(this.joiMessages.string),
-            }),
             ssnLastFour: new FormInput({
                 id: 'ssn-last-four',
                 name: 'ssn-last-four',
@@ -207,6 +200,13 @@ class RegisterLicensee extends mixins(MixinForm) {
                 label: computed(() => this.$t('licensing.licenseType')),
                 validation: Joi.string().required().messages(this.joiMessages.string),
                 valueOptions: this.licenseTypeOptions,
+            }),
+            email: new FormInput({
+                id: 'email',
+                name: 'email',
+                label: computed(() => this.$t('common.emailAddress')),
+                autocomplete: 'email',
+                validation: Joi.string().required().email({ tlds: false }).messages(this.joiMessages.string),
             }),
             submit: new FormInput({
                 isSubmitInput: true,
@@ -308,6 +308,8 @@ class RegisterLicensee extends mixins(MixinForm) {
             await nextTick();
 
             this.scrollIntoView('summary-heading');
+        } else {
+            this.showInvalidFormError();
         }
     }
 

--- a/webroot/src/styles.common/mixins/purchase-flow-buttons.less
+++ b/webroot/src/styles.common/mixins/purchase-flow-buttons.less
@@ -42,6 +42,7 @@
         }
 
         .payment-button-container {
+            position: relative;
             flex-grow: 1;
 
             .payment-overlay-button {

--- a/webroot/src/styles.common/mixins/purchase-flow-buttons.less
+++ b/webroot/src/styles.common/mixins/purchase-flow-buttons.less
@@ -34,10 +34,29 @@
     .form-nav-buttons {
         display: flex;
         flex-direction: row-reverse;
+        gap: 1rem;
         width: 100%;
 
         @media @tabletWidth {
             width: auto;
+        }
+
+        .payment-button-container {
+            flex-grow: 1;
+
+            .payment-overlay-button {
+                position: absolute;
+                top: 0;
+                left: 0;
+                z-index: 1;
+                justify-content: start;
+                width: 100%;
+                height: 100%;
+
+                :deep(.input-button) {
+                    width: 100%;
+                }
+            }
         }
 
         .form-nav-button {
@@ -67,7 +86,7 @@
 
     .form-override-buttons {
         .form-override-button {
-            margin-bottom: 0.8rem;
+            margin-bottom: 0;
 
             :deep(.input-button) {
                 font-weight: @fontWeight;


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Update practitioner registration and obtain privileges form to include a feature that scrolls and focuses the user to the first invalid required input in the form (from top to bottom)
    - Undoes the prior flow which includes disabled continue buttons until all required fields are valid 
- Improve unrelated test coverage
- Fix mobile bug where nav would scroll behind the fixed next / previous buttons in the obtain privileges flow
- Update payment summary screen title

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- yarn test:unit:coverage` confirm the branches line item has an updated acceptable percentage
- Code review
- Testing
    - Proceed to the practitioner registration form and confirm that the continue button is no longer disabled and will auto position screen to the first invalid required field in the form, as well as direct focus on that input element, with the exception of radio buttons which will focus the entire input group
    - Confirm that same experience in the obtain privileges form flow with a slight exception to the select privileges screen which disables the continue button initially until at least 1 state is selected

Closes #855 #863 
