### PR TITLE
Fix/hotfix patch

### DIFF
--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -205,13 +205,15 @@ class UserPool(CdkUserPool):
                 flows=OAuthFlows(authorization_code_grant=True, implicit_code_grant=False),
                 scopes=ui_scopes,
             ),
-            access_token_validity=Duration.minutes(60),
+            access_token_validity=Duration.minutes(5),
+            id_token_validity=Duration.minutes(5),
             auth_session_validity=Duration.minutes(15),
             enable_token_revocation=True,
             generate_secret=False,
             refresh_token_validity=Duration.days(30),
             write_attributes=write_attributes,
             read_attributes=read_attributes,
+            prevent_user_existence_errors=True,
         )
 
     def _add_risk_configuration(self, security_profile: SecurityProfile):

--- a/backend/compact-connect/docs/README.md
+++ b/backend/compact-connect/docs/README.md
@@ -81,24 +81,8 @@ dateOfIssuance,npi,licenseNumber,dateOfBirth,licenseType,familyName,homeAddressC
 
 ### Machine-to-machine automated uploads
 
-The data system API supports uploading of a large CSV file for asynchronous data ingest. The feature involves using two
-endpoints, which are described in the [Open API Specification](#open-api-specification). To upload a file for
-asynchronous data ingest perform the following steps:
-1) Request a dedicated client for your automated integration. Note that there may be some lead time for that request.
-2) Authenticate your client using the **OAuth2.0 client-credentials-grant** to obtain an access token for the API.
-3) Call the `GET /v1/compacts/{compact}/jurisdictions/{jurisdiction}/licenses/bulk-upload` endpoint to receive an upload
-   URL and upload fields to use when uploading your file.
-4) `POST` to the provided url, with `Content-Type: multipart/form-data`, providing all the fields returned from the
-   `GET` endpoint as form-data fields in addition to your file.
-
-For your convenience, use of this feature is included in the [Postman Collection](./postman/postman-collection.json).
-
-Note that, when using the bulk-upload feature, processing of licenses is asynchronous, and so feedback on invalid
-licenses is slow. The operational reports contact email will be sent a nightly report with a sample of validation
-errors, if there were any, from the day's uploads. For faster feedback, there is also a POST licenses endpoint,
-where up to 100 json-formatted licenses can be uploaded in a single request, with synchronous validation results. We
-highly recommend that states with the capability integrate with this JSON endpoint instead, for more efficient
-communication and feedback. See the API specification for more details.
+The data system API supports uploading of a large CSV file for asynchronous data ingest, as well as JSON license records
+for synchronous data ingest. See the [CompactConnect Automated License Data Upload Instructions](./it_staff_onboarding_instructions.md) for more information.
 
 ## Open API Specification
 [Back to top](#compact-connect---technical-user-guide)

--- a/backend/compact-connect/docs/it_staff_onboarding_instructions.md
+++ b/backend/compact-connect/docs/it_staff_onboarding_instructions.md
@@ -103,7 +103,7 @@ AWS documentation: https://docs.aws.amazon.com/cognito/latest/developerguide/tok
 - Your application should request a new token before the current one expires
 - Store the `access_token` value for use in API requests
 
-### Step 2: Upload License Data to the Beta Environment
+### Step 2: Upload License Data to the Beta Environment (JSON POST Endpoint)
 
 The CompactConnect License API can be called through a POST REST endpoint which takes in a list of license record
 objects. The following curl command example demonstrates how to upload license data into the **beta** environment, but
@@ -149,6 +149,7 @@ Replace:
 - `<compact>` with the lower-cased compact abbreviation (e.g., `aslp`, `octp`, or `coun`) - this information was
   provided in the email.
 - `<jurisdiction>` with your lower-cased two-letter state code (e.g., `ky`) - this information was provided in the email
+- The `User-Agent` header value with your own application name, version, and contact information
 - The example payload shown here with your test license data
 Note: The URL was provided during onboarding and is already configured for your jurisdiction and compact.
 
@@ -157,13 +158,78 @@ Note: The URL was provided during onboarding and is already configured for your 
 In addition to calling the POST endpoint, there is also an option to upload license data in a CSV file format.
 This method may be preferable for larger datasets or for systems that already generate CSV exports.
 
-For detailed documentation on CSV file uploads, including required fields, formatting requirements, and the upload
-process, please refer to [the technical user guide](./README.md#machine-to-machine-automated-uploads).
+#### CSV Upload Process
+
+The CSV upload process involves two steps:
+
+**Step 2a: Get Upload Configuration**
+
+First, obtain the upload URL and required form fields:
+
+```bash
+curl --location --request GET 'https://api.beta.compactconnect.org/v1/compacts/<compact>/jurisdictions/<jurisdiction>/licenses/bulk-upload' \
+--header 'Authorization: Bearer <access_token>' \
+--header 'Accept: application/json' \
+--header 'User-Agent: <your-app-name>/<version> (<contact-email-or-url>)'
+```
+
+Replace:
+- `<access_token>` with the access token from Step 1
+- `<compact>` with the lower-cased compact abbreviation (e.g., `aslp`, `octp`, or `coun`) - this information was
+  provided in the email.
+- `<jurisdiction>` with your lower-cased two-letter state code (e.g., `ky`) - this information was provided in the email
+- The `User-Agent` header value with your own application name, version, and contact information
+
+This will return a response like:
+```json
+{
+  "upload": {
+    "url": "<url>",
+    "fields": {
+      "key": "<object key>",
+      "x-amz-algorithm": "AWS4-HMAC-SHA256",
+      "x-amz-credential": "<credentials>",
+      "x-amz-date": "20240101T000000Z",
+      "x-amz-security-token": "<token>",
+      "policy": "<policy>",
+      "x-amz-signature": "<signature>",
+    }
+  }
+}
+```
+
+**Step 2b: Upload Your CSV File**
+
+Using the URL and fields from Step 2a, upload your CSV file. **Important**: You must include all the fields from the response, plus a `content-type` field set to `text/csv`, and your file:
+
+```bash
+curl --location --request POST '<upload_url_from_step_2a>' \
+--form 'key="<key_from_response>"' \
+--form 'x-amz-algorithm="<algorithm_from_response>"' \
+--form 'x-amz-credential="<credential_from_response>"' \
+--form 'x-amz-date="<date_from_response>"' \
+--form 'x-amz-signature="<signature_from_response>"' \
+--form 'x-amz-security-token="<token_from_response>"' \
+--form 'policy="<policy_from_response>"' \
+--form 'content-type="text/csv"' \
+--form 'file=@"/path/to/your/licenses.csv"'
+```
+
+**IMPORTANT**: The order of form fields matters for S3 uploads. Ensure the `file` field comes last, and all AWS signature fields are included as shown.
+
+Note that, when using the bulk-upload feature, processing of licenses is asynchronous, and so feedback on invalid
+licenses is slow. The operational reports contact email will be sent a nightly report with a sample of validation
+errors, if there were any, from the day's uploads. For faster feedback, we highly recommend that states with the 
+capability integrate with the JSON endpoint described above in step 2 instead, for more efficient communication and feedback. 
 
 ## License Data Schema Requirements
 
-For the latest information about the license data field requirements, along with descriptions of each field, please see
-[the technical user guide](./README.md#field-descriptions).
+For the latest information about the license data field requirements, along with descriptions of each field, please see the field description
+section of [the technical user guide](./README.md#field-descriptions).
+
+See the API specification at [Open API Specification](./README.md#open-api-specification) for more API schema details.
+
+For your convenience, use of this feature is included in the [Postman Collection](./postman/postman-collection.json).
 
 **Important Notes**:
 - If `licenseStatus` is "inactive", `compactEligibility` cannot be "eligible"

--- a/backend/compact-connect/lambdas/python/common/cc_common/data_model/provider_record_util.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/data_model/provider_record_util.py
@@ -63,6 +63,24 @@ class ProviderRecordUtility:
     privilege_previous_update_schema = PrivilegeUpdatePreviousGeneralResponseSchema()
 
     @staticmethod
+    def sanitize_provider_account_profile_fields_from_response(provider_response: dict) -> dict:
+        """
+        Remove sensitive profile related fields from a provider response.
+
+        These fields are only present if the provider has requested an email change or account recovery.
+        They should not be present in the provider response for any endpoint.
+
+        :param provider_response: The provider response to sanitize
+        :return: The provider response with sensitive profile related fields removed
+        """
+        provider_response.pop('emailVerificationExpiry', None)
+        provider_response.pop('emailVerificationCode', None)
+        provider_response.pop('pendingEmailAddress', None)
+        provider_response.pop('recoveryToken', None)
+        provider_response.pop('recoveryExpiry', None)
+        return provider_response
+
+    @staticmethod
     def get_records_of_type(
         provider_records: Iterable[dict],
         record_type: ProviderRecordType,
@@ -763,5 +781,7 @@ class ProviderUserRecords:
         provider['licenses'] = licenses
         provider['privileges'] = privileges
         provider['militaryAffiliations'] = military_affiliations
+
+        ProviderRecordUtility.sanitize_provider_account_profile_fields_from_response(provider)
 
         return provider

--- a/backend/compact-connect/lambdas/python/compact-configuration/handlers/compact_configuration.py
+++ b/backend/compact-connect/lambdas/python/compact-configuration/handlers/compact_configuration.py
@@ -118,6 +118,7 @@ def _get_public_compact_jurisdictions(event: dict, context: LambdaContext):  # n
     return CompactJurisdictionsPublicResponseSchema().load(compact_jurisdictions, many=True)
 
 
+@authorize_compact_level_only_action(action=CCPermissionsAction.ADMIN)
 def _get_staff_users_compact_configuration(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
     """
     Endpoint for staff users to get the compact configuration.
@@ -310,6 +311,7 @@ def _validate_configured_states_transitions(
                 )
 
 
+@authorize_state_level_only_action(action=CCPermissionsAction.ADMIN)
 def _get_staff_users_jurisdiction_configuration(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argument
     """
     Endpoint for staff users to get the jurisdiction configuration.

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/bulk_upload.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/bulk_upload.py
@@ -42,7 +42,11 @@ def _bulk_upload_url_handler(event: dict, context: LambdaContext):  # noqa: ARG0
         Key=f'{compact}/{jurisdiction}/{uuid4().hex}',
         ExpiresIn=config.presigned_post_ttl_seconds,
         # Limit content length to ~30MB, ~200k licenses
-        Conditions=[['content-length-range', 1, 30_000_000]],
+        Conditions=[
+            ['content-length-range', 1, 30_000_000],
+            # Enforce that only CSV files can be uploaded
+            ['eq', '$Content-Type', 'text/csv'],
+        ],
     )
     logger.info('Created pre-signed POST', url=upload['url'])
     return {'upload': upload}

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/main.py
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/main.py
@@ -30,7 +30,7 @@ def customize_scopes(event: dict, context: LambdaContext):  # noqa: ARG001 unuse
         user_data = UserData(sub)
         logger.debug('Adding scopes', scopes=user_data.scopes)
 
-        # Get all of the user's records and set their status to active
+        # Get all the user's records and set their status to active
         for record in user_data.records:
             # Only update the status if it's not already active
             if record['status'] != StaffUserStatus.ACTIVE.value:
@@ -48,7 +48,12 @@ def customize_scopes(event: dict, context: LambdaContext):  # noqa: ARG001 unuse
         return event
 
     event['response']['claimsAndScopeOverrideDetails'] = {
-        'accessTokenGeneration': {'scopesToAdd': list(user_data.scopes)}
+        'accessTokenGeneration': {
+            'scopesToAdd': list(user_data.scopes),
+            # we explicitly suppress the cognito admin scope,
+            # so they cannot change their email directly with the Cognito API
+            'scopesToSuppress': ['aws.cognito.signin.user.admin'],
+        }
     }
 
     return event

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/__init__.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/__init__.py
@@ -4,6 +4,7 @@ import os
 
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
+from common_test.test_constants import DEFAULT_FAMILY_NAME, DEFAULT_GIVEN_NAME
 from faker import Faker
 from moto import mock_aws
 
@@ -200,6 +201,20 @@ class TstFunction(TstLambdas):
             DesiredDeliveryMediums=['EMAIL'],
         )
         return get_sub_from_user_attributes(user_data['User']['Attributes'])
+
+    def _when_testing_with_valid_caller(self, compact: str = 'aslp'):
+        # creates a user for endpoints that require the caller to have an active database record
+        user = self.config.user_client.create_user(
+            compact=compact,
+            attributes={
+                'email': 'someEmail@test.com',
+                'familyName': DEFAULT_FAMILY_NAME,
+                'givenName': DEFAULT_GIVEN_NAME,
+            },
+            permissions={'actions': set(), 'jurisdictions': {}},
+        )
+
+        return user['userId']
 
     @staticmethod
     def _create_write_permissions(jurisdiction: str):

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -22,6 +22,8 @@ class TestPatchUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for aslp/oh
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin'
         event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
         event['body'] = json.dumps({'permissions': {'aslp': {'jurisdictions': {'oh': {'actions': {'admin': True}}}}}})
@@ -74,6 +76,8 @@ class TestPatchUser(TstFunction):
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
 
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email octp/admin oh/octp.admin'
         event['pathParameters'] = {'compact': 'octp', 'userId': '648864e8-10f1-702f-e666-2e0ff3482502'}
         event['body'] = json.dumps(
@@ -130,6 +134,8 @@ class TestPatchUser(TstFunction):
         api_user['permissions'] = {'aslp': {'jurisdictions': {}}}
         event['body'] = json.dumps(api_user)
 
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin'
         event['pathParameters'] = {'compact': 'aslp'}
 
@@ -170,6 +176,8 @@ class TestPatchUser(TstFunction):
         with open('tests/resources/api/user-post.json') as f:
             api_user = json.load(f)
 
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin'
         event['pathParameters'] = {'compact': 'aslp'}
         event['body'] = json.dumps(api_user)
@@ -210,6 +218,8 @@ class TestPatchUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for oh/aslp not ne/aslp
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin'
         event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
         event['body'] = json.dumps({'permissions': {'aslp': {'jurisdictions': {'ne': {'actions': {'admin': True}}}}}})
@@ -227,6 +237,8 @@ class TestPatchUser(TstFunction):
             event = json.load(f)
 
         # The caller has admin permission for oh/aslp not ne/aslp
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin'
         # The staff user does not exist
         event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
@@ -248,6 +260,8 @@ class TestPatchUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for compact and oh
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin aslp/admin'
         event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
         event['body'] = json.dumps(
@@ -295,6 +309,8 @@ class TestPatchUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for aslp
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin'
         event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
         # in this case, the user is attempting to add permission for inactive compact, which is not valid

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
@@ -26,6 +26,8 @@ class TestPostUser(TstFunction):
             api_user = json.load(f)
 
         # The user has admin permission for aslp/oh
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin oh/aslp.admin'
         event['pathParameters'] = {'compact': 'aslp'}
 
@@ -49,6 +51,7 @@ class TestPostUser(TstFunction):
         from handlers.users import get_one_user, post_user
 
         self._when_testing_with_valid_jurisdiction()
+        caller_id = self._when_testing_with_valid_caller()
 
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
@@ -60,6 +63,7 @@ class TestPostUser(TstFunction):
         event['body'] = json.dumps(api_user)
 
         # The user has admin permission for aslp admin
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin oh/aslp.admin'
         event['pathParameters'] = {'compact': 'aslp'}
 
@@ -113,6 +117,7 @@ class TestPostUser(TstFunction):
         from handlers.users import post_user
 
         self._load_compact_active_member_jurisdictions()
+        caller_id = self._when_testing_with_valid_caller()
 
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
@@ -125,6 +130,7 @@ class TestPostUser(TstFunction):
         event['body'] = json.dumps(api_user)
 
         # The user has admin permission for aslp
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin oh/aslp.admin'
         event['pathParameters'] = {'compact': 'aslp'}
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_reinvite_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_reinvite_user.py
@@ -14,6 +14,8 @@ class TestReinviteUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for all of aslp
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin'
         event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
         event['body'] = None
@@ -29,6 +31,8 @@ class TestReinviteUser(TstFunction):
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
 
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin'
         event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
         event['body'] = None
@@ -47,7 +51,9 @@ class TestReinviteUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for all of aslp
+        caller_id = self._when_testing_with_valid_caller()
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email aslp/admin'
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['pathParameters'] = {'compact': 'aslp', 'userId': user_id}
         event['body'] = None
 
@@ -67,6 +73,8 @@ class TestReinviteUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for aslp/oh
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin'
         event['pathParameters'] = {'compact': 'aslp', 'userId': user_id}
         event['body'] = None
@@ -87,6 +95,8 @@ class TestReinviteUser(TstFunction):
             event = json.load(f)
 
         # The user has admin permission for aslp/ne, user does not have aslp/oh permissions
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email ne/aslp.admin'
         event['pathParameters'] = {'compact': 'aslp', 'userId': user_id}
         event['body'] = None

--- a/webroot/src/network/stateApi/data.api.ts
+++ b/webroot/src/network/stateApi/data.api.ts
@@ -96,6 +96,8 @@ export class StateDataApi implements DataApiInterface {
         s3FieldOrder.forEach((field) => {
             formData.append(field, fields[field]);
         });
+        // Add Content-Type field required by S3 pre-signed POST condition
+        formData.append('Content-Type', 'text/csv');
         formData.append('file', file);
 
         return axios.post(url, formData, {

--- a/webroot/src/pages/PublicDashboard/PublicDashboard.ts
+++ b/webroot/src/pages/PublicDashboard/PublicDashboard.ts
@@ -55,7 +55,7 @@ export default class DashboardPublic extends Vue {
 
     get hostedLoginUriStaff(): string {
         const { domain, cognitoAuthDomainStaff, cognitoClientIdStaff } = this.$envConfig;
-        const loginScopes = 'email openid phone profile aws.cognito.signin.user.admin';
+        const loginScopes = 'email openid profile';
         const loginResponseType = 'code';
         const loginRedirectPath = '/auth/callback';
         const loginUriQuery = [
@@ -73,7 +73,7 @@ export default class DashboardPublic extends Vue {
 
     get hostedLoginUriLicensee(): string {
         const { domain, cognitoAuthDomainLicensee, cognitoClientIdLicensee } = this.$envConfig;
-        const loginScopes = 'email openid phone profile aws.cognito.signin.user.admin';
+        const loginScopes = 'email openid profile';
         const loginResponseType = 'code';
         const loginRedirectPath = '/auth/callback';
         const loginUriQuery = [

--- a/webroot/src/store/user/user.actions.ts
+++ b/webroot/src/store/user/user.actions.ts
@@ -228,7 +228,7 @@ export default {
         }
 
         const params = new URLSearchParams();
-        const refreshInMs = moment().add(expiresIn, 'seconds').subtract(5, 'minutes').diff(moment(), 'milliseconds');
+        const refreshInMs = moment().add(expiresIn, 'seconds').subtract(1, 'minutes').diff(moment(), 'milliseconds');
         const refreshTokens = async () => {
             let isError = false;
 


### PR DESCRIPTION
This includes several patches to address pentesting findings. It also adds documentation for the csv bulk upload endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Sanitizes sensitive provider recovery fields from API responses.
  - Re-enables disabled staff accounts on reinvite; disables directory account on delete.
  - Tightens admin-only access for select staff configuration endpoints.
  - Removes unnecessary scopes from login and suppresses admin scope in tokens.
  - Enforces CSV-only bulk uploads and includes Content-Type in upload forms.
  - Adjusts token refresh to occur closer to expiry.
- Documentation
  - Simplifies data upload overview and expands onboarding with detailed JSON and CSV upload guidance, schema requirements, and references.
- Tests
  - Adds coverage for scope suppression, authorization paths, and sensitive-field filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->