### PR TITLE
Revise app client process

### DIFF
--- a/backend/compact-connect/app_clients/README.md
+++ b/backend/compact-connect/app_clients/README.md
@@ -67,18 +67,19 @@ Add the new app client information to the external Google Sheet registry for tra
 
 ### 4. **Send Credentials to Consuming Team**
    **When using the Python script (recommended):**
-   The script will output comprehensive JSON with all necessary information for the consuming team:
+   The script will output two separate sections:
+
+   **A. Credentials JSON (for one-time link service):**
    ```json
    {
      "clientId": "6g34example89j",
-     "clientSecret": "1234example567890",
-     "compact": "octp",
-     "state": "la",
-     "authUrl": "https://compact-connect-staff-beta.auth.us-east-1.amazoncognito.com/oauth2/token",
-     "licenseUploadUrl": "https://api.beta.compactconnect.org/v1/compacts/octp/jurisdictions/la/licenses"
+     "clientSecret": "1234example567890"
    }
    ```
-   **Important:** These credentials should be securely transmitted to the consuming team via an encrypted channel (i.e., a one-time use link). The Python script output is ready to use directly with your one-time secret link generator. Once you have sent the credentials over to the IT staff, ensure you remove all remnants of the credentials from your device.
+   **Important:** These credentials should be securely transmitted to the consuming team via an encrypted channel (i.e., a one-time use link). Copy this JSON and use it with your one-time secret link generator. Once you have sent the credentials over to the IT staff, ensure you remove all remnants of the credentials from your device.
+
+   **B. Email Template:**
+   The script will also generate an email template with contextual information (compact name, state, auth URL, license upload URL) that you can copy/paste into your email client. This template includes a placeholder for the one-time link that you'll generate separately.
 
 
 #### Email Instructions for consuming team

--- a/backend/compact-connect/app_clients/it_staff_onboarding_instructions/README.md
+++ b/backend/compact-connect/app_clients/it_staff_onboarding_instructions/README.md
@@ -3,10 +3,10 @@
 ## Overview
 
 CompactConnect is a centralized platform that facilitates interstate license recognition for healthcare professionals
-through occupational licensing compacts. These compacts allow practitioners with licenses in good standing to work 
+through occupational licensing compacts. These compacts allow practitioners with licenses in good standing to work
 across state lines without obtaining additional licenses.
 
-As a state IT department responsible for managing professional license data, your role is crucial in this process. 
+As a state IT department responsible for managing professional license data, your role is crucial in this process.
 This document provides instructions for integrating your existing licensing systems with CompactConnect through its API.
 
 By automating license data uploads, your state will:
@@ -18,16 +18,17 @@ By automating license data uploads, your state will:
 - **Meet Compact Obligations**: Fulfill your state's requirements as a compact member
 
 This document outlines the technical process for setting up machine-to-machine authentication and automated license data
-uploads to CompactConnect's API. Following these instructions will help you establish a secure, reliable connection 
+uploads to CompactConnect's API. Following these instructions will help you establish a secure, reliable connection
 between your licensing systems and the CompactConnect platform.
 
 ## Credential Security
 
-You have received a one-time use link to access your API credentials. After retrieving the credentials, please:
+You have received a one-time use link to access your API credentials, along with an email containing contextual information about your integration. After retrieving the credentials, please:
 
 1. Store the credentials securely in a password manager or secrets management system
 2. Do not share these credentials with unauthorized personnel
 3. Do not hardcode these credentials in source code repositories
+4. Keep the contextual information (compact, state, URLs) for reference during integration
 
 > **Important**: If the link provided has already been used when you attempt to access the credentials, please contact the individual who sent the link to you as the credentials will need to be regenerated and sent using another link.
 
@@ -38,13 +39,15 @@ The credentials will be sent to you in this format:
 ```json
 {
   "clientId": "<client id>",
-  "clientSecret": "<client secret>",
-  "compact": "<compact>",
-  "jurisdiction": "<state postal abbreviation>",
-  "authUrl": "https://compact-connect-staff-beta.auth.us-east-1.amazoncognito.com/oauth2/token",
-  "licenseUploadUrl": "https://api.beta.compactconnect.org/v1/compacts/<compact>/jurisdictions/<jurisdiction>/licenses"
+  "clientSecret": "<client secret>"
 }
 ```
+
+You will also receive an email with the following contextual information:
+- **Compact**: The full name of the compact (e.g., "Occupational Therapy", "Audiology and Speech Language Pathology")
+- **State**: Your state's postal abbreviation (e.g., "KY", "LA")
+- **Auth URL**: The authentication endpoint URL
+- **License Upload URL**: The API endpoint for uploading license data
 
 ## Authentication Process for Uploading License Data
 
@@ -52,12 +55,12 @@ Follow these steps to obtain an access token and make requests to the CompactCon
 
 ### Step 1: Generate an Access Token
 
-You must first obtain an access token to authenticate your API requests. The access token will be used in the 
+You must first obtain an access token to authenticate your API requests. The access token will be used in the
 Authorization header of subsequent API calls. While the following curl command demonstrates how to generate a token for
 the **beta** environment, you should implement this authentication flow in your application's programming language using
 appropriate HTTPS request libraries:
 
-> **Note**: When copying commands, be careful of line breaks. You may need to remove any extra spaces or 
+> **Note**: When copying commands, be careful of line breaks. You may need to remove any extra spaces or
 > line breaks that occur when pasting.
 
 ```bash
@@ -73,9 +76,9 @@ curl --location --request POST '<authUrl>' \
 Replace:
 - `<clientId>` with your client ID
 - `<clientSecret>` with your client secret
-- `<jurisdiction>` with your lower-cased two-letter state code (e.g., `ky` for Kentucky)
+- `<jurisdiction>` with your lower-cased two-letter state code (e.g., `ky` for Kentucky) - this information was provided in the email
 - `<compact>` with the lower-cased compact abbreviation (`octp` for the 'Occupational Therapy' Compact,
-`aslp` for 'Audiology and Speech Language Pathology' Compact, or `coun` for the 'Counseling' Compact)
+`aslp` for 'Audiology and Speech Language Pathology' Compact, or `coun` for the 'Counseling' Compact) - this information was provided in the email
 
 Example response:
 ```json
@@ -86,7 +89,7 @@ Example response:
 }
 ```
 
-For more information about this authentication process, please see the following 
+For more information about this authentication process, please see the following
 AWS documentation: https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html
 
 **Important Notes**:
@@ -98,8 +101,8 @@ AWS documentation: https://docs.aws.amazon.com/cognito/latest/developerguide/tok
 
 The CompactConnect License API can be called through a POST REST endpoint which takes in a list of license record objects.
 The following curl command example demonstrates how to upload license data into the **beta** environment, but you should
-implement this API call in your application's programming language using appropriate HTTPS request libraries. You will need to 
-replace the example payload with valid license data that includes the correct license types for your 
+implement this API call in your application's programming language using appropriate HTTPS request libraries. You will need to
+replace the example payload with valid license data that includes the correct license types for your
 specific compact (you can send up to 100 license records per request):
 
 ```bash
@@ -111,8 +114,8 @@ curl --location --request POST '<licenseUploadUrl>' \
 
 Replace:
 - `<access_token>` with the access token from Step 1
-- `<compact>` with the lower-cased compact abbreviation (e.g., `aslp`, `octp`, or `coun`)
-- `<jurisdiction>` with your lower-cased two-letter state code (e.g., `ky`)
+- `<compact>` with the lower-cased compact abbreviation (e.g., `aslp`, `octp`, or `coun`) - this information was provided in the email
+- `<jurisdiction>` with your lower-cased two-letter state code (e.g., `ky`) - this information was provided in the email
 - The example payload shown here with your test license data
 
 ### Step 2 Alternative: Upload License Data via CSV File
@@ -155,10 +158,10 @@ If you receive an error response, check the status code and message:
 - **502**: Internal Server Error - There was a problem processing your request
 
 ### 3. Validation Errors
-If your license data fails validation, the API will return a 400 status code with details about the 
+If your license data fails validation, the API will return a 400 status code with details about the
 validation errors in the response body.
 
-> **Note**: Successful API responses (200 status code) indicate that the license data has been accepted for processing, but 
+> **Note**: Successful API responses (200 status code) indicate that the license data has been accepted for processing, but
 > actual processing happens asynchronously. The data will be validated and processed by the CompactConnect System after acceptance.
 
 ## Troubleshooting Common Issues
@@ -181,10 +184,10 @@ validation errors in the response body.
 
 1. Implement token refresh logic to get a new token before the current one expires
 2. Implement error handling for API responses
-3. Configure your application to securely store and access the client credentials, **do not store the credentials in your 
+3. Configure your application to securely store and access the client credentials, **do not store the credentials in your
 application code.**
 
 ## Support and Feedback
 
-If you encounter any issues, have questions, or would like to provide feedback based on your experience working with 
+If you encounter any issues, have questions, or would like to provide feedback based on your experience working with
 the CompactConnect API, please contact the individual which sent you the credentials.


### PR DESCRIPTION
### Description List
- Tweaked the docs and app_client script a bit to split secrets from context of their use

While I worked on #981 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated credential transmission instructions to separate sensitive credentials (clientId and clientSecret) from contextual information, providing a clearer process for secure sharing.
  * Added a dedicated email template section for sharing contextual details, including compact name, state, and relevant URLs.
  * Improved clarity and formatting in onboarding instructions for IT staff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->