### PR TITLE
Frontend/Pin qrcode dependency version

### DIFF
--- a/webroot/package.json
+++ b/webroot/package.json
@@ -28,7 +28,7 @@
     "moment": "^2.30.1",
     "numeral": "^2.0.6",
     "object.fromentries": "^2.0.2",
-    "qrcode": "^1.5.4",
+    "qrcode": "1.5.4",
     "register-service-worker": "^1.7.1",
     "text-encoding-shim": "^1.0.5",
     "uuid": "^8.3.2",

--- a/webroot/yarn.lock
+++ b/webroot/yarn.lock
@@ -10348,7 +10348,7 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qrcode@^1.5.4:
+qrcode@1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.4.tgz#5cb81d86eb57c675febb08cf007fff963405da88"
   integrity sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==


### PR DESCRIPTION
### Requirements List
- Remove `/webroot/node_modules` directory locally
- `yarn install --ignore-engines`

### Description List
- Pin the version of `qrcode` to avoid the mayhem of an npm author compromise until the dust settles
- Actively monitoring [this thread](https://github.com/debug-js/debug/issues/1005) by the maintainer Qix to determine if we ultimately need this PR or not -or- if we need to adjust other packages from any other affected maintainers

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Quick smoke test of app functionality, including the QR code on licensee proof pages

Closes #1067 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Pinned a third-party QR code library to a specific version to ensure consistent behavior across environments and avoid unexpected changes from automatic updates.
  - Improves build reproducibility and reliability for users by stabilizing dependency resolution.
  - No changes to features, UI, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->