### PR TITLE
Frontend/copy updates

### DIFF
--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -379,7 +379,7 @@
         "licensingPublic": "Search health providers",
         "users": "Manage users",
         "compactSettings": "Settings",
-        "purchasePrivileges": "Privilege purchasing",
+        "purchasePrivileges": "Obtain privileges",
         "styleGuide": "Styleguide",
         "account": "Account",
         "logout": "Logout"
@@ -602,7 +602,7 @@
         "revealFullSsn": "Reveal full SSN",
         "incorrectInfoDisclaimer": "The information on this page was provided by your home state. If the information is incorrect, you must reach out to that state and ask them to correct it. Refer to the compact FAQ page for more information.",
         "deselectState": "Deselect state",
-        "adminFee": "Administration Fee",
+        "adminFee": "Administrative Fee",
         "jurisdictionFee": "State Fee",
         "jurisdictionFeeMilitary": "State Fee (Military)",
         "licenseTypeSearch": "Profession type",

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -378,7 +378,7 @@
         "licensingPublic": "Buscar proveedores de salud",
         "users": "Usuarios",
         "compactSettings": "Ajustes",
-        "purchasePrivileges": "Compras con privilegios",
+        "purchasePrivileges": "Obtener privilegios",
         "styleGuide": "Guía de estilo",
         "account": "Cuenta",
         "logout": "Cerrar sesión"


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Updated licensee side nav item from "Privilege purchasing" to -> "Obtain privileges"
    - To match the phrasing of the similarly-named button on the licensee dashboard
- Updated the purchasing flow text from "Administration Fee" to -> "Administrative Fee"
    - Only needed to update the English copy here, as the Spanish copy was already grammatically correct

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - Log in as a licensee who can purchase privileges
    - Confirm that the side navigation now says "Obtain privileges"
    - Begin the purchase flow and advance to the "Select privileges" screen
    - **Confirm that the blue cards of selected states now have the text "Administrative Fee" (not "Administration Fee")**
    - Proceed to the "Payment Summary" screen
    - **Confirm that the itemized list shows the text "Administrative Fee" (not "Administration Fee")**

Closes #975 
Closes #1000 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected English label to “Administrative Fee” for improved grammar.

- Style
  - Updated navigation label to “Obtain privileges” for clearer, action-oriented wording in English.
  - Aligned Spanish navigation label to “Obtener privilegios” for consistency with English phrasing.

- Chores
  - Localization text refinements only; no structural or functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->