### PR TITLE
Frontend/Purchase state sort + test improvements

### DIFF
--- a/webroot/src/components/Licensee/LicenseeList/LicenseeList.spec.ts
+++ b/webroot/src/components/Licensee/LicenseeList/LicenseeList.spec.ts
@@ -23,9 +23,6 @@ const populateComponentStorePagingKeys = (component) => {
 };
 
 describe('LicenseeList component', async () => {
-    before(() => {
-        global.requestAnimationFrame = (cb) => cb(); // JSDOM omits this global method, so we need to mock it ourselves
-    });
     it('should mount the component', async () => {
         const wrapper = await mountFull(LicenseeList); // mounting full here to get ahead of some vue-test-utils oddities in fast local environments
 

--- a/webroot/src/models/PrivilegePurchaseOption/PrivilegePurchaseOption.model.spec.ts
+++ b/webroot/src/models/PrivilegePurchaseOption/PrivilegePurchaseOption.model.spec.ts
@@ -92,11 +92,6 @@ describe('PrivilegePurchaseOption model', () => {
                     amount: 100
                 }
             ],
-            militaryDiscount: {
-                active: true,
-                discountType: 'FLAT_RATE',
-                discountAmount: 10
-            },
             jurisprudenceRequirements: {
                 required: true,
                 linkToDocumentation: 'https://example.com',
@@ -133,7 +128,6 @@ describe('PrivilegePurchaseOption model', () => {
                     licenseTypeAbbreviation: 'aud'
                 }
             ],
-            militaryDiscount: null,
             jurisprudenceRequirements: {
                 required: true,
                 linkToDocumentation: 'https://example.com',

--- a/webroot/src/network/mocks/mock.data.ts
+++ b/webroot/src/network/mocks/mock.data.ts
@@ -176,18 +176,15 @@ export const createStatePrivilegePurchaseOption = (config: any = {}) => {
         privilegeFees: [
             {
                 licenseTypeAbbreviation: 'ot',
-                amount: 200
+                amount: 200,
+                militaryRate: (config?.hasMilitaryDiscount) ? 90 : undefined,
             },
             {
                 licenseTypeAbbreviation: 'ota',
-                amount: 100
+                amount: 100,
+                militaryRate: (config?.hasMilitaryDiscount) ? 50 : undefined,
             }
         ],
-        militaryDiscount: {
-            active: Boolean(config?.hasMilitaryDiscount),
-            discountType: 'FLAT_RATE',
-            discountAmount: 10,
-        },
         jurisprudenceRequirements: {
             required: Boolean(config?.hasJurisprudence),
         },

--- a/webroot/src/store/user/user.spec.ts
+++ b/webroot/src/store/user/user.spec.ts
@@ -769,21 +769,9 @@ describe('User Store Actions', async () => {
         const commit = sinon.spy();
         const dispatch = sinon.spy();
         const state = { currentCompact: new Compact({ type: CompactType.ASLP }) };
-
-        const data = {
-            jurisdiction: new State({ abbrev: 'ca' }),
-            compactType: CompactType.ASLP,
-            fee: 5,
-            isMilitaryDiscountActive: true,
-            militaryDiscountType: FeeTypes.FLAT_RATE,
-            militaryDiscountAmount: 10,
-            isJurisprudenceRequired: true,
-        };
-        const privilegePurchaseOption = new PrivilegePurchaseOption(data);
-
         const privilegePurchaseData = {
-            privilegePurchaseOptions: [ privilegePurchaseOption ],
-            compactCommissionFee: { compactType: CompactType.ASLP, feeType: 'FLAT_RATE', feeAmount: 3.5 }
+            privilegePurchaseOptions: [ new PrivilegePurchaseOption() ],
+            compactCommissionFee: { compactType: CompactType.ASLP, feeType: FeeTypes.FLAT_RATE, feeAmount: 3.5 }
         };
 
         await actions.getPrivilegePurchaseInformationSuccess({ commit, dispatch, state }, privilegePurchaseData);


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- On the Purchase payment summary page, sort the state names alphabetically (ascending)
- Clean up some of the related code in the PrivilegePurchaseFinalize component
- Cleanup out mock data & tests to no longer use the deprecated `militaryDiscount` data
- Tune our automated test runner setup with more stable locale & polyfill defaults

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - Login as a Licensee user who can purchase privileges
    - Begin the purchase flow and continue to the Payment Summary screen (nothing before screen this was changed in this PR)
    - The Payment Summary screen should show the selected states in alphabetical order
        - NOTE: This only applies to the states. Other fees like Admin & Credit Card fees should still be listed _after_ the states.

Closes #976 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer fee display for selected states, including explicit military-rate labeling with correctly formatted amounts.

- Improvements
  - Deterministic, case-insensitive alphabetical sorting of selected states for consistent presentation.
  - More resilient state selection logic to include only valid jurisdictions.

- Bug Fixes
  - Correct assembly of state fee text to prevent missing or overwritten labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->