### PR TITLE
Return 400 error for specific auth.net error code

### DIFF
--- a/backend/compact-connect/lambdas/python/purchases/purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/purchase_client.py
@@ -30,9 +30,10 @@ MAXIMUM_TRANSACTION_API_LIMIT = 1000
 # information passed in by the user, and an internal issue caused by the API itself. To account for this, we
 # pulled the list of known issues from their transaction response code lookup and put the list of error codes that are
 # likely caused by the user. These include issues such as an invalid or unsupported card number, the expiration date
-# being expired, or the card being declined. You can review the description of these codes by searching for them at
-# https://developer.authorize.net/api/reference/responseCodes.html
-AUTHORIZE_NET_CARD_USER_ERROR_CODES = ['2', '5', '6', '7', '8', '11', '17', '65']
+# being expired, or the card being declined. E00114 is included as it represents a suspicious activity filter
+# rejection that should be handled as a user error with retry guidance. You can review the description of these codes
+# by searching for them at https://developer.authorize.net/api/reference/responseCodes.html
+AUTHORIZE_NET_CARD_USER_ERROR_CODES = ['2', '5', '6', '7', '8', '11', '17', '65', 'E00114']
 
 # The authorizenet SDK emits many warnings due to a Pyxb issue that they will not address,
 # see https://github.com/AuthorizeNet/sdk-python/issues/133,
@@ -255,6 +256,15 @@ class AuthorizeNetPaymentProcessorClient(PaymentProcessorClient):
                 logger.warning(
                     logger_message, transaction_error_code=error_code, transaction_error_message=error_message
                 )
+                # This error code occurs most likely if Authorize.net filtered a request as suspicious
+                # We return this as a user error, with this message to let the user know they can try again
+                # after waiting, as Authorize.net advises having a delay before processing the request in this case.
+                # see https://github.com/csg-org/CompactConnect/issues/889 for more info
+                if error_code == 'E00114':
+                    raise CCInvalidRequestException(
+                        "The transaction was declined by the payment processor's security filters. "
+                        'Please wait a moment and try your transaction again.'
+                    )
                 raise CCInvalidRequestException(
                     f'Failed to process transaction. Error code: {error_code}, Error message: {error_message}'
                 )

--- a/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
+++ b/backend/compact-connect/lambdas/python/purchases/tests/unit/test_purchase_client.py
@@ -262,11 +262,11 @@ class TestAuthorizeDotNetPurchaseClient(TstLambdas):
 
         # Set up the 'code' field to support message['code']
         code_mock = MagicMock()
-        code_mock.text = 'E00114'
+        code_mock.text = error_code
 
         # Set up the 'text' field
         text_mock = MagicMock()
-        text_mock.text = 'Invalid OTS Token.'
+        text_mock.text = error_text
 
         # Add dictionary-style access for message['text']
         def message_getitem_with_text_attribute(self, key):


### PR DESCRIPTION
During user testing with practitioners, because we were using test card numbers with repeated names and privilege prices, the Authorize.net suspicious activity filter denied several requests, and this caused the API to fail with a 5xx error. The system should gracefully handle this scenario.

This adds a check for that specific error code so the backend will return a 400 with a message informing the user to try again.

Closes #889 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for declined transactions due to suspicious activity filters, providing users with clearer guidance to wait and retry later.

* **Tests**
  * Added tests to verify proper handling and user messaging when transactions are declined by security filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->