### PR TITLE
Frontend/improve modal voice navigation

### DIFF
--- a/webroot/src/components/App/App.vue
+++ b/webroot/src/components/App/App.vue
@@ -22,6 +22,7 @@
         </PageContainer>
         <Modal
             v-if="showMessageModal"
+            modalId="message-modal"
             :closeOnBackgroundClick="!isErrorModal"
             :isErrorModal="isErrorModal"
             @close-modal="closeModal"

--- a/webroot/src/components/CompactSettingsConfig/CompactSettingsConfig.less
+++ b/webroot/src/components/CompactSettingsConfig/CompactSettingsConfig.less
@@ -62,7 +62,9 @@
                     color: @midRed;
                     text-align: right;
                 }
+            }
 
+            .modal-actions {
                 .action-button-row {
                     display: flex;
                     flex-direction: column;

--- a/webroot/src/components/CompactSettingsConfig/CompactSettingsConfig.vue
+++ b/webroot/src/components/CompactSettingsConfig/CompactSettingsConfig.vue
@@ -57,7 +57,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isConfirmConfigModalDisplayed"
-                modalId="confirm-config-modal"
+                modalId="confirm-compact-config-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
                 :showActions="false"

--- a/webroot/src/components/CompactSettingsConfig/CompactSettingsConfig.vue
+++ b/webroot/src/components/CompactSettingsConfig/CompactSettingsConfig.vue
@@ -57,6 +57,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isConfirmConfigModalDisplayed"
+                modalId="confirm-config-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
                 :showActions="false"

--- a/webroot/src/components/CompactSettingsConfig/CompactSettingsConfig.vue
+++ b/webroot/src/components/CompactSettingsConfig/CompactSettingsConfig.vue
@@ -60,32 +60,34 @@
                 modalId="confirm-compact-config-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
-                :showActions="false"
+                :showActions="true"
                 @keydown.tab="focusTrapConfirmConfigModal($event)"
                 @keyup.esc="closeConfirmConfigModal"
             >
                 <template v-slot:content>
                     <div class="modal-content confirm-modal-content">
                         {{ $t('common.cannotBeUndone') }}
-                        <div class="action-button-row">
-                            <InputButton
-                                id="confirm-modal-submit-button"
-                                @click="submitConfirmConfigModal"
-                                class="action-button submit-button continue-button"
-                                :label="(isFormLoading)
-                                    ? $t('common.loading')
-                                    : $t('compact.confirmSaveCompactYes')"
-                                :isTransparent="true"
-                                :isEnabled="!isFormLoading"
-                            />
-                            <InputButton
-                                id="confirm-modal-cancel-button"
-                                class="action-button cancel-button"
-                                :label="$t('common.cancel')"
-                                :isWarning="true"
-                                :onClick="closeConfirmConfigModal"
-                            />
-                        </div>
+                    </div>
+                </template>
+                <template v-slot:actions>
+                    <div class="action-button-row">
+                        <InputButton
+                            id="confirm-modal-submit-button"
+                            @click="submitConfirmConfigModal"
+                            class="action-button submit-button continue-button"
+                            :label="(isFormLoading)
+                                ? $t('common.loading')
+                                : $t('compact.confirmSaveCompactYes')"
+                            :isTransparent="true"
+                            :isEnabled="!isFormLoading"
+                        />
+                        <InputButton
+                            id="confirm-modal-cancel-button"
+                            class="action-button cancel-button"
+                            :label="$t('common.cancel')"
+                            :isWarning="true"
+                            :onClick="closeConfirmConfigModal"
+                        />
                     </div>
                 </template>
             </Modal>

--- a/webroot/src/components/LicenseCard/LicenseCard.ts
+++ b/webroot/src/components/LicenseCard/LicenseCard.ts
@@ -370,8 +370,6 @@ class LicenseCard extends mixins(MixinForm) {
 
         if (this.isEncumberLicenseModalDisplayed) {
             this.initFormInputs();
-            await nextTick();
-            document.getElementById(this.formData.encumberModalDisciplineAction.id)?.focus();
         }
     }
 
@@ -433,7 +431,7 @@ class LicenseCard extends mixins(MixinForm) {
                 await this.$store.dispatch('license/getLicenseeRequest', { compact: compactType, licenseeId });
                 this.isEncumberLicenseModalSuccess = true;
                 await nextTick();
-                document.getElementById('encumber-modal-cancel-button')?.focus();
+                (this.$refs.encumberModalSuccess as HTMLElement)?.focus();
             }
 
             this.endFormLoading();
@@ -523,11 +521,6 @@ class LicenseCard extends mixins(MixinForm) {
 
         if (this.isUnencumberLicenseModalDisplayed) {
             this.initFormInputs();
-            await nextTick();
-            const firstEnabledInputId = this.getFirstEnabledFormInputId();
-            const firstTabIndex = document.getElementById(firstEnabledInputId);
-
-            firstTabIndex?.focus();
         }
     }
 
@@ -599,7 +592,7 @@ class LicenseCard extends mixins(MixinForm) {
                 await this.$store.dispatch('license/getLicenseeRequest', { compact: compactType, licenseeId });
                 this.isUnencumberLicenseModalSuccess = true;
                 await nextTick();
-                document.getElementById('unencumber-modal-cancel-button')?.focus();
+                (this.$refs.unencumberModalSuccess as HTMLElement)?.focus();
             }
 
             this.endFormLoading();

--- a/webroot/src/components/LicenseCard/LicenseCard.ts
+++ b/webroot/src/components/LicenseCard/LicenseCard.ts
@@ -430,8 +430,6 @@ class LicenseCard extends mixins(MixinForm) {
                 this.isFormSuccessful = true;
                 await this.$store.dispatch('license/getLicenseeRequest', { compact: compactType, licenseeId });
                 this.isEncumberLicenseModalSuccess = true;
-                await nextTick();
-                (this.$refs.encumberModalSuccess as HTMLElement)?.focus();
             }
 
             this.endFormLoading();
@@ -591,8 +589,6 @@ class LicenseCard extends mixins(MixinForm) {
                 this.isFormSuccessful = true;
                 await this.$store.dispatch('license/getLicenseeRequest', { compact: compactType, licenseeId });
                 this.isUnencumberLicenseModalSuccess = true;
-                await nextTick();
-                (this.$refs.unencumberModalSuccess as HTMLElement)?.focus();
             }
 
             this.endFormLoading();

--- a/webroot/src/components/LicenseCard/LicenseCard.vue
+++ b/webroot/src/components/LicenseCard/LicenseCard.vue
@@ -181,7 +181,7 @@
                         aria-live="polite"
                         role="status"
                     >
-                        <div class="icon-container"><CheckCircleIcon /></div>
+                        <div class="icon-container"><CheckCircleIcon aria-hidden="true" /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmLicenseEncumberSuccess') }}</h1>
                         <div class="success-container">
                             <div class="input-label static-label">{{ licenseeName }}</div>
@@ -298,7 +298,7 @@
                         aria-live="polite"
                         role="status"
                     >
-                        <div class="icon-container"><CheckCircleIcon /></div>
+                        <div class="icon-container"><CheckCircleIcon aria-hidden="true" /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmLicenseUnencumberSuccess') }}</h1>
                         <div class="success-container">
                             <div

--- a/webroot/src/components/LicenseCard/LicenseCard.vue
+++ b/webroot/src/components/LicenseCard/LicenseCard.vue
@@ -176,10 +176,7 @@
                         tabindex="0"
                     >
                         <div class="icon-container"><CheckCircleIcon /></div>
-                        <h1
-                            id="encumber-modal-success-title"
-                            class="modal-title">{{ $t('licensing.confirmLicenseEncumberSuccess') }}
-                        </h1>
+                        <h1 class="modal-title">{{ $t('licensing.confirmLicenseEncumberSuccess') }}</h1>
                         <div class="success-container">
                             <div class="input-label static-label">{{ licenseeName }}</div>
                             <div class="static-value">{{ stateContent }}</div>

--- a/webroot/src/components/LicenseCard/LicenseCard.vue
+++ b/webroot/src/components/LicenseCard/LicenseCard.vue
@@ -177,7 +177,6 @@
                     </div>
                     <div v-else
                         class="modal-content encumber-modal-content modal-content-success"
-                        ref="encumberModalSuccess"
                         tabindex="0"
                         aria-live="polite"
                         role="status"
@@ -295,7 +294,6 @@
                     </div>
                     <div v-else
                         class="modal-content unencumber-modal-content modal-content-success"
-                        ref="unencumberModalSuccess"
                         tabindex="0"
                         aria-live="polite"
                         role="status"

--- a/webroot/src/components/LicenseCard/LicenseCard.vue
+++ b/webroot/src/components/LicenseCard/LicenseCard.vue
@@ -148,7 +148,12 @@
                                 />
                             </div>
                             </div>
-                            <div v-if="modalErrorMessage" class="modal-error">{{ modalErrorMessage }}</div>
+                            <div
+                                v-if="modalErrorMessage"
+                                class="modal-error"
+                                aria-live="assertive"
+                                role="alert"
+                            >{{ modalErrorMessage }}</div>
                             <div class="action-button-row">
                                 <InputButton
                                     id="encumber-modal-cancel-button"
@@ -174,6 +179,8 @@
                         class="modal-content encumber-modal-content modal-content-success"
                         ref="encumberModalSuccess"
                         tabindex="0"
+                        aria-live="polite"
+                        role="status"
                     >
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmLicenseEncumberSuccess') }}</h1>
@@ -259,7 +266,12 @@
                                 />
                             </div>
                             </div>
-                            <div v-if="modalErrorMessage" class="modal-error">{{ modalErrorMessage }}</div>
+                            <div
+                                v-if="modalErrorMessage"
+                                class="modal-error"
+                                aria-live="assertive"
+                                role="alert"
+                            >{{ modalErrorMessage }}</div>
                             <div class="action-button-row">
                                 <InputButton
                                     id="unencumber-modal-cancel-button"
@@ -285,6 +297,8 @@
                         class="modal-content unencumber-modal-content modal-content-success"
                         ref="unencumberModalSuccess"
                         tabindex="0"
+                        aria-live="polite"
+                        role="status"
                     >
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmLicenseUnencumberSuccess') }}</h1>

--- a/webroot/src/components/LicenseCard/LicenseCard.vue
+++ b/webroot/src/components/LicenseCard/LicenseCard.vue
@@ -91,6 +91,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isEncumberLicenseModalDisplayed"
+                modalId="encumber-license-modal"
                 class="license-edit-modal encumber-license-modal"
                 :title="!isEncumberLicenseModalSuccess ? $t('licensing.confirmLicenseEncumberTitle') : ' '"
                 :showActions="false"
@@ -169,9 +170,16 @@
                             </div>
                         </form>
                     </div>
-                    <div v-else class="modal-content encumber-modal-content modal-content-success">
+                    <div v-else
+                        class="modal-content encumber-modal-content modal-content-success"
+                        ref="encumberModalSuccess"
+                        tabindex="0"
+                    >
                         <div class="icon-container"><CheckCircleIcon /></div>
-                        <h1 class="modal-title">{{ $t('licensing.confirmLicenseEncumberSuccess') }}</h1>
+                        <h1
+                            id="encumber-modal-success-title"
+                            class="modal-title">{{ $t('licensing.confirmLicenseEncumberSuccess') }}
+                        </h1>
                         <div class="success-container">
                             <div class="input-label static-label">{{ licenseeName }}</div>
                             <div class="static-value">{{ stateContent }}</div>
@@ -188,6 +196,7 @@
             </Modal>
             <Modal
                 v-if="isUnencumberLicenseModalDisplayed"
+                modalId="unencumber-license-modal"
                 class="license-edit-modal unencumber-license-modal"
                 :title="!isUnencumberLicenseModalSuccess ? $t('licensing.confirmLicenseUnencumberTitle') : ' '"
                 :showActions="false"
@@ -275,7 +284,11 @@
                             </div>
                         </form>
                     </div>
-                    <div v-else class="modal-content unencumber-modal-content modal-content-success">
+                    <div v-else
+                        class="modal-content unencumber-modal-content modal-content-success"
+                        ref="unencumberModalSuccess"
+                        tabindex="0"
+                    >
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmLicenseUnencumberSuccess') }}</h1>
                         <div class="success-container">

--- a/webroot/src/components/MilitaryAffiliationInfoBlock/MilitaryAffiliationInfoBlock.vue
+++ b/webroot/src/components/MilitaryAffiliationInfoBlock/MilitaryAffiliationInfoBlock.vue
@@ -77,6 +77,7 @@
         </div>
         <Modal
             v-if="shouldShowEndAffiliationModal"
+            modalId="end-affiliation-modal"
             class="end-affiliation-modal"
             :closeOnBackgroundClick="true"
             :showActions="false"

--- a/webroot/src/components/Modal/Modal.ts
+++ b/webroot/src/components/Modal/Modal.ts
@@ -11,6 +11,7 @@ import {
     Prop,
     toNative
 } from 'vue-facing-decorator';
+import { nextTick } from 'vue';
 import InputButton from '@components/Forms/InputButton/InputButton.vue';
 
 @Component({
@@ -42,7 +43,7 @@ class Modal extends Vue {
         this.$store.dispatch('setModalIsOpen', true);
 
         // Focus the modal content for screen readers to read title then content automatically
-        this.$nextTick(() => {
+        nextTick(() => {
             (this.$refs.modalContent as HTMLElement)?.focus();
         });
     }

--- a/webroot/src/components/Modal/Modal.ts
+++ b/webroot/src/components/Modal/Modal.ts
@@ -39,13 +39,11 @@ class Modal extends Vue {
         this.globalStore = this.$store.state;
     }
 
-    mounted() {
+    async mounted() {
         this.$store.dispatch('setModalIsOpen', true);
 
-        // Focus the modal content for screen readers to read title then content automatically
-        nextTick(() => {
-            (this.$refs.modalContent as HTMLElement)?.focus();
-        });
+        await nextTick();
+        await this.initializeModalAccessibility();
     }
 
     beforeUnmount() {
@@ -82,6 +80,21 @@ class Modal extends Vue {
     //
     // Methods
     //
+    async initializeModalAccessibility() {
+        const modalContainer = document.querySelector('.modal-container[role="dialog"]') as HTMLElement;
+        const modalContent = this.$refs.modalContent as HTMLElement;
+
+        if (modalContainer && modalContent) {
+            // Focus dialog container first for title announcement
+            modalContainer.setAttribute('tabindex', '-1');
+            modalContainer.focus();
+
+            await nextTick();
+            // Focus content for keyboard navigation and content reading
+            modalContent.focus();
+        }
+    }
+
     closeModal() {
         this.$emit('close-modal');
         this.$store.dispatch('setModalIsOpen', false);

--- a/webroot/src/components/Modal/Modal.ts
+++ b/webroot/src/components/Modal/Modal.ts
@@ -41,13 +41,9 @@ class Modal extends Vue {
     mounted() {
         this.$store.dispatch('setModalIsOpen', true);
 
-        // Focus the modal content so VoiceOver reads title then content
+        // Focus the modal content for screen readers to read title then content automatically
         this.$nextTick(() => {
-            const modalContent = this.$refs.modalContent as HTMLElement;
-
-            if (modalContent) {
-                modalContent.focus();
-            }
+            (this.$refs.modalContent as HTMLElement)?.focus();
         });
     }
 

--- a/webroot/src/components/Modal/Modal.ts
+++ b/webroot/src/components/Modal/Modal.ts
@@ -73,6 +73,12 @@ class Modal extends Vue {
         return `${baseId}-title`;
     }
 
+    get contentId(): string {
+        const baseId = this.modalId || 'modal';
+
+        return `${baseId}-content`;
+    }
+
     //
     // Methods
     //

--- a/webroot/src/components/Modal/Modal.ts
+++ b/webroot/src/components/Modal/Modal.ts
@@ -27,6 +27,7 @@ class Modal extends Vue {
     @Prop({ default: false }) private isErrorModal?: boolean;
     @Prop({ default: true }) private showActions?: boolean;
     @Prop({ default: [] }) private customActions?: Array<{ label: string; emitEventName: string; closeAfter: boolean }>
+    @Prop({ default: '' }) private modalId?: string;
 
     globalStore: any = {};
 
@@ -39,6 +40,15 @@ class Modal extends Vue {
 
     mounted() {
         this.$store.dispatch('setModalIsOpen', true);
+
+        // Focus the modal content so VoiceOver reads title then content
+        this.$nextTick(() => {
+            const modalContent = this.$refs.modalContent as HTMLElement;
+
+            if (modalContent) {
+                modalContent.focus();
+            }
+        });
     }
 
     beforeUnmount() {
@@ -58,6 +68,12 @@ class Modal extends Vue {
 
     get isLogoutOnly(): boolean {
         return this.globalStore.isModalLogoutOnly;
+    }
+
+    get titleId(): string {
+        const baseId = this.modalId || 'modal';
+
+        return `${baseId}-title`;
     }
 
     //

--- a/webroot/src/components/Modal/Modal.ts
+++ b/webroot/src/components/Modal/Modal.ts
@@ -81,17 +81,21 @@ class Modal extends Vue {
     // Methods
     //
     async initializeModalAccessibility() {
-        const modalContainer = document.querySelector('.modal-container[role="dialog"]') as HTMLElement;
-        const modalContent = this.$refs.modalContent as HTMLElement;
+        const root = this.$el as HTMLElement | null;
+        const modalContainer = root?.querySelector('.modal-container[role="dialog"]') as HTMLElement | null;
+        const modalContent = this.$refs.modalContent as (HTMLElement | undefined);
 
-        if (modalContainer && modalContent) {
-            // Focus dialog container first for title announcement
+        // Focus dialog container first for title announcement (even if content not yet rendered)
+        if (modalContainer) {
             modalContainer.setAttribute('tabindex', '-1');
-            modalContainer.focus();
+            modalContainer.focus({ preventScroll: true });
+        }
 
-            await nextTick();
-            // Focus content for keyboard navigation and content reading
-            modalContent.focus();
+        await nextTick();
+
+        // Optionally move focus to content for reading/keyboard nav if present
+        if (modalContent && document.contains(modalContent)) {
+            modalContent.focus({ preventScroll: true });
         }
     }
 

--- a/webroot/src/components/Modal/Modal.vue
+++ b/webroot/src/components/Modal/Modal.vue
@@ -19,10 +19,10 @@
                     :class="{ 'modal-error': isErrorModal }"
                     role="dialog"
                     aria-modal="true"
-                    :aria-labelledby="titleId"
+                    :aria-labelledby="(displayTitle) ? titleId : undefined"
                 >
                     <div class="header-container">
-                        <h1 v-if="displayTitle" class="modal-title">{{ displayTitle }}</h1>
+                        <h1 v-if="displayTitle" :id="titleId" class="modal-title">{{ displayTitle }}</h1>
                         <InputButton
                             label="X"
                             v-if="hasCloseIcon"

--- a/webroot/src/components/Modal/Modal.vue
+++ b/webroot/src/components/Modal/Modal.vue
@@ -20,6 +20,7 @@
                     role="dialog"
                     aria-modal="true"
                     :aria-labelledby="(displayTitle) ? titleId : undefined"
+                    :aria-describedby="contentId"
                 >
                     <div class="header-container">
                         <h1 v-if="displayTitle" :id="titleId" class="modal-title">{{ displayTitle }}</h1>
@@ -35,7 +36,7 @@
                         <slot name="header-fixed"></slot>
                     </div>
                     <form @submit.prevent>
-                        <div ref="modalContent" class="modal-content" tabindex="0">
+                        <div ref="modalContent" :id="contentId" class="modal-content" tabindex="0">
                             <slot name="content"></slot>
                         </div>
                         <div

--- a/webroot/src/components/Modal/Modal.vue
+++ b/webroot/src/components/Modal/Modal.vue
@@ -18,6 +18,8 @@
                     class="modal-container"
                     :class="{ 'modal-error': isErrorModal }"
                     role="dialog"
+                    aria-modal="true"
+                    :aria-labelledby="titleId"
                 >
                     <div class="header-container">
                         <h1 v-if="displayTitle" class="modal-title">{{ displayTitle }}</h1>
@@ -33,7 +35,7 @@
                         <slot name="header-fixed"></slot>
                     </div>
                     <form @submit.prevent>
-                        <div class="modal-content">
+                        <div ref="modalContent" class="modal-content" tabindex="0">
                             <slot name="content"></slot>
                         </div>
                         <div

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
@@ -485,8 +485,6 @@ class PrivilegeCard extends mixins(MixinForm) {
                 this.isFormSuccessful = true;
                 await this.$store.dispatch('license/getLicenseeRequest', { compact: compactType, licenseeId });
                 this.isEncumberPrivilegeModalSuccess = true;
-                await nextTick();
-                (this.$refs.encumberModalSuccess as HTMLElement)?.focus();
             }
 
             this.endFormLoading();
@@ -646,8 +644,6 @@ class PrivilegeCard extends mixins(MixinForm) {
                 this.isFormSuccessful = true;
                 await this.$store.dispatch('license/getLicenseeRequest', { compact: compactType, licenseeId });
                 this.isUnencumberPrivilegeModalSuccess = true;
-                await nextTick();
-                (this.$refs.unencumberModalSuccess as HTMLElement)?.focus();
             }
 
             this.endFormLoading();

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
@@ -353,8 +353,6 @@ class PrivilegeCard extends mixins(MixinForm) {
 
             if (this.isDeactivatePrivilegeModalDisplayed) {
                 this.initFormInputs();
-                await nextTick();
-                document.getElementById(this.formData.deactivateModalNotes.id)?.focus();
             }
         }
     }
@@ -427,8 +425,6 @@ class PrivilegeCard extends mixins(MixinForm) {
 
         if (this.isEncumberPrivilegeModalDisplayed) {
             this.initFormInputs();
-            await nextTick();
-            document.getElementById(this.formData.encumberModalDisciplineAction.id)?.focus();
         }
     }
 
@@ -490,7 +486,7 @@ class PrivilegeCard extends mixins(MixinForm) {
                 await this.$store.dispatch('license/getLicenseeRequest', { compact: compactType, licenseeId });
                 this.isEncumberPrivilegeModalSuccess = true;
                 await nextTick();
-                document.getElementById('encumber-modal-cancel-button')?.focus();
+                (this.$refs.encumberModalSuccess as HTMLElement)?.focus();
             }
 
             this.endFormLoading();
@@ -580,11 +576,6 @@ class PrivilegeCard extends mixins(MixinForm) {
 
         if (this.isUnencumberPrivilegeModalDisplayed) {
             this.initFormInputs();
-            await nextTick();
-            const firstEnabledInputId = this.getFirstEnabledFormInputId();
-            const firstTabIndex = document.getElementById(firstEnabledInputId);
-
-            firstTabIndex?.focus();
         }
     }
 
@@ -656,7 +647,7 @@ class PrivilegeCard extends mixins(MixinForm) {
                 await this.$store.dispatch('license/getLicenseeRequest', { compact: compactType, licenseeId });
                 this.isUnencumberPrivilegeModalSuccess = true;
                 await nextTick();
-                document.getElementById('unencumber-modal-cancel-button')?.focus();
+                (this.$refs.unencumberModalSuccess as HTMLElement)?.focus();
             }
 
             this.endFormLoading();

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
@@ -241,7 +241,7 @@
                         aria-live="polite"
                         role="status"
                     >
-                        <div class="icon-container"><CheckCircleIcon /></div>
+                        <div class="icon-container"><CheckCircleIcon aria-hidden="true" /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmPrivilegeEncumberSuccess') }}</h1>
                         <div class="success-container">
                             <div class="input-label static-label">{{ licenseeName }}</div>
@@ -358,7 +358,7 @@
                         aria-live="polite"
                         role="status"
                     >
-                        <div class="icon-container"><CheckCircleIcon /></div>
+                        <div class="icon-container"><CheckCircleIcon aria-hidden="true" /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmPrivilegeUnencumberSuccess') }}</h1>
                         <div class="success-container">
                             <div

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
@@ -104,7 +104,7 @@
                 @keyup.esc="closeDeactivatePrivilegeModal"
             >
                 <template v-slot:content>
-                    <div class="deactivate-modal-content">
+                    <div class="modal-content deactivate-modal-content">
                         {{ $t('licensing.confirmPrivilegeDeactivateSubtext') }}
                         <form class="privilege-edit-form" @submit.prevent="submitDeactivatePrivilege">
                             <MockPopulate
@@ -255,7 +255,7 @@
                 @keyup.esc="closeUnencumberPrivilegeModal"
             >
                 <template v-slot:content>
-                    <div v-if="!isUnencumberPrivilegeModalSuccess" class="unencumber-modal-content">
+                    <div v-if="!isUnencumberPrivilegeModalSuccess" class="modal-content unencumber-modal-content">
                         <form
                             id="unencumber-modal-form"
                             class="privilege-edit-form unencumber-privilege-form"

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
@@ -153,7 +153,7 @@
                 @keyup.esc="closeEncumberPrivilegeModal"
             >
                 <template v-slot:content>
-                    <div v-if="!isEncumberPrivilegeModalSuccess" class="encumber-modal-content">
+                    <div v-if="!isEncumberPrivilegeModalSuccess" class="modal-content encumber-modal-content">
                         {{ $t('licensing.confirmPrivilegeEncumberSubtext') }}
                         <form
                             id="encumber-modal-form"

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
@@ -237,7 +237,6 @@
                     </div>
                     <div v-else
                         class="modal-content encumber-modal-content modal-content-success"
-                        ref="encumberModalSuccess"
                         tabindex="0"
                         aria-live="polite"
                         role="status"
@@ -355,7 +354,6 @@
                     </div>
                     <div v-else
                         class="modal-content unencumber-modal-content modal-content-success"
-                        ref="unencumberModalSuccess"
                         tabindex="0"
                         aria-live="polite"
                         role="status"

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
@@ -119,7 +119,12 @@
                                     :shouldResizeY="true"
                                 />
                             </div>
-                            <div v-if="modalErrorMessage" class="modal-error">{{ modalErrorMessage }}</div>
+                            <div
+                                v-if="modalErrorMessage"
+                                class="modal-error"
+                                aria-live="assertive"
+                                role="alert"
+                            >{{ modalErrorMessage }}</div>
                             <div class="action-button-row">
                                 <InputButton
                                     id="deactivate-modal-cancel-button"
@@ -203,7 +208,12 @@
                                 />
                             </div>
                             </div>
-                            <div v-if="modalErrorMessage" class="modal-error">{{ modalErrorMessage }}</div>
+                            <div
+                                v-if="modalErrorMessage"
+                                class="modal-error"
+                                aria-live="assertive"
+                                role="alert"
+                            >{{ modalErrorMessage }}</div>
                             <div class="action-button-row">
                                 <InputButton
                                     id="encumber-modal-cancel-button"
@@ -229,6 +239,8 @@
                         class="modal-content encumber-modal-content modal-content-success"
                         ref="encumberModalSuccess"
                         tabindex="0"
+                        aria-live="polite"
+                        role="status"
                     >
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmPrivilegeEncumberSuccess') }}</h1>
@@ -314,7 +326,12 @@
                                 />
                             </div>
                             </div>
-                            <div v-if="modalErrorMessage" class="modal-error">{{ modalErrorMessage }}</div>
+                            <div
+                                v-if="modalErrorMessage"
+                                class="modal-error"
+                                aria-live="assertive"
+                                role="alert"
+                            >{{ modalErrorMessage }}</div>
                             <div class="action-button-row">
                                 <InputButton
                                     id="unencumber-modal-cancel-button"
@@ -340,6 +357,8 @@
                         class="modal-content unencumber-modal-content modal-content-success"
                         ref="unencumberModalSuccess"
                         tabindex="0"
+                        aria-live="polite"
+                        role="status"
                     >
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmPrivilegeUnencumberSuccess') }}</h1>

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.vue
@@ -96,6 +96,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isDeactivatePrivilegeModalDisplayed"
+                modalId="deactivate-privilege-modal"
                 class="privilege-edit-modal deactivate-privilege-modal"
                 :title="$t('licensing.confirmPrivilegeDeactivateTitle')"
                 :showActions="false"
@@ -103,7 +104,7 @@
                 @keyup.esc="closeDeactivatePrivilegeModal"
             >
                 <template v-slot:content>
-                    <div class="modal-content deactivate-modal-content">
+                    <div class="deactivate-modal-content">
                         {{ $t('licensing.confirmPrivilegeDeactivateSubtext') }}
                         <form class="privilege-edit-form" @submit.prevent="submitDeactivatePrivilege">
                             <MockPopulate
@@ -144,6 +145,7 @@
             </Modal>
             <Modal
                 v-if="isEncumberPrivilegeModalDisplayed"
+                modalId="encumber-privilege-modal"
                 class="privilege-edit-modal encumber-privilege-modal"
                 :title="!isEncumberPrivilegeModalSuccess ? $t('licensing.confirmPrivilegeEncumberTitle') : ' '"
                 :showActions="false"
@@ -151,7 +153,7 @@
                 @keyup.esc="closeEncumberPrivilegeModal"
             >
                 <template v-slot:content>
-                    <div v-if="!isEncumberPrivilegeModalSuccess" class="modal-content encumber-modal-content">
+                    <div v-if="!isEncumberPrivilegeModalSuccess" class="encumber-modal-content">
                         {{ $t('licensing.confirmPrivilegeEncumberSubtext') }}
                         <form
                             id="encumber-modal-form"
@@ -223,7 +225,11 @@
                             </div>
                         </form>
                     </div>
-                    <div v-else class="modal-content encumber-modal-content modal-content-success">
+                    <div v-else
+                        class="modal-content encumber-modal-content modal-content-success"
+                        ref="encumberModalSuccess"
+                        tabindex="0"
+                    >
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmPrivilegeEncumberSuccess') }}</h1>
                         <div class="success-container">
@@ -241,6 +247,7 @@
             </Modal>
             <Modal
                 v-if="isUnencumberPrivilegeModalDisplayed"
+                modalId="unencumber-privilege-modal"
                 class="privilege-edit-modal unencumber-privilege-modal"
                 :title="!isUnencumberPrivilegeModalSuccess ? $t('licensing.confirmPrivilegeUnencumberTitle') : ' '"
                 :showActions="false"
@@ -248,7 +255,7 @@
                 @keyup.esc="closeUnencumberPrivilegeModal"
             >
                 <template v-slot:content>
-                    <div v-if="!isUnencumberPrivilegeModalSuccess" class="modal-content unencumber-modal-content">
+                    <div v-if="!isUnencumberPrivilegeModalSuccess" class="unencumber-modal-content">
                         <form
                             id="unencumber-modal-form"
                             class="privilege-edit-form unencumber-privilege-form"
@@ -329,7 +336,11 @@
                             </div>
                         </form>
                     </div>
-                    <div v-else class="modal-content unencumber-modal-content modal-content-success">
+                    <div v-else
+                        class="modal-content unencumber-modal-content modal-content-success"
+                        ref="unencumberModalSuccess"
+                        tabindex="0"
+                    >
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('licensing.confirmPrivilegeUnencumberSuccess') }}</h1>
                         <div class="success-container">

--- a/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.vue
+++ b/webroot/src/components/SelectedStatePurchaseInformation/SelectedStatePurchaseInformation.vue
@@ -71,6 +71,7 @@
         </div>
         <Modal
             v-if="isJurisprudencePending"
+            modalId="jurisprudence-modal"
             class="attestation-modal"
             :closeOnBackgroundClick="true"
             :showActions="false"
@@ -104,6 +105,7 @@
         </Modal>
         <Modal
             v-if="isScopeOfPracticePending"
+            modalId="scope-of-practice-modal"
             class="attestation-modal"
             :closeOnBackgroundClick="true"
             :showActions="false"

--- a/webroot/src/components/StateSettingsConfig/StateSettingsConfig.less
+++ b/webroot/src/components/StateSettingsConfig/StateSettingsConfig.less
@@ -63,7 +63,9 @@
                     color: @midRed;
                     text-align: right;
                 }
+            }
 
+            .modal-actions {
                 .action-button-row {
                     display: flex;
                     flex-direction: column;

--- a/webroot/src/components/StateSettingsConfig/StateSettingsConfig.vue
+++ b/webroot/src/components/StateSettingsConfig/StateSettingsConfig.vue
@@ -57,7 +57,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isConfirmConfigModalDisplayed"
-                modalId="confirm-config-modal"
+                modalId="confirm-state-config-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
                 :showActions="false"

--- a/webroot/src/components/StateSettingsConfig/StateSettingsConfig.vue
+++ b/webroot/src/components/StateSettingsConfig/StateSettingsConfig.vue
@@ -60,32 +60,34 @@
                 modalId="confirm-state-config-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
-                :showActions="false"
+                :showActions="true"
                 @keydown.tab="focusTrapConfirmConfigModal($event)"
                 @keyup.esc="closeConfirmConfigModal"
             >
                 <template v-slot:content>
                     <div class="modal-content confirm-modal-content">
                         {{ $t('common.cannotBeUndone') }}
-                        <div class="action-button-row">
-                            <InputButton
-                                id="confirm-modal-submit-button"
-                                @click="submitConfirmConfigModal"
-                                class="action-button submit-button continue-button"
-                                :label="(isFormLoading)
-                                    ? $t('common.loading')
-                                    : $t('compact.confirmSaveCompactYes')"
-                                :isTransparent="true"
-                                :isEnabled="!isFormLoading"
-                            />
-                            <InputButton
-                                id="confirm-modal-cancel-button"
-                                class="action-button cancel-button"
-                                :label="$t('common.cancel')"
-                                :isWarning="true"
-                                :onClick="closeConfirmConfigModal"
-                            />
-                        </div>
+                    </div>
+                </template>
+                <template v-slot:actions>
+                    <div class="action-button-row">
+                        <InputButton
+                            id="confirm-modal-submit-button"
+                            @click="submitConfirmConfigModal"
+                            class="action-button submit-button continue-button"
+                            :label="(isFormLoading)
+                                ? $t('common.loading')
+                                : $t('compact.confirmSaveCompactYes')"
+                            :isTransparent="true"
+                            :isEnabled="!isFormLoading"
+                        />
+                        <InputButton
+                            id="confirm-modal-cancel-button"
+                            class="action-button cancel-button"
+                            :label="$t('common.cancel')"
+                            :isWarning="true"
+                            :onClick="closeConfirmConfigModal"
+                        />
                     </div>
                 </template>
             </Modal>

--- a/webroot/src/components/StateSettingsConfig/StateSettingsConfig.vue
+++ b/webroot/src/components/StateSettingsConfig/StateSettingsConfig.vue
@@ -57,6 +57,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isConfirmConfigModalDisplayed"
+                modalId="confirm-config-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
                 :showActions="false"

--- a/webroot/src/components/StateSettingsList/StateSettingsList.less
+++ b/webroot/src/components/StateSettingsList/StateSettingsList.less
@@ -104,7 +104,9 @@
                     color: @midRed;
                     text-align: right;
                 }
+            }
 
+            .modal-actions {
                 .action-button-row {
                     display: flex;
                     flex-direction: column;

--- a/webroot/src/components/StateSettingsList/StateSettingsList.vue
+++ b/webroot/src/components/StateSettingsList/StateSettingsList.vue
@@ -55,6 +55,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isStateLiveModalDisplayed"
+                modalId="confirm-config-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
                 :showActions="false"

--- a/webroot/src/components/StateSettingsList/StateSettingsList.vue
+++ b/webroot/src/components/StateSettingsList/StateSettingsList.vue
@@ -55,7 +55,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isStateLiveModalDisplayed"
-                modalId="confirm-config-modal"
+                modalId="confirm-state-live-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
                 :showActions="false"

--- a/webroot/src/components/StateSettingsList/StateSettingsList.vue
+++ b/webroot/src/components/StateSettingsList/StateSettingsList.vue
@@ -58,7 +58,7 @@
                 modalId="confirm-state-live-modal"
                 class="confirm-config-modal"
                 :title="$t('compact.confirmSaveCompactTitle')"
-                :showActions="false"
+                :showActions="true"
                 @keydown.tab="focusTrapStateLiveModal($event)"
                 @keyup.esc="closeStateLiveModal"
             >
@@ -66,26 +66,28 @@
                     <div class="modal-content confirm-modal-content">
                         {{ $t('common.cannotBeUndone') }}
                         <div v-if="modalErrorMessage" class="modal-error">{{ modalErrorMessage }}</div>
-                        <div class="action-button-row">
-                            <InputButton
-                                id="confirm-modal-submit-button"
-                                @click="submitStateLive"
-                                class="action-button submit-button continue-button"
-                                :label="(isFormLoading)
-                                    ? $t('common.loading')
-                                    : $t('compact.confirmSaveCompactYes')"
-                                :isTransparent="true"
-                                :isEnabled="!isFormLoading"
-                            />
-                            <InputButton
-                                id="confirm-modal-cancel-button"
-                                class="action-button cancel-button"
-                                :label="$t('common.cancel')"
-                                :isWarning="true"
-                                :isEnabled="isFormValid && !isFormLoading"
-                                :onClick="closeStateLiveModal"
-                            />
-                        </div>
+                    </div>
+                </template>
+                <template v-slot:actions>
+                    <div class="action-button-row">
+                        <InputButton
+                            id="confirm-modal-submit-button"
+                            @click="submitStateLive"
+                            class="action-button submit-button continue-button"
+                            :label="(isFormLoading)
+                                ? $t('common.loading')
+                                : $t('compact.confirmSaveCompactYes')"
+                            :isTransparent="true"
+                            :isEnabled="!isFormLoading"
+                        />
+                        <InputButton
+                            id="confirm-modal-cancel-button"
+                            class="action-button cancel-button"
+                            :label="$t('common.cancel')"
+                            :isWarning="true"
+                            :isEnabled="isFormValid && !isFormLoading"
+                            :onClick="closeStateLiveModal"
+                        />
                     </div>
                 </template>
             </Modal>

--- a/webroot/src/components/StyleGuide/ExampleModal/ExampleModal.vue
+++ b/webroot/src/components/StyleGuide/ExampleModal/ExampleModal.vue
@@ -15,6 +15,7 @@
         </div>
         <Modal
             v-if="isModalVisible"
+            modalId="example-modal"
             :closeOnBackgroundClick="true"
             :title="isErrorModal ? $t('styleGuide.errorModal') : $t('styleGuide.modal')"
             :isErrorModal="isErrorModal"

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.less
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.less
@@ -76,12 +76,6 @@
                     flex-direction: column;
                     align-items: center;
                 }
-
-                .success-content {
-                    display: flex;
-                    flex-direction: column;
-                    align-items: center;
-                }
             }
 
             .modal-actions {

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.less
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.less
@@ -76,6 +76,12 @@
                     flex-direction: column;
                     align-items: center;
                 }
+
+                .success-content {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                }
             }
 
             .modal-actions {

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.less
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.less
@@ -70,6 +70,12 @@
                     margin-bottom: 2rem;
                     font-size: 1.8rem;
                 }
+
+                .jurisdiction-modal-content {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                }
             }
 
             .modal-actions {

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.ts
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.ts
@@ -234,9 +234,8 @@ class UpdateHomeJurisdiction extends mixins(MixinForm) {
             await this.$store.dispatch('user/updateHomeJurisdictionRequest', jurisdictionUpdateData).then(async () => {
                 this.isSuccess = true;
                 this.isFormLoading = false;
-                await nextTick(() => {
-                    (this.$refs.confirmJurisdictionModalContent as HTMLElement)?.focus();
-                });
+                await nextTick();
+                (this.$refs.confirmJurisdictionModalContent as HTMLElement)?.focus();
             }).catch((err: any) => {
                 this.isError = true;
                 this.errorMessage = err?.message || this.$t('common.tryAgain');

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.ts
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.ts
@@ -14,8 +14,7 @@ import {
 import {
     reactive,
     computed,
-    ComputedRef,
-    nextTick
+    ComputedRef
 } from 'vue';
 import { stateList } from '@/app.config';
 import MixinForm from '@components/Forms/_mixins/form.mixin';
@@ -234,15 +233,10 @@ class UpdateHomeJurisdiction extends mixins(MixinForm) {
             await this.$store.dispatch('user/updateHomeJurisdictionRequest', jurisdictionUpdateData).then(async () => {
                 this.isSuccess = true;
                 this.isFormLoading = false;
-                await nextTick();
-                (this.$refs.confirmJurisdictionModalContent as HTMLElement)?.focus();
             }).catch((err: any) => {
                 this.isError = true;
                 this.errorMessage = err?.message || this.$t('common.tryAgain');
                 this.isFormLoading = false;
-                nextTick(() => {
-                    (this.$refs.confirmJurisdictionModalContent as HTMLElement)?.focus();
-                });
             });
         }
     }

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.ts
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.ts
@@ -209,8 +209,6 @@ class UpdateHomeJurisdiction extends mixins(MixinForm) {
         this.isSuccess = false;
         this.isError = false;
         this.errorMessage = '';
-        await nextTick();
-        document.getElementById('jurisdiction-cancel-btn')?.focus();
     }
 
     closeConfirmJurisdictionModal(): void {
@@ -233,15 +231,19 @@ class UpdateHomeJurisdiction extends mixins(MixinForm) {
                 jurisdiction: newHomeJurisdiction
             };
 
-            await this.$store.dispatch('user/updateHomeJurisdictionRequest', jurisdictionUpdateData).then(async () => {
+            await this.$store.dispatch('user/updateHomeJurisdictionRequest', jurisdictionUpdateData).then(() => {
                 this.isSuccess = true;
                 this.isFormLoading = false;
-                await nextTick();
-                document.getElementById('jurisdiction-close-btn')?.focus();
+                nextTick(() => {
+                    (this.$refs.confirmJurisdictionModalContent as HTMLElement)?.focus();
+                });
             }).catch((err: any) => {
                 this.isError = true;
                 this.errorMessage = err?.message || this.$t('common.tryAgain');
                 this.isFormLoading = false;
+                nextTick(() => {
+                    (this.$refs.confirmJurisdictionModalContent as HTMLElement)?.focus();
+                });
             });
         }
     }

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.ts
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.ts
@@ -231,10 +231,10 @@ class UpdateHomeJurisdiction extends mixins(MixinForm) {
                 jurisdiction: newHomeJurisdiction
             };
 
-            await this.$store.dispatch('user/updateHomeJurisdictionRequest', jurisdictionUpdateData).then(() => {
+            await this.$store.dispatch('user/updateHomeJurisdictionRequest', jurisdictionUpdateData).then(async () => {
                 this.isSuccess = true;
                 this.isFormLoading = false;
-                nextTick(() => {
+                await nextTick(() => {
                     (this.$refs.confirmJurisdictionModalContent as HTMLElement)?.focus();
                 });
             }).catch((err: any) => {

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
@@ -42,7 +42,7 @@
             @keyup.esc="closeConfirmJurisdictionModal"
         >
             <template v-slot:content>
-                <div ref="confirmJurisdictionModalContent" tabindex="0">
+                <div ref="confirmJurisdictionModalContent" class="jurisdiction-modal-content" tabindex="0">
                     <template v-if="!isSuccess && !isError">
                         <div class="modal-subtext">{{ $t('homeJurisdictionChange.modalSubtext') }}</div>
                     </template>

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
@@ -45,8 +45,8 @@
                 <div
                     class="jurisdiction-modal-content"
                     tabindex="0"
-                    aria-live="polite"
-                    role="status"
+                    :aria-live="(isSuccess) ? 'polite' : undefined"
+                    :role="(isSuccess) ? 'status' : undefined"
                 >
                     <template v-if="!isSuccess && !isError">
                         <div class="modal-subtext">{{ $t('homeJurisdictionChange.modalSubtext') }}</div>

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
@@ -42,21 +42,26 @@
             @keyup.esc="closeConfirmJurisdictionModal"
         >
             <template v-slot:content>
-                <div ref="confirmJurisdictionModalContent" class="jurisdiction-modal-content" tabindex="0">
+                <div
+                    class="jurisdiction-modal-content"
+                    tabindex="0"
+                    aria-live="polite"
+                    role="status"
+                >
                     <template v-if="!isSuccess && !isError">
                         <div class="modal-subtext">{{ $t('homeJurisdictionChange.modalSubtext') }}</div>
                     </template>
                     <template v-else-if="isSuccess">
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('homeJurisdictionChange.successTitle') }}</h1>
-                        <div
-                            class="modal-subtext"
-                            aria-live="polite"
-                            role="status"
-                        >{{ $t('homeJurisdictionChange.successSubtext') }}</div>
+                        <div class="modal-subtext">{{ $t('homeJurisdictionChange.successSubtext') }}</div>
                     </template>
                     <template v-else-if="isError">
-                        <div class="modal-subtext" aria-live="assertive" role="alert">{{ errorMessage }}</div>
+                        <div
+                            class="modal-subtext"
+                            aria-live="assertive"
+                            role="alert"
+                        >{{ errorMessage }}</div>
                     </template>
                 </div>
             </template>

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
@@ -30,6 +30,7 @@
         </form>
         <Modal
             v-if="isConfirmJurisdictionModalOpen"
+            modalId="home-jurisdiction-modal"
             id="home-jurisdiction-modal"
             class="home-jurisdiction-modal"
             :class="{ 'is-success': isSuccess }"
@@ -41,17 +42,19 @@
             @keyup.esc="closeConfirmJurisdictionModal"
         >
             <template v-slot:content>
-                <template v-if="!isSuccess && !isError">
-                    <div class="modal-subtext">{{ $t('homeJurisdictionChange.modalSubtext') }}</div>
-                </template>
-                <template v-else-if="isSuccess">
-                    <div class="icon-container"><CheckCircleIcon /></div>
-                    <h1 class="modal-title">{{ $t('homeJurisdictionChange.successTitle') }}</h1>
-                    <div class="modal-subtext">{{ $t('homeJurisdictionChange.successSubtext') }}</div>
-                </template>
-                <template v-else-if="isError">
-                    <div class="modal-subtext">{{ errorMessage }}</div>
-                </template>
+                <div ref="confirmJurisdictionModalContent" tabindex="0">
+                    <template v-if="!isSuccess && !isError">
+                        <div class="modal-subtext">{{ $t('homeJurisdictionChange.modalSubtext') }}</div>
+                    </template>
+                    <template v-else-if="isSuccess">
+                        <div class="icon-container"><CheckCircleIcon /></div>
+                        <h1 class="modal-title">{{ $t('homeJurisdictionChange.successTitle') }}</h1>
+                        <div class="modal-subtext">{{ $t('homeJurisdictionChange.successSubtext') }}</div>
+                    </template>
+                    <template v-else-if="isError">
+                        <div class="modal-subtext">{{ errorMessage }}</div>
+                    </template>
+                </div>
             </template>
             <template v-slot:actions>
                 <div v-if="!isSuccess && !isError" class="action-button-row initial-action-buttons">

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
@@ -52,7 +52,7 @@
                         <div class="modal-subtext">{{ $t('homeJurisdictionChange.modalSubtext') }}</div>
                     </template>
                     <template v-else-if="isSuccess">
-                        <div class="icon-container"><CheckCircleIcon /></div>
+                        <div class="icon-container"><CheckCircleIcon aria-hidden="true" /></div>
                         <h1 class="modal-title">{{ $t('homeJurisdictionChange.successTitle') }}</h1>
                         <div class="modal-subtext">{{ $t('homeJurisdictionChange.successSubtext') }}</div>
                     </template>

--- a/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
+++ b/webroot/src/components/UpdateHomeJurisdiction/UpdateHomeJurisdiction.vue
@@ -49,10 +49,14 @@
                     <template v-else-if="isSuccess">
                         <div class="icon-container"><CheckCircleIcon /></div>
                         <h1 class="modal-title">{{ $t('homeJurisdictionChange.successTitle') }}</h1>
-                        <div class="modal-subtext">{{ $t('homeJurisdictionChange.successSubtext') }}</div>
+                        <div
+                            class="modal-subtext"
+                            aria-live="polite"
+                            role="status"
+                        >{{ $t('homeJurisdictionChange.successSubtext') }}</div>
                     </template>
                     <template v-else-if="isError">
-                        <div class="modal-subtext">{{ errorMessage }}</div>
+                        <div class="modal-subtext" aria-live="assertive" role="alert">{{ errorMessage }}</div>
                     </template>
                 </div>
             </template>

--- a/webroot/src/components/UserAccount/UserAccount.ts
+++ b/webroot/src/components/UserAccount/UserAccount.ts
@@ -203,6 +203,9 @@ class UserAccount extends mixins(MixinForm) {
                 this.setError(err.message);
             });
 
+        await nextTick();
+        (this.$refs.confirmEmailModalContent as HTMLElement)?.focus();
+
         if (!this.isFormError) {
             this.isFormSuccessful = true;
             this.updateFormSubmitSuccess(this.$t('common.success'));
@@ -229,13 +232,14 @@ class UserAccount extends mixins(MixinForm) {
                 });
             this.endFormLoading();
         }
+
+        await nextTick();
+        (this.$refs.confirmEmailModalContent as HTMLElement)?.focus();
     }
 
     async openEmailVerificationModal(): Promise<void> {
         this.isEmailVerificationModalDisplayed = true;
         this.initFormInputs();
-        await nextTick();
-        document.getElementById(this.formData.emailVerificationCode.id)?.focus();
     }
 
     async closeEmailVerificationModal(): Promise<void> {
@@ -287,13 +291,14 @@ class UserAccount extends mixins(MixinForm) {
 
                 if (!isError) {
                     this.isEmailVerificationModalSuccess = true;
-                    await nextTick();
-                    document.getElementById('confirm-modal-cancel-button')?.focus();
                     await this.$store.dispatch(`user/getLicenseeAccountRequest`);
                 }
 
                 this.endFormLoading();
             }
+
+            await nextTick();
+            (this.$refs.confirmEmailModalContent as HTMLElement)?.focus();
         }
     }
 

--- a/webroot/src/components/UserAccount/UserAccount.ts
+++ b/webroot/src/components/UserAccount/UserAccount.ts
@@ -203,9 +203,6 @@ class UserAccount extends mixins(MixinForm) {
                 this.setError(err.message);
             });
 
-        await nextTick();
-        (this.$refs.confirmEmailModalContent as HTMLElement)?.focus();
-
         if (!this.isFormError) {
             this.isFormSuccessful = true;
             this.updateFormSubmitSuccess(this.$t('common.success'));
@@ -232,9 +229,6 @@ class UserAccount extends mixins(MixinForm) {
                 });
             this.endFormLoading();
         }
-
-        await nextTick();
-        (this.$refs.confirmEmailModalContent as HTMLElement)?.focus();
     }
 
     async openEmailVerificationModal(): Promise<void> {
@@ -296,9 +290,6 @@ class UserAccount extends mixins(MixinForm) {
 
                 this.endFormLoading();
             }
-
-            await nextTick();
-            (this.$refs.confirmEmailModalContent as HTMLElement)?.focus();
         }
     }
 

--- a/webroot/src/components/UserAccount/UserAccount.vue
+++ b/webroot/src/components/UserAccount/UserAccount.vue
@@ -31,7 +31,7 @@
                     @keyup.esc="closeEmailVerificationModal"
                 >
                     <template v-slot:content>
-                        <div class="modal-content confirm-modal-content">
+                        <div ref="confirmEmailModalContent" class="modal-content confirm-modal-content" tabindex="0">
                             <template v-if="!isEmailVerificationModalSuccess">
                                 <div class="confirm-email-subtext">
                                     {{ $t('account.enterVerificationCodeSubtext') }}
@@ -41,11 +41,16 @@
                                     class="verification-code-input-container"
                                 />
                             </template>
-                            <div v-else class="verification-code-success">
+                            <div v-else class="verification-code-success" aria-live="polite" role="status">
                                 <div class="icon-container"><CheckCircleIcon /></div>
                                 {{ $t('account.emailUpdateSuccess') }}
                             </div>
-                            <div v-if="emailVerificationErrorMessage" class="modal-error">
+                            <div
+                                v-if="emailVerificationErrorMessage"
+                                class="modal-error"
+                                aria-live="assertive"
+                                role="alert"
+                            >
                                 {{ emailVerificationErrorMessage }}
                             </div>
                             <div class="action-button-row">

--- a/webroot/src/components/UserAccount/UserAccount.vue
+++ b/webroot/src/components/UserAccount/UserAccount.vue
@@ -23,6 +23,7 @@
             <TransitionGroup>
                 <Modal
                     v-if="isEmailVerificationModalDisplayed"
+                    modalId="confirm-email-modal"
                     class="confirm-email-modal"
                     :title="(!isEmailVerificationModalSuccess) ? $t('account.enterVerificationCode') : ' '"
                     :showActions="false"

--- a/webroot/src/components/UserAccount/UserAccount.vue
+++ b/webroot/src/components/UserAccount/UserAccount.vue
@@ -42,7 +42,7 @@
                                 />
                             </template>
                             <div v-else class="verification-code-success" aria-live="polite" role="status">
-                                <div class="icon-container"><CheckCircleIcon /></div>
+                                <div class="icon-container"><CheckCircleIcon aria-hidden="true" /></div>
                                 {{ $t('account.emailUpdateSuccess') }}
                             </div>
                             <div

--- a/webroot/src/components/UserAccount/UserAccount.vue
+++ b/webroot/src/components/UserAccount/UserAccount.vue
@@ -31,7 +31,7 @@
                     @keyup.esc="closeEmailVerificationModal"
                 >
                     <template v-slot:content>
-                        <div ref="confirmEmailModalContent" class="modal-content confirm-modal-content" tabindex="0">
+                        <div class="modal-content confirm-modal-content" tabindex="0">
                             <template v-if="!isEmailVerificationModalSuccess">
                                 <div class="confirm-email-subtext">
                                     {{ $t('account.enterVerificationCodeSubtext') }}

--- a/webroot/src/components/Users/UserRow/UserRow.vue
+++ b/webroot/src/components/Users/UserRow/UserRow.vue
@@ -214,6 +214,7 @@
             </div>
             <Modal
                 v-else-if="isReinviteUserModalDisplayed"
+                modalId="reinvite-user-modal"
                 class="reinvite-user-modal"
                 :title="$t('account.confirmUserReinviteTitle', { name: accountFullName })"
                 :closeOnBackgroundClick="true"
@@ -247,6 +248,7 @@
             </Modal>
             <Modal
                 v-else-if="isDeactivateUserModalDisplayed"
+                modalId="deactivate-user-modal"
                 class="deactivate-user-modal"
                 :title="accountFullName"
                 :closeOnBackgroundClick="true"

--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -76,7 +76,7 @@
         "ethnicity": "Ethnicity",
         "welcome": "Welcome",
         "finish": "Finish",
-        "cannotBeUndone": "This action cannot be undone",
+        "cannotBeUndone": "This action cannot be undone.",
         "formValidationErrorMessage": "Please correct the errors on the form shown in red and check the box acknowledging no refunds",
         "daysOfTheWeek": {
             "monday": {

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -76,7 +76,7 @@
         "race": "Raza",
         "ethnicity": "Origen étnico",
         "finish": "Termina",
-        "cannotBeUndone": "Esta acción no se puede deshacer",
+        "cannotBeUndone": "Esta acción no se puede deshacer.",
         "daysOfTheWeek": {
             "monday": {
                 "full": "Lunes",

--- a/webroot/src/pages/LicenseeDashboard/LicenseeDashboard.ts
+++ b/webroot/src/pages/LicenseeDashboard/LicenseeDashboard.ts
@@ -6,7 +6,7 @@
 //
 
 import { Component, Vue } from 'vue-facing-decorator';
-import { reactive, nextTick } from 'vue';
+import { reactive } from 'vue';
 import { FormInput } from '@/models/FormInput/FormInput.model';
 import HomeStateBlock from '@/components/HomeStateBlock/HomeStateBlock.vue';
 import LicenseCard from '@/components/LicenseCard/LicenseCard.vue';
@@ -152,8 +152,6 @@ export default class LicenseeDashboard extends Vue {
 
     async openPurchaseUnavailableModal(): Promise<void> {
         this.isPurchaseUnavailableModalDisplayed = true;
-        await nextTick();
-        document.getElementById('purchase-unavailable-modal-reasons')?.focus();
     }
 
     closePurchaseUnavailableModal(): void {
@@ -171,10 +169,9 @@ export default class LicenseeDashboard extends Vue {
 
     focusTrapPurchaseUnavailable(event: KeyboardEvent): void {
         const closeButton = document.getElementById('submit-close-purchase-unavailable');
-        const reasonsList = document.getElementById('purchase-unavailable-modal-reasons');
         const militaryLink = document.getElementById('military-status-link');
         // Array of focusable elements in order
-        const focusables = [reasonsList, militaryLink, closeButton]
+        const focusables = [militaryLink, closeButton]
             .filter((element) => element !== null) as HTMLElement[];
         const currentIndex = focusables.indexOf(document.activeElement as HTMLElement);
         let nextIndex;

--- a/webroot/src/pages/LicenseeDashboard/LicenseeDashboard.vue
+++ b/webroot/src/pages/LicenseeDashboard/LicenseeDashboard.vue
@@ -93,6 +93,7 @@
         <TransitionGroup>
             <Modal
                 v-if="isPurchaseUnavailableModalDisplayed"
+                modalId="purchase-unavailable-modal"
                 class="purchase-unavailable-modal"
                 title=" "
                 :showActions="true"
@@ -105,11 +106,7 @@
                         <p id="purchase-unavailable-modal-title" class="purchase-unavailable-message">
                             {{ $t('licensing.purchaseUnavailableMessage') }}
                         </p>
-                        <ol
-                            id="purchase-unavailable-modal-reasons"
-                            class="purchase-unavailable-list good-wrap"
-                            tabindex="-1"
-                        >
+                        <ol class="purchase-unavailable-list good-wrap">
                             <li v-if="!hasEligibleLicenses">
                                 {{ $t('licensing.purchaseUnavailableNoEligibleLicenses') }}
                             </li>


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Update all existing modals with aria labeling needed to improve voice over

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing:
    - To turn on macOS VoiceOver 
    - Click the Apple  menu (top left)
        - System Settings (or System Preferences on older macOS)
        - Go to Accessibility
        - In the sidebar, select VoiceOver
        - Toggle VoiceOver on.
    - Test all existing modals and confirm that the VoiceOver reads the title (if exists) and content on initial / success / error 
phases
    - Confirm that the focus trap still works as before

Closes #971 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-instance modal identifiers (modalId) across many dialogs.

- **Accessibility**
  - Modals improved with ARIA attributes, labelled/description IDs, focusable content areas, conditional live regions for errors/success, and decorative icons hidden from assistive tech.

- **Behavioral Change**
  - Removed automatic autofocus sequencing and nextTick-based focus adjustments after modal open and post-submit.

- **Style**
  - Modal action layout and jurisdiction modal content updated for vertical stacking and responsive alignment.

- **Localization**
  - Punctuation added to "cannot be undone" in English and Spanish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->