### PR TITLE
Limit 20 privs per purchase

### DIFF
--- a/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api_model.py
@@ -630,8 +630,13 @@ class ApiModel:
                     ),
                     'selectedJurisdictions': JsonSchema(
                         type=JsonSchemaType.ARRAY,
-                        # setting a max length to prevent abuse
-                        max_length=100,
+                        # Authorize.net has a limit of 30 line items per transaction. For every transaction, each
+                        # privilege takes up an individual line item, and we include an additional line item for
+                        # compact administrative fees, plus a line item for credit card transaction fees if the
+                        # compact collects those. In order to avoid ever hitting the limit of 30 line items, the system
+                        # sets a limit of 20 privileges per transaction (this gives the system space to add an
+                        # additional 8 line items to any transaction should the need arise)
+                        max_length=20,
                         items=JsonSchema(
                             type=JsonSchemaType.STRING,
                             description='Jurisdictions a provider has selected to purchase privileges in.',

--- a/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
+++ b/backend/compact-connect/tests/resources/snapshots/PURCHASE_PRIVILEGE_REQUEST_SCHEMA.json
@@ -71,7 +71,7 @@
         ],
         "type": "string"
       },
-      "maxLength": 100,
+      "maxLength": 20,
       "type": "array"
     },
     "orderInformation": {


### PR DESCRIPTION
### Requirements List
- Set privilege purchase jurisdiction limit to 20

### Testing List
- Code review

Closes #714 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the maximum number of jurisdictions that can be selected per privilege purchase to 20.

* **Documentation**
  * Added detailed explanation for the new limit to clarify its purpose for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->