### PR TITLE
Frontend/privilege selection updates

### DIFF
--- a/webroot/src/components/Forms/MockPopulate/MockPopulate.less
+++ b/webroot/src/components/Forms/MockPopulate/MockPopulate.less
@@ -6,6 +6,7 @@
 //
 
 .mock-populate {
+    display: inline-block;
     color: @midBlue;
     font-style: italic;
     cursor: pointer;

--- a/webroot/src/components/Forms/MockPopulate/MockPopulate.ts
+++ b/webroot/src/components/Forms/MockPopulate/MockPopulate.ts
@@ -18,6 +18,7 @@ import {
 })
 class MockPopulate extends Vue {
     @Prop({ default: false }) isEnabled?: boolean;
+    @Prop({ default: '' }) customLabel?: string;
 
     //
     // Methods

--- a/webroot/src/components/Forms/MockPopulate/MockPopulate.vue
+++ b/webroot/src/components/Forms/MockPopulate/MockPopulate.vue
@@ -12,7 +12,8 @@
         @keyup.enter="clicked"
         class="mock-populate"
     >
-        {{ $t('styleGuide.mockPopulate') }}
+        <template v-if="customLabel">{{ customLabel }}</template>
+        <template v-else>{{ $t('styleGuide.mockPopulate') }}</template>
     </div>
 </template>
 

--- a/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.less
+++ b/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.less
@@ -13,6 +13,11 @@
         align-items: center;
         width: 100%;
 
+        .form-error-message {
+            padding: 2rem;
+            color: @midRed;
+        }
+
         .button-row {
             .purchase-flow-buttons();
         }
@@ -58,21 +63,10 @@
 
             .lists-container {
                 display: flex;
-                flex-direction: column;
-                align-items: center;
-
-                @media @tabletWidth {
-                    flex-direction: row;
-                    align-items: flex-start;
-                    justify-content: space-between;
-                }
 
                 .state-select-list {
-                    display: flex;
-                    flex-flow: column wrap;
-
                     @media @desktopWidth {
-                        max-height: 80vh;
+                        column-count: 2;
                     }
 
                     .state-unit {

--- a/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.ts
+++ b/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.ts
@@ -295,7 +295,7 @@ export default class PrivilegePurchaseSelect extends mixins(MixinForm) {
         this.watchFormInputs();
     }
 
-    addStateAttestationInputs(stateAbbrev: string) {
+    addStateAttestationInputs(stateAbbrev: string): void {
         const stateObj = this.purchaseDataList.find(
             (option) => option.jurisdiction?.abbrev === stateAbbrev
         );
@@ -323,12 +323,12 @@ export default class PrivilegePurchaseSelect extends mixins(MixinForm) {
         });
     }
 
-    removeStateAttestationInputs(stateAbbrev: string) {
+    removeStateAttestationInputs(stateAbbrev: string): void {
         delete this.formData[`jurisprudence-${stateAbbrev}`];
         delete this.formData[`scope-${stateAbbrev}`];
     }
 
-    toggleStateSelected(stateFormInput) {
+    toggleStateSelected(stateFormInput): void {
         const newStateFormInputValue = !stateFormInput.value;
         const stateAbbrev = stateFormInput.id;
 
@@ -345,7 +345,7 @@ export default class PrivilegePurchaseSelect extends mixins(MixinForm) {
         }
     }
 
-    deselectState(stateAbbrev: string) {
+    deselectState(stateAbbrev: string): void {
         this.formData.stateCheckList.find((checkBox) => (checkBox.id === stateAbbrev)).value = false;
         this.removeStateAttestationInputs(stateAbbrev);
         this.formErrorMessage = '';
@@ -364,11 +364,13 @@ export default class PrivilegePurchaseSelect extends mixins(MixinForm) {
         return statePurchaseData;
     }
 
-    handleSubmit() {
+    async handleSubmit(): Promise<void> {
         this.validateAll({ asTouched: true });
 
         if (this.numPrivilegesChosen > 20) {
             this.formErrorMessage = this.$t('licensing.privilegePurchaseLimit');
+            await nextTick();
+            document.getElementById('form-error-message')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
         } else if (this.isAtLeastOnePrivilegeChosen && this.isFormValid) {
             const selectedStates = this.formData.stateCheckList.filter((input) => input.value).map((input) => input.id);
             const attestationData = this.prepareAttestations();
@@ -393,7 +395,7 @@ export default class PrivilegePurchaseSelect extends mixins(MixinForm) {
         })));
     }
 
-    handleCancelClicked() {
+    handleCancelClicked(): void {
         this.$store.dispatch('user/resetToPurchaseFlowStep', 0);
 
         if (this.currentCompactType) {
@@ -404,7 +406,7 @@ export default class PrivilegePurchaseSelect extends mixins(MixinForm) {
         }
     }
 
-    handleBackClicked() {
+    handleBackClicked(): void {
         if (this.currentCompactType) {
             this.$router.push({
                 name: 'PrivilegePurchaseInformationConfirmation',

--- a/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
+++ b/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
@@ -81,7 +81,13 @@
                         </div>
                     </div>
                 </div>
-                <div v-if="formErrorMessage" class="form-error-message">{{formErrorMessage}}</div>
+                <div
+                    v-if="formErrorMessage"
+                    id="form-error-message"
+                    class="form-error-message"
+                >
+                    {{formErrorMessage}}
+                </div>
                 <div id="button-row" class="button-row">
                     <div class="form-nav-buttons">
                         <InputSubmit

--- a/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
+++ b/webroot/src/components/PrivilegePurchaseSelect/PrivilegePurchaseSelect.vue
@@ -21,6 +21,12 @@
                             @selected="mockPopulate"
                             class="mock-populate"
                         />
+                        <br /><MockPopulate
+                            :isEnabled="isMockPopulateEnabled"
+                            customLabel="Mock Populate All"
+                            @selected="mockPopulate(true)"
+                            class="mock-populate"
+                        />
                         <div class="lists-container">
                             <ul class="state-select-list">
                                 <li
@@ -30,9 +36,7 @@
                                 >
                                     <div v-if="isStateSelectDisabled(state)" class="state-select-unit">
                                         <div class="disabled-state-overlay" />
-                                        <InputCheckbox
-                                            :formInput="state"
-                                        />
+                                        <InputCheckbox :formInput="state" />
                                     </div>
                                     <div
                                         v-else
@@ -41,14 +45,11 @@
                                     >
                                         <div
                                             @click.prevent="toggleStateSelected(state)"
-                                            @keyup.enter="toggleStateSelected(state)"
                                             @keyup.space="toggleStateSelected(state)"
-                                            tabindex="0"
                                             class="enabled-state-overlay"
+                                            tabindex="0"
                                         />
-                                        <InputCheckbox
-                                            :formInput="state"
-                                        />
+                                        <InputCheckbox :formInput="state" />
                                     </div>
                                     <Transition name="fade">
                                         <SelectedStatePurchaseInformation
@@ -64,7 +65,7 @@
                                     </Transition>
                                 </li>
                             </ul>
-                            <TransitionGroup tag="ul" name="list" v-if="!isPhone" class="selected-state-list">
+                            <TransitionGroup v-if="!isPhone" tag="ul" name="list" class="selected-state-list">
                                 <SelectedStatePurchaseInformation
                                     v-for="(state) in selectedStatePurchaseDataList"
                                     :key="state.jurisdiction.abbrev"
@@ -80,6 +81,7 @@
                         </div>
                     </div>
                 </div>
+                <div v-if="formErrorMessage" class="form-error-message">{{formErrorMessage}}</div>
                 <div id="button-row" class="button-row">
                     <div class="form-nav-buttons">
                         <InputSubmit

--- a/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.vue
+++ b/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.vue
@@ -13,8 +13,8 @@
                 v-if="!isPriceCollapsed"
                 class="deselect-state"
                 :aria-label="$t('licensing.deselectState')"
-                @click="deselectState()"
-                @keyup.enter="deselectState()"
+                @click.prevent="deselectState()"
+                @keyup.enter.prevent="deselectState()"
             >X</button>
         </div>
         <div v-if="!isPriceCollapsed">

--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -600,6 +600,7 @@
         "expireDate": "Expire Date",
         "expires": "Expires",
         "selectPrivileges": "Select privileges",
+        "privilegePurchaseLimit": "A maximum of 20 privileges may be selected in one transaction",
         "iUnderstand": "I understand",
         "jurisprudenceConfirmation": "Jurisprudence Confirmation",
         "lastUpdate": "Latest upload",

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -598,6 +598,7 @@
         "expires": "Caduca",
         "iUnderstand": "Yo entiendo",
         "selectPrivileges": "Seleccionar privilegios",
+        "privilegePurchaseLimit": "Se pueden seleccionar un máximo de 20 privilegios en una transacción",
         "jurisprudenceConfirmation": "Confirmación de jurisprudencia",
         "adminFee": "Tarifa Administrativa",
         "jurisdictionFee": "Tarifa Estatal",

--- a/webroot/src/network/mocks/mock.data.ts
+++ b/webroot/src/network/mocks/mock.data.ts
@@ -2257,6 +2257,14 @@ export const getAttestation = (attestationId) => {
     case 'military-affiliation-confirmation-attestation':
         attestationObj.text = 'I hereby attest and affirm that my current military status documentation as uploaded to CompactConnect is accurate.';
         break;
+    case 'jurisprudence-confirmation':
+        attestationObj.text = 'I understand that an attestation is a legally binding statement. I understand that providing false information on this application could result in a loss of my licenses and/or privileges. I acknowledge that the Commission may audit jurisprudence attestations at their discretion.';
+        break;
+    case 'scope-of-practice-attestation':
+        attestationObj.text = `I hereby attest and affirm that I have reviewed, understand, and will abide by this state's scope of practice and all applicable laws and rules when practicing in the state. I understand that the issuance of a Compact Privilege authorizes me to legally practice in the member jurisdiction in accordance with the laws and rules governing practice of my profession in that jurisdiction.
+
+        If I violate the practice act, the appropriate board may take action against my Compact Privilege, which may result in the revocation of other Compact Privileges or licenses I may hold. I will also be prohibited from obtaining any other Compact Privileges for a period of at least two (2) years.`;
+        break;
     default:
         break;
     }

--- a/webroot/src/network/mocks/mock.data.ts
+++ b/webroot/src/network/mocks/mock.data.ts
@@ -527,7 +527,223 @@ export const privilegePurchaseOptionsResponse = {
                 required: true
             },
             type: 'jurisdiction'
-        }
+        },
+        {
+            jurisdictionName: 'alabama',
+            postalAbbreviation: 'al',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: true
+            },
+            type: 'jurisdiction'
+        },
+        {
+            jurisdictionName: 'montana',
+            postalAbbreviation: 'mt',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: false
+            },
+            type: 'jurisdiction'
+        },
+        {
+            jurisdictionName: 'maryland',
+            postalAbbreviation: 'md',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: false
+            },
+            type: 'jurisdiction'
+        },
+        {
+            jurisdictionName: 'utah',
+            postalAbbreviation: 'ut',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: false
+            },
+            type: 'jurisdiction'
+        },
+        {
+            jurisdictionName: 'new mexico',
+            postalAbbreviation: 'nm',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: false
+            },
+            type: 'jurisdiction'
+        },
+        {
+            jurisdictionName: 'oklahoma',
+            postalAbbreviation: 'ok',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: false
+            },
+            type: 'jurisdiction'
+        },
+        {
+            jurisdictionName: 'washington',
+            postalAbbreviation: 'wa',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: false
+            },
+            type: 'jurisdiction'
+        },
+        {
+            jurisdictionName: 'oregon',
+            postalAbbreviation: 'or',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: false
+            },
+            type: 'jurisdiction'
+        },
+        {
+            jurisdictionName: 'new hampshire',
+            postalAbbreviation: 'nh',
+            compact: 'octp',
+            privilegeFees: [
+                {
+                    licenseTypeAbbreviation: 'ot',
+                    amount: 200
+                },
+                {
+                    licenseTypeAbbreviation: 'ota',
+                    amount: 100
+                }
+            ],
+            militaryDiscount: {
+                active: false,
+                discountType: 'FLAT_RATE',
+                discountAmount: 10
+            },
+            jurisprudenceRequirements: {
+                required: false
+            },
+            type: 'jurisdiction'
+        },
     ],
     pagination: {
         pageSize: 100,

--- a/webroot/src/pages/RegisterLicensee/RegisterLicensee.vue
+++ b/webroot/src/pages/RegisterLicensee/RegisterLicensee.vue
@@ -38,7 +38,7 @@
                 <template v-else-if="!isFormSuccessful">
                     <form @submit.prevent="handleSubmit" class="register-licensee-form" id="register-licensee-form">
                         <div v-if="!isConfirmationScreen" class="register-licensee-form-container">
-                            <MockPopulate :isEnabled="isMockPopulateEnabled" @selected="mockPopulate" />
+                            <MockPopulate :isEnabled="isMockPopulateEnabled" @selected="mockPopulate" /><br />
                             <a
                                 v-if="isMockPopulateEnabled"
                                 @click="resetForm()"


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Update PrivilegePurchaseSelect component to restrict number of privilege selections to 20
- Add purchase-config states to mock data to allow new privilege purchase limit to be tested
- Add mock-populate-all to PrivilegePurchaseSelect component (local)
- Fix list layout issues on PrivilegePurchaseSelect component
- Minor code consistency cleanup in PrivilegePurchaseSelect component
- Remove enter-key from selecting state checkboxes in PrivilegePurchaseSelect component (#804)
- Confirm user can't purchase privilege in home state (#490)
- Update MockPopulate component to accept a custom label
- Update mock attestation data to include jurisprudence & scope-of-practice attestations

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - Login as a licensee user who can purchase privileges
    - Begin the purchase workflow and proceed to the screen titled "Select privileges"
    - With keyboard nav, confirm that spacebar, not enter, selects states
    - Select a state to show the blue state box with $ totals (no changes)
    - Adjust screen size; state checkbox columns should no longer overflow to a 3rd column and / or overlap the blue state $ box
    - If more than 20 states are available, select them all
        - _2025-07-31: Only developers using mock data can trigger this many states_
        - Attempt to advance to the next screen
        - Should receive an error stating a maximum limit of 20
        - Changing the selections to 20 or fewer should allow the form to advance (assuming all blue-card required fields have been completed)

Closes #715 
Closes #804 
Closes #490 
