### PR TITLE
Privilege active from date (#739)

### DIFF
--- a/webroot/src/components/LicenseCard/LicenseCard.vue
+++ b/webroot/src/components/LicenseCard/LicenseCard.vue
@@ -63,10 +63,6 @@
             <div class="license-status-description" ref="statusDescription">{{statusDescriptionDisplay}}</div>
         </div>
         <div class="license-info-grid">
-            <div class="info-item-container">
-                <div class="info-item-title">{{ $t('licensing.issued') }}</div>
-                <div class="info-item">{{issuedContent}}</div>
-            </div>
            <div class="info-item-container">
                 <div class="info-item-title">{{expiresTitle}}</div>
                 <div class="info-item">{{expiresContent}}</div>

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
@@ -160,6 +160,10 @@ class PrivilegeCard extends mixins(MixinForm) {
         return this.privilege?.issueDateDisplay() || '';
     }
 
+    get activeFromContent(): string {
+        return this.privilege?.activeFromDateDisplay() || '';
+    }
+
     get isExpired(): boolean {
         return Boolean(this.privilege?.isExpired());
     }

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
@@ -70,8 +70,8 @@
         </div>
         <div class="privilege-info-grid">
             <div class="info-item-container">
-                <div class="info-item-title">{{ $t('licensing.issued') }}</div>
-                <div class="info-item">{{issuedContent}}</div>
+                <div class="info-item-title">{{ $t('licensing.activeFrom') }}</div>
+                <div class="info-item">{{ (isActive) ? activeFromContent : $t('licensing.deactivated') }}</div>
             </div>
            <div class="info-item-container">
                 <div class="info-item-title">{{expiresTitle}}</div>

--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -610,6 +610,7 @@
         "status": "Status",
         "expired": "Expired",
         "issueDate": "Issue Date",
+        "activeFrom": "Active from",
         "state": "State",
         "issued": "Issued",
         "expirationDate": "Expiration date",

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -584,6 +584,7 @@
         "status": "Estado",
         "deselectState": "Deseleccionar estado",
         "issueDate": "Fecha de asunto",
+        "activeFrom": "Activo desde",
         "expirationDate": "Fecha de caducidad",
         "expiration": "Vencimiento",
         "expireDate": "Fecha de caducidad",

--- a/webroot/src/models/License/License.model.spec.ts
+++ b/webroot/src/models/License/License.model.spec.ts
@@ -51,6 +51,7 @@ describe('License model', () => {
         expect(license.licenseeId).to.equal(null);
         expect(license.issueState).to.be.an.instanceof(State);
         expect(license.issueDate).to.equal(null);
+        expect(license.activeFromDate).to.equal(null);
         expect(license.renewalDate).to.equal(null);
         expect(license.expireDate).to.equal(null);
         expect(license.npi).to.equal(null);
@@ -68,6 +69,7 @@ describe('License model', () => {
         expect(license.issueDateDisplay()).to.equal('');
         expect(license.renewalDateDisplay()).to.equal('');
         expect(license.expireDateDisplay()).to.equal('');
+        expect(license.activeFromDateDisplay()).to.equal('');
         expect(license.isExpired()).to.equal(false);
         expect(license.isDeactivated()).to.equal(false);
         expect(license.isCompactEligible()).to.equal(false);
@@ -113,6 +115,7 @@ describe('License model', () => {
         expect(license.licenseeId).to.equal(data.licenseeId);
         expect(license.issueState).to.be.an.instanceof(State);
         expect(license.issueDate).to.equal(data.issueDate);
+        expect(license.activeFromDate).to.be.null;
         expect(license.renewalDate).to.equal(data.renewalDate);
         expect(license.expireDate).to.equal(data.expireDate);
         expect(license.mailingAddress).to.be.an.instanceof(Address);
@@ -130,6 +133,7 @@ describe('License model', () => {
         expect(license.issueDateDisplay()).to.equal('Invalid date');
         expect(license.renewalDateDisplay()).to.equal('Invalid date');
         expect(license.expireDateDisplay()).to.equal('Invalid date');
+        expect(license.activeFromDateDisplay()).to.equal('');
         expect(license.isExpired()).to.equal(false);
         expect(license.isDeactivated()).to.equal(false);
         expect(license.isCompactEligible()).to.equal(true);
@@ -175,6 +179,7 @@ describe('License model', () => {
             dateOfIssuance: moment().format(serverDateFormat),
             dateOfRenewal: moment().format(serverDateFormat),
             dateOfExpiration: moment().subtract(1, 'day').format(serverDateFormat),
+            activeSince: null,
             npi: 'npi',
             licenseNumber: 'licenseNumber',
             homeAddressStreet1: 'test-street1',
@@ -209,6 +214,7 @@ describe('License model', () => {
         expect(license.issueDate).to.equal(data.dateOfIssuance);
         expect(license.renewalDate).to.equal(data.dateOfRenewal);
         expect(license.expireDate).to.equal(data.dateOfExpiration);
+        expect(license.activeFromDate).to.equal(data.activeSince);
         expect(license.licenseType).to.equal(data.licenseType);
         expect(license.status).to.equal(data.licenseStatus);
         expect(license.statusDescription).to.equal(data.licenseStatusName);
@@ -260,6 +266,7 @@ describe('License model', () => {
             dateOfIssuance: '2022-03-19T21:51:26+00:00',
             dateOfRenewal: '2025-03-26T16:19:09+00:00',
             dateOfExpiration: '2025-02-12',
+            activeSince: '2025-05-26T16:19:09+00:00',
             compactTransactionId: '120060088901',
             adverseActions: [
                 {
@@ -564,6 +571,7 @@ describe('License model', () => {
         expect(license.issueDate).to.equal(data.dateOfIssuance);
         expect(license.renewalDate).to.equal(data.dateOfRenewal);
         expect(license.expireDate).to.equal(data.dateOfExpiration);
+        expect(license.activeFromDate).to.equal(data.activeSince);
         expect(license.licenseType).to.equal(data.licenseType);
         expect(license.privilegeId).to.equal(data.privilegeId);
         expect(license.history[0]).to.be.an.instanceof(LicenseHistoryItem);
@@ -582,6 +590,9 @@ describe('License model', () => {
         );
         expect(license.expireDateDisplay()).to.equal(
             moment(data.dateOfExpiration, serverDateFormat).format(displayDateFormat)
+        );
+        expect(license.activeFromDateDisplay()).to.equal(
+            moment(data.activeSince, serverDateFormat).format(displayDateFormat)
         );
         expect(license.isExpired()).to.equal(true);
         expect(license.isDeactivated()).to.equal(false);
@@ -610,6 +621,7 @@ describe('License model', () => {
             dateOfIssuance: '2022-03-19T21:51:26+00:00',
             dateOfRenewal: '2025-03-26T16:19:09+00:00',
             dateOfExpiration: '2025-02-12',
+            activeSince: '2025-05-26T16:19:09+00:00',
             compactTransactionId: '120060088901',
             attestations: [],
             privilegeId: 'OTA-NE-10',

--- a/webroot/src/models/License/License.model.ts
+++ b/webroot/src/models/License/License.model.ts
@@ -50,6 +50,7 @@ export interface InterfaceLicense {
     isHomeState?: boolean;
     issueDate?: string | null;
     renewalDate?: string | null;
+    activeFromDate?: string | null;
     mailingAddress?: Address;
     expireDate?: string | null;
     npi?: string | null;
@@ -75,6 +76,7 @@ export class License implements InterfaceLicense {
     public licenseeId? = null;
     public issueState? = new State();
     public issueDate? = null;
+    public activeFromDate? = null;
     public mailingAddress? = new Address();
     public renewalDate? = null;
     public npi? = null;
@@ -107,6 +109,10 @@ export class License implements InterfaceLicense {
 
     public renewalDateDisplay(): string {
         return dateDisplay(this.renewalDate);
+    }
+
+    public activeFromDateDisplay(): string {
+        return dateDisplay(this.activeFromDate);
     }
 
     public expireDateDisplay(): string {
@@ -215,6 +221,7 @@ export class LicenseSerializer {
             }),
             issueState: new State({ abbrev: json.jurisdiction || json.licenseJurisdiction }),
             issueDate: json.dateOfIssuance,
+            activeFromDate: json.activeSince,
             npi: json.npi,
             licenseNumber: json.licenseNumber, // License field only
             privilegeId: json.privilegeId, // Privilege field only

--- a/webroot/src/network/mocks/mock.data.ts
+++ b/webroot/src/network/mocks/mock.data.ts
@@ -770,6 +770,7 @@ export const licensees = {
                     dateOfIssuance: moment().subtract(2, 'years').subtract(7, 'months').format(serverDateFormat),
                     dateOfRenewal: moment().subtract(2, 'months').format(serverDateFormat),
                     dateOfExpiration: moment().add(10, 'months').format(serverDateFormat),
+                    activeSince: moment().subtract(1, 'years').subtract(2, 'months').format(serverDateFormat),
                     compactTransactionId: '120060088902',
                     attestations: [
                         {
@@ -1065,6 +1066,7 @@ export const licensees = {
                     dateOfIssuance: moment().subtract(9, 'months').format(serverDateFormat),
                     dateOfRenewal: moment().subtract(9, 'months').format(serverDateFormat),
                     dateOfExpiration: moment().add(1, 'month').format(serverDateFormat),
+                    activeSince: moment().subtract(6, 'months').format(serverDateFormat),
                     compactTransactionId: '120060088903',
                     attestations: [
                         {
@@ -1504,6 +1506,7 @@ export const licensees = {
                     dateOfIssuance: moment().subtract(2, 'years').subtract(7, 'months').format(serverDateFormat),
                     dateOfRenewal: moment().subtract(2, 'months').format(serverDateFormat),
                     dateOfExpiration: moment().add(10, 'months').format(serverDateFormat),
+                    activeSince: moment().subtract(1, 'years').subtract(2, 'months').format(serverDateFormat),
                     compactTransactionId: '120060088901',
                     attestations: [
                         {
@@ -2013,6 +2016,7 @@ export const licensees = {
                     dateOfIssuance: moment().subtract(9, 'months').format(serverDateFormat),
                     dateOfRenewal: moment().subtract(9, 'months').format(serverDateFormat),
                     dateOfExpiration: moment().add(1, 'month').format(serverDateFormat),
+                    activeSince: moment().subtract(6, 'months').format(serverDateFormat),
                     compactTransactionId: '120060088901',
                     attestations: [
                         {
@@ -2505,6 +2509,7 @@ export const licensees = {
                     type: 'privilege',
                     dateOfIssuance: moment().subtract(10, 'months').subtract(1, 'year').format(serverDateFormat),
                     dateOfUpdate: moment().subtract(10, 'months').subtract(1, 'year').format(serverDateFormat),
+                    activeSince: moment().subtract(10, 'months').subtract(1, 'year').format(serverDateFormat),
                     status: 'active',
                     privilegeId: 'OCTP-AL-22'
                 }

--- a/webroot/src/pages/LicenseeProof/LicenseeProof.ts
+++ b/webroot/src/pages/LicenseeProof/LicenseeProof.ts
@@ -86,10 +86,10 @@ export default class LicenseeProof extends Vue {
             .filter((privilege: License) =>
                 privilege.status === LicenseStatus.ACTIVE)
             .sort((a: License, b: License) => {
-                const dateA = moment(a.issueDate);
-                const dateB = moment(b.issueDate);
+                const dateA = moment(a.activeFromDate);
+                const dateB = moment(b.activeFromDate);
 
-                return dateB.valueOf() - dateA.valueOf(); // Most recent issueDate first
+                return dateB.valueOf() - dateA.valueOf(); // Most recent activeFromDate first
             });
 
         return sortedPrivileges;

--- a/webroot/src/pages/LicenseeProof/LicenseeProof.vue
+++ b/webroot/src/pages/LicenseeProof/LicenseeProof.vue
@@ -61,10 +61,7 @@
                 <div class="cell">
                     <span class="cell-display-name">{{ license.displayName(', ') }}</span>
                 </div>
-                <div class="cell max-gap">
-                    <span class="cell-title">{{ $t('licensing.activeDate') }}</span>
-                    <span class="date-text">{{ license.issueDateDisplay() }}</span>
-                </div>
+                <div class="cell max-gap"></div>
                 <div class="cell">
                     <span class="cell-title">{{ $t('licensing.expiration') }}</span>
                     <span class="date-text">{{ license.expireDateDisplay() }}</span>
@@ -86,8 +83,8 @@
                     <span v-if="privilege.privilegeId" class="cell-id">{{ privilege.privilegeId }}</span>
                 </div>
                 <div class="cell max-gap">
-                    <span class="cell-title">{{ $t('licensing.activeDate') }}</span>
-                    <span class="date-text">{{ privilege.issueDateDisplay() }}</span>
+                    <span class="cell-title">{{ $t('licensing.activeFrom') }}</span>
+                    <span class="date-text">{{ privilege.activeFromDateDisplay() }}</span>
                 </div>
                 <div class="cell">
                     <span class="cell-title">{{ $t('licensing.expiration') }}</span>


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Remove "Issue date" from the license card and "Active date" from the license table in the license verification proof page
- Add "Active from" to the privilege card and to the privilege table in the license verification proof page using new property from the API response

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing:
    - Using **mock data**, update `getAuthenticatedLicenseeUser` in `mock.data.api` to return `licensees.providers[1]`
    - Log into the app, and in the dashboard page confirm that the license cards no longer include an "Issue date"
    - Confirm that the privilege cards have a new "Active date" field, and 
        - For active privileges, the date is being displayed as expected
        - For inactive privileges, the date is displayed as "deactivated"
    - Go to the license verification proof page and confirm that
        - The "Privileges" table has an "Active from" column and the record are sorted by most recent first
        - The "Home State Licenses" table only as an "Expiration" column

Closes #739 
