### PR TITLE
Feat/military affiliation file download

### DIFF
--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -644,8 +644,8 @@ def _generate_pre_signed_urls_for_military_affiliation_records(provider: dict):
                 # for an affiliation record, but there were hints that this may change in the future in which case
                 # we would need to generate links per document key.
                 Params={'Bucket': config.provider_user_bucket_name, 'Key': record['documentKeys'][0]},
-                # 8 hours in seconds, to avoid links becoming stale during their session.
-                ExpiresIn=28800,
+                # 2 hours in seconds, to avoid links becoming stale during their session.
+                ExpiresIn=7200,
             )
             # returning this as a list of one for now, to support multiple download links in the future
             record['downloadLinks'] = [{'fileName': record['fileNames'][0], 'url': url}]

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -665,12 +665,18 @@ def sanitize_provider_data_based_on_caller_scopes(compact: str, provider: dict, 
     :param set scopes: The caller's scopes from the request.
     :return: The provider record, sanitized based on the user's scopes.
     """
-    if caller_is_compact_admin(compact, caller_scopes=scopes):
+
+    caller_is_admin = caller_is_compact_admin(compact, caller_scopes=scopes)
+    if caller_is_admin:
         # compact admins have the ability to download military affiliation records
         # so we generate a pre-signed url per military affiliation document
         _generate_pre_signed_urls_for_military_affiliation_records(provider)
 
-    if _user_has_read_private_access_for_provider(compact=compact, provider_information=provider, scopes=scopes):
+    # Currently, the UI bundles permissions for admins, granting them the readPrivate scope along with admin. Should
+    # this ever change, we will need to account for that here. This 'or' conditional is a precautionary measure to keep
+    # UI changes from unintentionally breaking existing functionality
+    if (caller_is_admin or
+            _user_has_read_private_access_for_provider(compact=compact, provider_information=provider, scopes=scopes)):
         # return full object since caller has 'readPrivate' access for provider
         return provider
 

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -575,11 +575,7 @@ def get_sub_from_user_attributes(attributes: list):
 
 def caller_is_compact_admin(compact: str, caller_scopes: set[str]) -> bool:
     if f'{compact}/{CCPermissionsAction.ADMIN}' in caller_scopes:
-        logger.debug(
-            'User has admin permission at compact level',
-            compact=compact,
-            scopes=caller_scopes
-        )
+        logger.debug('User has admin permission at compact level', compact=compact, scopes=caller_scopes)
         return True
 
     return False
@@ -637,19 +633,8 @@ def _user_has_permission_for_action_on_user(
 
 def _generate_pre_signed_urls_for_military_affiliation_records(provider: dict):
     """
-    {
-      "pk": "aslp#PROVIDER#89a6377e-c3a5-40e5-bca5-317ec854c570",
-      "sk": "aslp#PROVIDER#military-affiliation#2024-11-08",
-      "providerId": "89a6377e-c3a5-40e5-bca5-317ec854c570",
-      "compact": "aslp",
-      "type": "militaryAffiliation",
-      "documentKeys": ["/provider/89a6377e-c3a5-40e5-bca5-317ec854c570/document-type/military-affiliations/2024-07-08/1234#military-waiver.pdf"],
-      "affiliationType": "militaryMember",
-      "fileNames": ["military-waiver.pdf"],
-      "status": "active",
-      "dateOfUpload": "2024-11-08T23:59:59+00:00",
-      "dateOfUpdate": "2024-11-08T23:59:59+00:00"
-    }
+    Generates temporary S3 pre-signed urls to allow users with the link to access documents.
+    See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html
     """
     for record in provider['militaryAffiliations']:
         try:
@@ -663,10 +648,7 @@ def _generate_pre_signed_urls_for_military_affiliation_records(provider: dict):
                 ExpiresIn=28800,
             )
             # returning this as a list of one for now, to support multiple download links in the future
-            record['downloadLinks'] = [{
-                "fileName": record['fileNames'][0],
-                "url": url
-            }]
+            record['downloadLinks'] = [{'fileName': record['fileNames'][0], 'url': url}]
         except ClientError as e:
             # if the url could not be generated, we log the error and continue, so as to not fail the entire request
             # for this peripheral feature
@@ -687,7 +669,6 @@ def sanitize_provider_data_based_on_caller_scopes(compact: str, provider: dict, 
         # compact admins have the ability to download military affiliation records
         # so we generate a pre-signed url per military affiliation document
         _generate_pre_signed_urls_for_military_affiliation_records(provider)
-
 
     if _user_has_read_private_access_for_provider(compact=compact, provider_information=provider, scopes=scopes):
         # return full object since caller has 'readPrivate' access for provider

--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -631,9 +631,9 @@ def _user_has_permission_for_action_on_user(
     return False
 
 
-def _generate_pre_signed_urls_for_military_affiliation_records(provider: dict):
+def _inject_pre_signed_urls_into_military_affiliation_records(provider: dict):
     """
-    Generates temporary S3 pre-signed urls to allow users with the link to access documents.
+    Generates temporary S3 pre-signed urls to allow users with the link to access the associated document.
     See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html
     """
     for record in provider['militaryAffiliations']:
@@ -642,7 +642,7 @@ def _generate_pre_signed_urls_for_military_affiliation_records(provider: dict):
                 'get_object',
                 # the 'documentKeys' field is a list of 1, as we only support uploading one military affiliation record
                 # for an affiliation record, but there were hints that this may change in the future in which case
-                # we would need to generate links per document key.
+                # we would need to generate a link per document key.
                 Params={'Bucket': config.provider_user_bucket_name, 'Key': record['documentKeys'][0]},
                 # 2 hours in seconds, to avoid links becoming stale during their session.
                 ExpiresIn=7200,
@@ -670,7 +670,7 @@ def sanitize_provider_data_based_on_caller_scopes(compact: str, provider: dict, 
     if caller_is_admin:
         # compact admins have the ability to download military affiliation records
         # so we generate a pre-signed url per military affiliation document
-        _generate_pre_signed_urls_for_military_affiliation_records(provider)
+        _inject_pre_signed_urls_into_military_affiliation_records(provider)
 
     # Currently, the UI bundles permissions for admins, granting them the readPrivate scope along with admin. Should
     # this ever change, we will need to account for that here. This 'or' conditional is a precautionary measure to keep

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_providers.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_providers.py
@@ -276,10 +276,10 @@ class TestGetProvider(TstFunction):
             sk = json.load(f)['sk']
         # The actual sensitive part is the hash at the end of the key
         return sk.split('/')[-1]
-    
+
     def _call_get_provider_and_return_provider_data(self, scopes: str):
         from handlers.providers import get_provider
-        
+
         with open('../common/tests/resources/api-event.json') as f:
             event = json.load(f)
 
@@ -299,7 +299,6 @@ class TestGetProvider(TstFunction):
         self.assertNotIn(sensitive_hash, resp['body'])
 
         return provider_data
-    
 
     def _when_testing_get_provider_response_based_on_read_access(self, scopes: str, expected_provider: dict):
         self._load_provider_data()
@@ -388,12 +387,16 @@ class TestGetProvider(TstFunction):
             scopes='openid email aslp/readGeneral aslp/admin aslp/readPrivate'
         )
 
-        self.assertEqual('military-waiver.pdf',
-                         provider_data['militaryAffiliations'][0]['downloadLinks'][0]['fileName'])
+        self.assertEqual(
+            'military-waiver.pdf', provider_data['militaryAffiliations'][0]['downloadLinks'][0]['fileName']
+        )
         # we can't assert on the whole url, since it changes with time
         # we can verify the path to the file matches expected values
-        self.assertIn('https://provider-user-bucket.s3.amazonaws.com//provider/89a6377e-c3a5-40e5-bca5-317ec854c570/document-type/military-affiliations/2024-07-08/1234%23military-waiver.pdf',
-                      provider_data['militaryAffiliations'][0]['downloadLinks'][0]['url'])
+        self.assertIn(
+            'https://provider-user-bucket.s3.amazonaws.com//provider/89a6377e-c3a5-40e5-bca5-317ec854c570/document-type/military-affiliations/2024-07-08/1234%23military-waiver.pdf',
+            provider_data['militaryAffiliations'][0]['downloadLinks'][0]['url'],
+        )
+
 
 @mock_aws
 class TestGetProviderSSN(TstFunction):

--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -1341,6 +1341,17 @@ class ApiModel:
                                 type=JsonSchemaType.STRING, format='date', pattern=cc_api.YMD_FORMAT
                             ),
                             'status': JsonSchema(type=JsonSchemaType.STRING, enum=['active', 'inactive']),
+                            'downloadLinks': JsonSchema(
+                                type=JsonSchemaType.ARRAY,
+                                items=JsonSchema(
+                                    type=JsonSchemaType.OBJECT,
+                                    required=['url', 'fileName'],
+                                    properties={
+                                        'url': JsonSchema(type=JsonSchemaType.STRING),
+                                        'fileName': JsonSchema(type=JsonSchemaType.STRING),
+                                    },
+                                ),
+                            ),
                         },
                     ),
                 ),

--- a/backend/compact-connect/stacks/api_stack/v1_api/provider_management.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/provider_management.py
@@ -21,6 +21,7 @@ from common_constructs.cc_api import CCApi
 from common_constructs.nodejs_function import NodejsFunction
 from common_constructs.python_function import PythonFunction
 from common_constructs.stack import Stack
+from persistent_stack import ProviderUsersBucket
 
 from stacks import persistent_stack as ps
 from stacks.persistent_stack import ProviderTable, RateLimitingTable, SSNTable, StaffUsers
@@ -64,6 +65,7 @@ class ProviderManagement:
             'USER_POOL_ID': persistent_stack.staff_users.user_pool_id,
             'EMAIL_NOTIFICATION_SERVICE_LAMBDA_NAME': persistent_stack.email_notification_service_lambda.function_name,
             'USERS_TABLE_NAME': persistent_stack.staff_users.user_table.table_name,
+            'PROVIDER_USER_BUCKET_NAME': persistent_stack.provider_users_bucket.bucket_name,
             **stack.common_env_vars,
         }
 
@@ -95,6 +97,7 @@ class ProviderManagement:
             method_options=method_options,
             data_encryption_key=persistent_stack.shared_encryption_key,
             provider_data_table=persistent_stack.provider_table,
+            provider_users_bucket=persistent_stack.provider_users_bucket,
             lambda_environment=lambda_environment,
         )
         self._add_get_provider_ssn(
@@ -135,6 +138,7 @@ class ProviderManagement:
         method_options: MethodOptions,
         data_encryption_key: IKey,
         provider_data_table: ProviderTable,
+        provider_users_bucket: ProviderUsersBucket,
         lambda_environment: dict,
     ):
         self.get_provider_handler = self._get_provider_handler(
@@ -142,6 +146,7 @@ class ProviderManagement:
             provider_data_table=provider_data_table,
             lambda_environment=lambda_environment,
         )
+        provider_users_bucket.grant_read(self.get_provider_handler)
         self.api.log_groups.append(self.get_provider_handler.log_group)
 
         self.provider_resource.add_method(

--- a/backend/compact-connect/stacks/api_stack/v1_api/provider_management.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/provider_management.py
@@ -21,10 +21,9 @@ from common_constructs.cc_api import CCApi
 from common_constructs.nodejs_function import NodejsFunction
 from common_constructs.python_function import PythonFunction
 from common_constructs.stack import Stack
-from persistent_stack import ProviderUsersBucket
 
 from stacks import persistent_stack as ps
-from stacks.persistent_stack import ProviderTable, RateLimitingTable, SSNTable, StaffUsers
+from stacks.persistent_stack import ProviderTable, ProviderUsersBucket, RateLimitingTable, SSNTable, StaffUsers
 
 from .api_model import ApiModel
 

--- a/backend/compact-connect/tests/resources/snapshots/GET_PROVIDER_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/GET_PROVIDER_RESPONSE_SCHEMA.json
@@ -1700,6 +1700,24 @@
               "inactive"
             ],
             "type": "string"
+          },
+          "downloadLinks": {
+            "items": {
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "fileName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "fileName"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           }
         },
         "required": [

--- a/backend/compact-connect/tests/resources/snapshots/PROVIDER_USER_RESPONSE_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PROVIDER_USER_RESPONSE_SCHEMA.json
@@ -1700,6 +1700,24 @@
               "inactive"
             ],
             "type": "string"
+          },
+          "downloadLinks": {
+            "items": {
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "fileName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "fileName"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           }
         },
         "required": [

--- a/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
@@ -187,7 +187,7 @@ def get_provider_data_with_read_private_access_smoke_test(test_staff_user_id: st
 
     # Step 3: Verify the Provider response matches the profile.
     provider_object = get_provider_response.json()
-    # because this test staff user is a compact admin, there will be download links present the
+    # because this test staff user is a compact admin, there will be download links present for the
     # military affiliation files, so we need to account for those here by removing them from the
     # list of military records and checking the links to verify they are valid
     for record in provider_object['militaryAffiliations']:

--- a/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
@@ -54,26 +54,34 @@ def get_general_provider_user_data_smoke_test():
     logger.info('Received success response from GET endpoint')
 
     # Step 3: Verify the Provider response matches the profile.
-    provider_object = get_provider_response.json()
+    get_provider_general_provider_object = get_provider_response.json()
 
     # verify the ssn is NOT in the response
-    if 'ssn' in provider_object:
+    if 'ssn' in get_provider_general_provider_object:
         raise SmokeTestFailureException(f'unexpected ssn field returned. Response: {get_provider_response.json()}')
 
     # remove the fields from the user profile that are not in the query response
-    test_user_profile.pop('ssn', None)
+    test_user_profile.pop('ssnLastFour', None)
     test_user_profile.pop('dateOfBirth', None)
+    test_user_profile.pop('encumberedStatus', None)
     for provider_license in test_user_profile['licenses']:
-        provider_license.pop('ssn', None)
+        provider_license.pop('ssnLastFour', None)
         provider_license.pop('dateOfBirth', None)
+        # TODO - should the general response not include the encumbered status
+        test_user_profile.pop('encumberedStatus', None)
+        for history_event in provider_license['history']:
+            history_event['previous'].pop('ssnLastFour', None)
+            history_event['previous'].pop('dateOfBirth', None)
+            # TODO - should the general response not include the encumbered status
+            history_event['previous'].pop('encumberedStatus', None)
     for military_affiliation in test_user_profile['militaryAffiliations']:
         military_affiliation.pop('documentKeys', None)
 
-    if provider_object != test_user_profile:
+    if get_provider_general_provider_object != test_user_profile:
         raise SmokeTestFailureException(
             f'Provider object does not match the profile.\n'
-            f'Profile response: {json.dumps(test_user_profile)}\n'
-            f'Get Provider response: {json.dumps(provider_object)}'
+            f'Get Provider response: {str(get_provider_general_provider_object)}\n'
+            f'Profile response: {str(test_user_profile)}\n'
         )
     logger.info('Successfully fetched expected provider records.')
 
@@ -177,6 +185,30 @@ def get_provider_data_with_read_private_access_smoke_test(test_staff_user_id: st
 
     # Step 3: Verify the Provider response matches the profile.
     provider_object = get_provider_response.json()
+    # because this test staff user is a compact admin, there will be download links present the
+    # military affiliation files, so we need to account for those here by removing them from the
+    # list of military records and checking the links to verify they are valid
+    for record in provider_object['militaryAffiliations']:
+        if 'downloadLinks' in record.keys():
+            download_links = record.pop('downloadLinks')
+            # Verify the download link is valid and can download the file
+            for download_link in download_links:
+                if 'url' not in download_link or 'fileName' not in download_link:
+                    raise SmokeTestFailureException(f'Invalid download link structure: {download_link}')
+
+                # Attempt to download the file using the pre-signed URL
+                download_response = requests.get(download_link['url'], timeout=30)
+                if download_response.status_code != 200:
+                    raise SmokeTestFailureException(
+                        f'Failed to download file from pre-signed URL. Status code: {download_response.status_code}, '
+                        f'URL: {download_link["url"]}, File name: {download_link["fileName"]}'
+                    )
+                logger.info(f'Successfully downloaded file: {download_link["fileName"]}')
+        else:
+            raise SmokeTestFailureException(
+                f'Missing expected download links for military affiliation. Military affiliation: {record}'
+            )
+
     if provider_object != test_user_profile:
         raise SmokeTestFailureException(
             f'Provider object does not match the profile.\n'

--- a/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
+++ b/backend/compact-connect/tests/smoke/query_provider_smoke_tests.py
@@ -199,6 +199,7 @@ def get_provider_data_with_read_private_access_smoke_test(test_staff_user_id: st
                     raise SmokeTestFailureException(f'Invalid download link structure: {download_link}')
 
                 # Attempt to download the file using the pre-signed URL
+                logger.info(f'downloading test file from {download_link["url"]}')
                 download_response = requests.get(download_link['url'], timeout=30)
                 if download_response.status_code != 200:
                     raise SmokeTestFailureException(


### PR DESCRIPTION
We need to enable compact admins with the ability to verify military affiliation records that practitioners upload when claiming a military affiliation in the system. This adds logic to generate S3 pre-signed URLs in the provider detail response whenever a compact admin calls this endpoint, which the frontend will call to get the requested file.

Closes #775


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Military affiliation records for providers now include downloadable document links, accessible to users with admin-level permissions.
  * Provider data responses and schemas have been updated to support these download links within military affiliation details.
  * Lambda environment updated to enable access to provider user document storage for relevant operations.

* **Bug Fixes**
  * Enhanced validation and error reporting for provider data in smoke tests, including verification of document download links.

* **Tests**
  * Added tests to verify military affiliation document download links for admin users.
  * Refactored existing tests for improved maintainability and clarity.

* **Documentation**
  * Updated response schema documentation to include the new `downloadLinks` property for military affiliations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->