### PR TITLE
Block privilege purchases two years after encumbrance

### DIFF
--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/provider_record_util.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/provider_record_util.py
@@ -304,6 +304,18 @@ class ProviderUserRecords:
         """
         return [record for record in self._license_records if filter_condition is None or filter_condition(record)]
 
+    def get_adverse_action_records(
+        self, filter_condition: Callable[[AdverseActionData], bool]
+    ) -> list[AdverseActionData]:
+        response = []
+        for record in self._adverse_action_records:
+            if filter_condition is None or filter_condition(record):
+                response.append(record)
+        return response
+        # return [
+        #     record for record in self._adverse_action_records if filter_condition is None or filter_condition(record)
+        # ]
+
     def get_adverse_action_records_for_license(
         self,
         license_jurisdiction: str,

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/provider_record_util.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/provider_record_util.py
@@ -305,16 +305,11 @@ class ProviderUserRecords:
         return [record for record in self._license_records if filter_condition is None or filter_condition(record)]
 
     def get_adverse_action_records(
-        self, filter_condition: Callable[[AdverseActionData], bool]
+        self, filter_condition: Callable[[AdverseActionData], bool] | None = None
     ) -> list[AdverseActionData]:
-        response = []
-        for record in self._adverse_action_records:
-            if filter_condition is None or filter_condition(record):
-                response.append(record)
-        return response
-        # return [
-        #     record for record in self._adverse_action_records if filter_condition is None or filter_condition(record)
-        # ]
+        return [
+            record for record in self._adverse_action_records if filter_condition is None or filter_condition(record)
+        ]
 
     def get_adverse_action_records_for_license(
         self,


### PR DESCRIPTION
### Requirements List
- Added check on privilege purchase for any encumbrances lifted less than two years ago

Closes #949 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent privilege purchases if there are unresolved or recently lifted adverse license or privilege encumbrances.
* **Bug Fixes**
  * Improved error handling and messaging when privilege purchase is blocked due to encumbrances.
* **Tests**
  * Introduced new test cases to verify privilege purchase eligibility related to encumbrance status and timing.
  * Removed redundant test to streamline test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->