### PR TITLE
Frontend/override iOS Safari button styles

### DIFF
--- a/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.less
+++ b/webroot/src/components/PrivilegePurchaseFinalize/PrivilegePurchaseFinalize.less
@@ -129,7 +129,7 @@
                 width: 100%;
                 height: 100%;
 
-                :deep(.input-button) {
+                :deep(.input-submit) {
                     width: 100%;
                 }
             }

--- a/webroot/src/styles.common/mixins/buttons.less
+++ b/webroot/src/styles.common/mixins/buttons.less
@@ -37,6 +37,8 @@
         color @transition,
         background-color @transition,
         border-color @transition;
+    -webkit-appearance: none;
+    appearance: none;
 
     &:disabled {
         border-color: @buttonDisabledBGColor;


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Add additional styles to primary button to override iOS Safari built-in styling
- Fix mobile UI bug on the final step of the privilege purchase flow

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing:
    - Smoke test the app using Xcode simulator on an iOS device with Safari and confirm that the buttons encountered look like they do on a desktop browser experience

Closes #1008 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized primary button appearance across browsers by disabling native browser styling, improving visual consistency and reducing OS-specific quirks (e.g., unexpected shadows or rounded corners).
  - Updated styling for the payment overlay’s submit button to ensure it displays full-width and matches the app’s primary button look during checkout/finalization.
  - Visual-only adjustments; no changes to interaction flow or functionality. Users should see more consistent button rendering across devices and browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->