### PR TITLE
Frontend/storage switch and redirect preserve

### DIFF
--- a/webroot/src/app.config.ts
+++ b/webroot/src/app.config.ts
@@ -4,7 +4,7 @@
 //
 //  Created by InspiringApps on 4/27/21.
 //
-import sessionStorage from '@store/session.storage';
+import localStorage from '@store/local.storage';
 
 // =========================
 // =  Authorization Types  =
@@ -37,7 +37,7 @@ export enum FeeTypes {
 // ====================
 // =   Auth storage   =
 // ====================
-export const authStorage = sessionStorage;
+export const authStorage = localStorage;
 export const tokens = {
     staff: {
         AUTH_TOKEN: 'auth_token_staff',
@@ -54,8 +54,9 @@ export const tokens = {
         REFRESH_TOKEN: 'refresh_token_licensee',
     },
 };
-export const AUTH_LOGIN_GOTO_PATH = 'login_goto';
 export const AUTH_TYPE = 'auth_type';
+export const AUTH_LOGIN_GOTO_PATH = 'login_goto';
+export const AUTH_LOGIN_GOTO_PATH_AUTH_TYPE = 'login_goto_auth_type';
 
 // ====================
 // =  User Languages  =

--- a/webroot/src/pages/AuthCallback/AuthCallback.ts
+++ b/webroot/src/pages/AuthCallback/AuthCallback.ts
@@ -9,7 +9,13 @@ import { nextTick } from 'vue';
 import { Component, Vue } from 'vue-facing-decorator';
 import Section from '@components/Section/Section.vue';
 import Card from '@components/Card/Card.vue';
-import { authStorage, AuthTypes, AUTH_LOGIN_GOTO_PATH } from '@/app.config';
+import {
+    authStorage,
+    AuthTypes,
+    AUTH_TYPE,
+    AUTH_LOGIN_GOTO_PATH,
+    AUTH_LOGIN_GOTO_PATH_AUTH_TYPE
+} from '@/app.config';
 import axios from 'axios';
 
 @Component({
@@ -124,9 +130,13 @@ export default class AuthCallback extends Vue {
 
     async redirectUser(): Promise<void> {
         const goto = authStorage.getItem(AUTH_LOGIN_GOTO_PATH);
+        const gotoAuthType = authStorage.getItem(AUTH_LOGIN_GOTO_PATH_AUTH_TYPE);
+        const currentAuthType = authStorage.getItem(AUTH_TYPE);
 
-        if (goto) {
-            authStorage.removeItem(AUTH_LOGIN_GOTO_PATH);
+        authStorage.removeItem(AUTH_LOGIN_GOTO_PATH);
+        authStorage.removeItem(AUTH_LOGIN_GOTO_PATH_AUTH_TYPE);
+
+        if (goto && (!gotoAuthType || gotoAuthType === currentAuthType)) {
             this.$router.push({ path: goto });
         } else {
             await nextTick();

--- a/webroot/src/pages/Logout/Logout.ts
+++ b/webroot/src/pages/Logout/Logout.ts
@@ -8,8 +8,10 @@
 import { Component, Vue } from 'vue-facing-decorator';
 import {
     authStorage,
-    AUTH_LOGIN_GOTO_PATH,
     AuthTypes,
+    AUTH_TYPE,
+    AUTH_LOGIN_GOTO_PATH,
+    AUTH_LOGIN_GOTO_PATH_AUTH_TYPE,
     tokens
 } from '@/app.config';
 
@@ -81,23 +83,28 @@ export default class Logout extends Vue {
             await this.logoutChecklist(isRemoteLoggedInAsLicenseeOnly);
             this.beginLogoutRedirectChain(isRemoteLoggedInAsLicenseeOnly);
         } else {
+            await this.logoutChecklist(false);
             window.location.replace(this.loginURL);
         }
     }
 
     async logoutChecklist(isRemoteLoggedInAsLicenseeOnly): Promise<void> {
-        const authType = isRemoteLoggedInAsLicenseeOnly ? AuthTypes.LICENSEE : AuthTypes.STAFF;
+        const authType = (isRemoteLoggedInAsLicenseeOnly) ? AuthTypes.LICENSEE : AuthTypes.STAFF;
 
-        this.$store.dispatch('user/clearRefreshTokenTimeout');
         this.stashWorkingUri();
+        this.$store.dispatch('user/clearRefreshTokenTimeout');
         await this.$store.dispatch('user/logoutRequest', authType);
     }
 
     stashWorkingUri(): void {
         const { workingUri } = this;
+        const authType = authStorage.getItem(AUTH_TYPE);
 
         if (workingUri) {
             authStorage.setItem(AUTH_LOGIN_GOTO_PATH, workingUri);
+            if (authType) {
+                authStorage.setItem(AUTH_LOGIN_GOTO_PATH_AUTH_TYPE, authType);
+            }
         }
     }
 

--- a/webroot/src/pages/PublicDashboard/PublicDashboard.ts
+++ b/webroot/src/pages/PublicDashboard/PublicDashboard.ts
@@ -6,7 +6,12 @@
 //
 
 import { Component, Vue } from 'vue-facing-decorator';
-import { AuthTypes } from '@/app.config';
+import {
+    authStorage,
+    AuthTypes,
+    AUTH_LOGIN_GOTO_PATH,
+    AUTH_LOGIN_GOTO_PATH_AUTH_TYPE
+} from '@/app.config';
 import SearchIcon from '@components/Icons/Search/Search.vue';
 import RegisterIcon from '@components/Icons/RegisterAlt/RegisterAlt.vue';
 import StaffUserIcon from '@components/Icons/StaffUser/StaffUser.vue';
@@ -81,6 +86,8 @@ export default class DashboardPublic extends Vue {
     }
 
     async mockStaffLogin(): Promise<void> {
+        const goto = authStorage.getItem(AUTH_LOGIN_GOTO_PATH);
+        const gotoAuthType = authStorage.getItem(AUTH_LOGIN_GOTO_PATH_AUTH_TYPE);
         const data = {
             access_token: 'mock_access_token',
             token_type: 'Bearer',
@@ -89,13 +96,21 @@ export default class DashboardPublic extends Vue {
             refresh_token: 'mock_refresh_token'
         };
 
+        authStorage.removeItem(AUTH_LOGIN_GOTO_PATH);
+        authStorage.removeItem(AUTH_LOGIN_GOTO_PATH_AUTH_TYPE);
         await this.$store.dispatch('user/updateAuthTokens', { tokenResponse: data, authType: AuthTypes.STAFF });
         this.$store.dispatch('user/loginSuccess', AuthTypes.STAFF);
 
-        this.$router.push({ name: 'Home' });
+        if (goto && (!gotoAuthType || gotoAuthType === AuthTypes.STAFF)) {
+            this.$router.push({ path: goto });
+        } else {
+            this.$router.push({ name: 'Home' });
+        }
     }
 
     async mockLicenseeLogin(): Promise<void> {
+        const goto = authStorage.getItem(AUTH_LOGIN_GOTO_PATH);
+        const gotoAuthType = authStorage.getItem(AUTH_LOGIN_GOTO_PATH_AUTH_TYPE);
         const data = {
             access_token: 'mock_access_token',
             token_type: 'Bearer',
@@ -104,9 +119,15 @@ export default class DashboardPublic extends Vue {
             refresh_token: 'mock_refresh_token'
         };
 
+        authStorage.removeItem(AUTH_LOGIN_GOTO_PATH);
+        authStorage.removeItem(AUTH_LOGIN_GOTO_PATH_AUTH_TYPE);
         await this.$store.dispatch('user/updateAuthTokens', { tokenResponse: data, authType: AuthTypes.LICENSEE });
         this.$store.dispatch('user/loginSuccess', AuthTypes.LICENSEE);
 
-        this.$router.push({ name: 'Home' });
+        if (goto && (!gotoAuthType || gotoAuthType === AuthTypes.LICENSEE)) {
+            this.$router.push({ path: goto });
+        } else {
+            this.$router.push({ name: 'Home' });
+        }
     }
 }

--- a/webroot/src/router/index.ts
+++ b/webroot/src/router/index.ts
@@ -48,7 +48,11 @@ router.beforeEach(async (to, from, next) => {
         const { isLoggedIn } = store.getters['user/state'];
 
         if (!isLoggedIn) {
-            next({ name: 'Logout' });
+            if (to?.path) {
+                next({ name: 'Logout', query: { goto: to.path }});
+            } else {
+                next({ name: 'Logout' });
+            }
         } else if ((isLicenseeRoute && isStaffRoute)
         || (isLicenseeRoute && authStorage.getItem(AUTH_TYPE) === AuthTypes.LICENSEE)
         || (isStaffRoute && authStorage.getItem(AUTH_TYPE) === AuthTypes.STAFF)) {


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Changed the storage for auth from `sessionStorage` to `localStorage`
- Added the ability to preserve the requested path through the auth workflow
    - e.g. If users get logged out by the router nav guard, the app will attempt to route them to that page after the next time they (re)authenticate

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - After authenticating, additional browser tabs can be opened to the app without having to re-authenticate
    - If attempting to access an authenticated page while logged out, that page should be the landing page after logging in. Otherwise, logging in should redirect to the same default pages as before.
        - Example 1 (Staff)
            1. Login as a Staff user
            1. Search licensing data and navigate to the detail page of a licensee
            1. Copy the URL of the staff-authenticated licensee detail page
            1. Logout
            1. Attempt to visit the copied URL (the staff-authenticated licensee detail page)
            1. Since you are not logged in, you should be taken to the public dashboard page
            1. Login as the same staff user
            1. After successful login, you should be automatically redirected to the licensee detail page you tried to request while logged out
            1. Logout
            1. Login as the same Staff user
            1. After successful login, you should be automatically redirected to the default staff home page - licensee search page - because you didn't request any specific pages while logged out (as expected)
        - Example 2 (Licensee)
            1. Keep the same staff-authenticated licensee detail page URL copied from Example 1 (Staff) above
            1. While logged out, attempt to visit the copied URL (the staff-authenticated licensee detail page)
            1. Since you are not logged in, you should be taken to the public dashboard page
            1. Login as a _Licensee_ user
            1. After successful login, you should be automatically redirected to the default licensee home page - the licensee dashboard - because the staff URL you attempted while logged out is not a valid licensee page
            1. Visit the Generate-verification-doc page as a licensee
            1. Copy the URL of the licensee-authenticate verification-doc page
            1. Logout
            1. Attempt to visit the copied URL (the licensee-authenticate verification-doc page)
            1. Since you are not logged in, you should be taken to the public dashboard page
            1. Login as the same licensee user
            1. After successful login, you should be automatically redirected to the licensee detail page you tried to request while logged out
            1. Logout
            1. Login as the same Licensee user
            1. After successful login, you should be automatically redirected to the default licensee home page - licensee dashboard - because you didn't request any specific pages while logged out (as expected)

Closes #866 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved user redirection after authentication and logout by preserving both the intended destination and authentication type.
  * Users are now redirected back to their original path after login if the authentication type matches.

* **Bug Fixes**
  * Ensured the logout checklist runs consistently, even when the user is not logged in.

* **Enhancements**
  * Enhanced navigation logic to better handle redirect paths and authentication types across login, logout, and mock login scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->