### PR TITLE
Ensure privilege is not unencumbered if license is still encumbered

### DIFF
--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/data_client.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/data_client.py
@@ -1658,11 +1658,30 @@ class DataClient:
 
             # If this was the last unlifted adverse action, update privilege status and create update record
             unlifted_adverse_actions = self._get_unlifted_adverse_actions(adverse_action_records, adverse_action_id)
+            # we also need to check if the license record the privilege is associated with is also unencumbered
+            license_records = provider_user_records.get_license_records(
+                filter_condition=lambda license_record: (
+                    license_record.jurisdiction == privilege_data.licenseJurisdiction
+                    and license_record.licenseType == license_type_name
+                )
+            )
+            if not license_records:
+                message = 'License record not found for adverse action record.'
+                logger.error(message, license_type_name=license_type_name)
+                raise CCInternalException(message)
+
+            license_data = license_records[0]
+
             if not unlifted_adverse_actions:
-                # Update privilege record to unencumbered status
+                encumbered_status = PrivilegeEncumberedStatusEnum.UNENCUMBERED
+                # If the license is encumbered, we need to update the privilege record to the license encumbered status
+                # otherwise, we update the privilege record to unencumbered
+                if license_data.encumberedStatus == LicenseEncumberedStatusEnum.ENCUMBERED:
+                    encumbered_status = PrivilegeEncumberedStatusEnum.LICENSE_ENCUMBERED
+                # Update privilege record to new status
                 privilege_update_item = self._generate_set_privilege_encumbered_status_item(
                     privilege_data=privilege_data,
-                    privilege_encumbered_status=PrivilegeEncumberedStatusEnum.UNENCUMBERED,
+                    privilege_encumbered_status=encumbered_status,
                 )
                 transact_items.append(privilege_update_item)
 
@@ -1681,7 +1700,8 @@ class DataClient:
                         'effectiveDate': effective_lift_date,
                         'previous': privilege_data.to_dict(),
                         'updatedValues': {
-                            'encumberedStatus': PrivilegeEncumberedStatusEnum.UNENCUMBERED,
+                            # this may be unencumbered or license encumbered
+                            'encumberedStatus': encumbered_status,
                         },
                     }
                 ).serialize_to_database_record()

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_encumbrance.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_encumbrance.py
@@ -517,7 +517,9 @@ class TestPostLicenseEncumbrance(TstFunction):
 class TestPatchPrivilegeEncumbranceLifting(TstFunction):
     """Test suite for privilege encumbrance lifting endpoints."""
 
-    def _setup_privilege_with_adverse_action(self, adverse_action_overrides=None, privilege_overrides=None):
+    def _setup_privilege_with_adverse_action(
+        self, adverse_action_overrides=None, privilege_overrides=None, license_overrides=None
+    ):
         """Helper method to set up a privilege with an adverse action for testing."""
         self.test_data_generator.put_default_provider_record_in_provider_table(
             value_overrides={'encumberedStatus': 'encumbered'}
@@ -531,6 +533,17 @@ class TestPatchPrivilegeEncumbranceLifting(TstFunction):
                 'jurisdiction': test_privilege_record.jurisdiction,
                 'licenseType': test_privilege_record.licenseType,
                 **(adverse_action_overrides or {}),
+            }
+        )
+
+        # Set up license with encumbered status
+        self.test_data_generator.put_default_license_record_in_provider_table(
+            value_overrides={
+                'providerId': test_privilege_record.providerId,
+                'compact': test_privilege_record.compact,
+                'jurisdiction': test_privilege_record.licenseJurisdiction,
+                'licenseType': test_privilege_record.licenseType,
+                **(license_overrides or {}),
             }
         )
         return test_privilege_record, test_adverse_action
@@ -772,15 +785,10 @@ class TestPatchPrivilegeEncumbranceLifting(TstFunction):
         from cc_common.data_model.schema.common import LicenseEncumberedStatusEnum
         from handlers.encumbrance import encumbrance_handler
 
-        # Set up privilege with adverse action
-        privilege_record, adverse_action = self._setup_privilege_with_adverse_action()
-
-        # Set up license with encumbered status
-        self.test_data_generator.put_default_license_record_in_provider_table(
-            value_overrides={
+        # Set up privilege with adverse action and encumbered license
+        privilege_record, adverse_action = self._setup_privilege_with_adverse_action(
+            license_overrides={
                 'encumberedStatus': 'encumbered',
-                'providerId': privilege_record.providerId,
-                'compact': privilege_record.compact,
             }
         )
 
@@ -796,6 +804,37 @@ class TestPatchPrivilegeEncumbranceLifting(TstFunction):
 
         loaded_provider_data = provider_records.get_provider_record()
         self.assertEqual(LicenseEncumberedStatusEnum.ENCUMBERED, loaded_provider_data.encumberedStatus)
+
+    def test_should_update_privilege_to_license_encumbered_when_associated_license_is_encumbered(self):
+        """Test that lifting a privilege encumbrance sets privilege to LICENSE_ENCUMBERED when associated
+        license is encumbered."""
+        from cc_common.data_model.provider_record_util import ProviderUserRecords
+        from cc_common.data_model.schema.common import PrivilegeEncumberedStatusEnum
+        from handlers.encumbrance import encumbrance_handler
+
+        # Set up privilege with adverse action and encumbered license
+        privilege_record, adverse_action = self._setup_privilege_with_adverse_action(
+            privilege_overrides={'encumberedStatus': 'encumbered'}, license_overrides={'encumberedStatus': 'encumbered'}
+        )
+
+        event = self._generate_lift_encumbrance_event(privilege_record, adverse_action)
+
+        response = encumbrance_handler(event, self.mock_context)
+        self.assertEqual(200, response['statusCode'])
+
+        # Verify privilege record is now LICENSE_ENCUMBERED (not UNENCUMBERED)
+        provider_records: ProviderUserRecords = self.config.data_client.get_provider_user_records(
+            compact=privilege_record.compact, provider_id=str(privilege_record.providerId)
+        )
+
+        privilege_records = provider_records.get_privilege_records(
+            filter_condition=lambda p: (
+                p.jurisdiction == privilege_record.jurisdiction and p.licenseType == privilege_record.licenseType
+            )
+        )
+
+        self.assertEqual(1, len(privilege_records))
+        self.assertEqual(PrivilegeEncumberedStatusEnum.LICENSE_ENCUMBERED, privilege_records[0].encumberedStatus)
 
     def test_should_return_access_denied_if_compact_admin_attempts_to_lift_privilege_encumbrance(self):
         """Verifying that only state admins are allowed to lift privilege encumbrances"""


### PR DESCRIPTION
This fixes a bug where privileges were being marked as unencumbered when all their encumbrances were lifted, without accounting for the fact that the associated license might also be encumbered and we need to set the privilege in this case to the LICENSE_ENCUMBERED status.

This also addresses an issue where when a license becomes unencumbered, it automatically removes the encumbrances from all the associated privilege records, without accounting for the fact that the privilege may still have its own active encumbrance and needs to remain encumbrance.

Closes #943 
