### PR TITLE
Update permission policy for user pool

### DIFF
--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -75,7 +75,15 @@ class UserPool(CdkUserPool):
             ),
             mfa=Mfa.REQUIRED if security_profile == SecurityProfile.RECOMMENDED else Mfa.OPTIONAL,
             mfa_second_factor=MfaSecondFactor(otp=True, sms=False),
-            password_policy=PasswordPolicy(min_length=12) if not password_policy else password_policy,
+            password_policy=PasswordPolicy(
+                min_length=12,
+                require_digits=True,
+                require_lowercase=True,
+                require_uppercase=True,
+                password_history_size=4,
+            )
+            if not password_policy
+            else password_policy,
             self_sign_up_enabled=False,
             sign_in_aliases=sign_in_aliases,
             sign_in_case_sensitive=False,

--- a/backend/compact-connect/lambdas/python/cognito-backup/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/cognito-backup/tests/function/__init__.py
@@ -36,10 +36,10 @@ class TstFunction(TstLambdas):
             PoolName='test-user-pool',
             Policies={
                 'PasswordPolicy': {
-                    'MinimumLength': 8,
-                    'RequireUppercase': False,
-                    'RequireLowercase': False,
-                    'RequireNumbers': False,
+                    'MinimumLength': 12,
+                    'RequireUppercase': True,
+                    'RequireLowercase': True,
+                    'RequireNumbers': True,
                     'RequireSymbols': False,
                 }
             },

--- a/backend/compact-connect/lambdas/python/common/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/common/tests/function/__init__.py
@@ -60,9 +60,9 @@ class TstFunction(TstLambdas):
             Policies={
                 'PasswordPolicy': {
                     'MinimumLength': 12,
-                    'RequireUppercase': False,
-                    'RequireLowercase': False,
-                    'RequireNumbers': False,
+                    'RequireUppercase': True,
+                    'RequireLowercase': True,
+                    'RequireNumbers': True,
                     'RequireSymbols': False,
                 },
             },

--- a/backend/compact-connect/stacks/provider_users/provider_users.py
+++ b/backend/compact-connect/stacks/provider_users/provider_users.py
@@ -56,7 +56,13 @@ class ProviderUsers(UserPool):
                 'providerId': StringAttribute(mutable=False),
                 'compact': StringAttribute(mutable=False),
             },
-            password_policy=PasswordPolicy(min_length=12, temp_password_validity=Duration.days(1)),
+            password_policy=PasswordPolicy(
+                min_length=12,
+                require_digits=True,
+                require_lowercase=True,
+                require_uppercase=True,
+                temp_password_validity=Duration.days(1),
+            ),
             **kwargs,
         )
 


### PR DESCRIPTION
As part of working with OT to fill out the SAQ A form, it listed a section which sets the following password requirements for staff users:

1. passwords minimum of 12 characters
2. passwords use both numbers and letters
3. users cannot use last 4 previous passwords when resetting password.

This configures this in our CDK logic for user pools. It shouldn't take more than a day now that we now where this is set.

For practitioners, since they do not have any admin access to payment credentials, we do not need to enforce any of these according to the SAQ A form. We set the first two items since this was part of the original request for this ticket.

Closes #899
