### PR TITLE
Frontend/military home state attestation 

### DIFF
--- a/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.ts
+++ b/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.ts
@@ -142,7 +142,7 @@ export default class PrivilegePurchaseInformationConfirmation extends mixins(Mix
 
     get homeStateAttestationId(): string {
         return (this.licensee?.isMilitaryStatusActive())
-            ? 'military-personal-information-home-state-attestation'
+            ? 'military-personal-information-state-license-attestation'
             : 'personal-information-home-state-attestation';
     }
 

--- a/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.ts
+++ b/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.ts
@@ -49,20 +49,6 @@ export default class PrivilegePurchaseInformationConfirmation extends mixins(Mix
     //
     // Data
     //
-    attestationIds = {
-        aslp: [
-            'personal-information-address-attestation',
-            'personal-information-home-state-attestation',
-        ],
-        coun: [
-            'personal-information-address-attestation',
-            'personal-information-home-state-attestation',
-        ],
-        octp: [
-            'personal-information-address-attestation',
-            'personal-information-home-state-attestation',
-        ],
-    }
     attestationRecords: Array<PrivilegeAttestation> = []; // eslint-disable-line lines-between-class-members
     areFormInputsSet = false;
 
@@ -154,6 +140,31 @@ export default class PrivilegePurchaseInformationConfirmation extends mixins(Mix
         return Boolean(this.$envConfig.isDevelopment);
     }
 
+    get homeStateAttestation(): string {
+        return (this.licensee?.isMilitaryStatusActive())
+            ? 'military-personal-information-home-state-attestation'
+            : 'personal-information-home-state-attestation';
+    }
+
+    get attestationIds(): Record<string, string[]> {
+        const addressAttestationId = 'personal-information-address-attestation';
+
+        return {
+            aslp: [
+                addressAttestationId,
+                this.homeStateAttestation,
+            ],
+            coun: [
+                addressAttestationId,
+                this.homeStateAttestation,
+            ],
+            octp: [
+                addressAttestationId,
+                this.homeStateAttestation,
+            ],
+        };
+    }
+
     //
     // Methods
     //
@@ -164,7 +175,7 @@ export default class PrivilegePurchaseInformationConfirmation extends mixins(Mix
             homeState: new FormInput({
                 id: 'home-state',
                 name: 'home-state',
-                label: this.getAttestation('personal-information-home-state-attestation')?.text || '',
+                label: this.getAttestation(this.homeStateAttestation)?.text || '',
                 validation: Joi.boolean().invalid(false).messages(this.joiMessages.boolean),
                 value: false,
             }),

--- a/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.ts
+++ b/webroot/src/components/PrivilegePurchaseInformationConfirmation/PrivilegePurchaseInformationConfirmation.ts
@@ -140,7 +140,7 @@ export default class PrivilegePurchaseInformationConfirmation extends mixins(Mix
         return Boolean(this.$envConfig.isDevelopment);
     }
 
-    get homeStateAttestation(): string {
+    get homeStateAttestationId(): string {
         return (this.licensee?.isMilitaryStatusActive())
             ? 'military-personal-information-home-state-attestation'
             : 'personal-information-home-state-attestation';
@@ -152,15 +152,15 @@ export default class PrivilegePurchaseInformationConfirmation extends mixins(Mix
         return {
             aslp: [
                 addressAttestationId,
-                this.homeStateAttestation,
+                this.homeStateAttestationId,
             ],
             coun: [
                 addressAttestationId,
-                this.homeStateAttestation,
+                this.homeStateAttestationId,
             ],
             octp: [
                 addressAttestationId,
-                this.homeStateAttestation,
+                this.homeStateAttestationId,
             ],
         };
     }
@@ -175,7 +175,7 @@ export default class PrivilegePurchaseInformationConfirmation extends mixins(Mix
             homeState: new FormInput({
                 id: 'home-state',
                 name: 'home-state',
-                label: this.getAttestation(this.homeStateAttestation)?.text || '',
+                label: this.getAttestation(this.homeStateAttestationId)?.text || '',
                 validation: Joi.boolean().invalid(false).messages(this.joiMessages.boolean),
                 value: false,
             }),

--- a/webroot/src/network/mocks/mock.data.ts
+++ b/webroot/src/network/mocks/mock.data.ts
@@ -2905,7 +2905,7 @@ export const getAttestation = (attestationId) => {
     case 'personal-information-address-attestation':
         attestationObj.text = 'I hereby attest and affirm that the address information I have provided herein and is my current address. I further consent to accept service of process at this address. I will notify the Commission of a change in my Home State address or email address via updating personal information records in this system. I understand that I am only eligible for a Compact Privilege if I am a licensee in my Home State as defined by the Compact. If I mislead the Compact Commission about my Home State, the appropriate board may take action against my Compact Privilege, which may result in the revocation of other Compact Privileges I may hold. I will also be prohibited from obtaining any other Compact Privileges for a period of at least two (2) years.*';
         break;
-    case 'military-personal-information-home-state-attestation':
+    case 'military-personal-information-state-license-attestation':
         attestationObj.text = `As active duty military or the spouse of such, I hereby attest and affirm that this is my personal and licensure information and I hold an eligible license in the state listed on this page.*`;
         break;
     case 'personal-information-home-state-attestation':

--- a/webroot/src/network/mocks/mock.data.ts
+++ b/webroot/src/network/mocks/mock.data.ts
@@ -2905,6 +2905,9 @@ export const getAttestation = (attestationId) => {
     case 'personal-information-address-attestation':
         attestationObj.text = 'I hereby attest and affirm that the address information I have provided herein and is my current address. I further consent to accept service of process at this address. I will notify the Commission of a change in my Home State address or email address via updating personal information records in this system. I understand that I am only eligible for a Compact Privilege if I am a licensee in my Home State as defined by the Compact. If I mislead the Compact Commission about my Home State, the appropriate board may take action against my Compact Privilege, which may result in the revocation of other Compact Privileges I may hold. I will also be prohibited from obtaining any other Compact Privileges for a period of at least two (2) years.*';
         break;
+    case 'military-personal-information-home-state-attestation':
+        attestationObj.text = `As active duty military or the spouse of such, I hereby attest and affirm that this is my personal and licensure information and I hold an eligible license in the state listed on this page.*`;
+        break;
     case 'personal-information-home-state-attestation':
         attestationObj.text = 'I hereby attest and affirm that this is my personal and licensure information and that I am a resident of the state listed on this page.*';
         break;


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Update privilege purchase personal information to optionally display military home state attestation copy
- Update related mock data

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing:
    - Log in as practitioner who is able to obtain privileges
    - Start the privilege purchase flow and on the personal information page confirm that
        - If user is active military (or spouse), the home state attestation copy is referencing the military copy
        - If not, then the home state attestation copy is referencing the original copy with no reference to military

Closes #776 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attestation content and labels now adapt to active military status, showing a military-specific home-state attestation when applicable.
  * Home-state input label updates dynamically to reflect the selected attestation.
  * Added a new military-specific attestation statement to support confirmation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->