### PR TITLE
Frontend/helpdesk external link

### DIFF
--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -382,7 +382,8 @@
         "purchasePrivileges": "Obtain privileges",
         "styleGuide": "Styleguide",
         "account": "Account",
-        "logout": "Logout"
+        "logout": "Logout",
+        "helpCenter": "Help Center"
     },
     "privacyPolicy": {
         "title": "Privacy Policy",

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -381,7 +381,8 @@
         "purchasePrivileges": "Obtener privilegios",
         "styleGuide": "Guía de estilo",
         "account": "Cuenta",
-        "logout": "Cerrar sesión"
+        "logout": "Cerrar sesión",
+        "helpCenter": "Centro de ayuda"
     },
     "paging": {
         "previousPage": "Pagina anterior",

--- a/webroot/src/pages/PublicDashboard/PublicDashboard.less
+++ b/webroot/src/pages/PublicDashboard/PublicDashboard.less
@@ -174,6 +174,13 @@
             display: flex;
             margin-bottom: @separatorSpacing;
 
+            // Override focus styles to use box-shadow instead of outline
+            &:focus {
+                border-radius: 2px;
+                outline: none;
+                box-shadow: 0 0 0 2px @primaryColor;
+            }
+
             @media @desktopWidth {
                 &:not(:first-child) {
                     margin-left: @separatorSpacing;
@@ -195,6 +202,11 @@
                         cursor: default;
                         content: ' ';
                         pointer-events: none;
+                    }
+
+                    // Prevent focus styles from affecting the separator
+                    &:focus::after {
+                        box-shadow: none;
                     }
                 }
             }

--- a/webroot/src/pages/PublicDashboard/PublicDashboard.less
+++ b/webroot/src/pages/PublicDashboard/PublicDashboard.less
@@ -174,7 +174,6 @@
             display: flex;
             margin-bottom: @separatorSpacing;
 
-            // Override focus styles to use box-shadow instead of outline
             &:focus {
                 border-radius: 2px;
                 outline: none;
@@ -204,7 +203,6 @@
                         pointer-events: none;
                     }
 
-                    // Prevent focus styles from affecting the separator
                     &:focus::after {
                         box-shadow: none;
                     }

--- a/webroot/src/pages/PublicDashboard/PublicDashboard.vue
+++ b/webroot/src/pages/PublicDashboard/PublicDashboard.vue
@@ -85,6 +85,14 @@
             <router-link :to="{ name: 'PrivacyPolicy' }" class="footer-link">
                 {{ $t('privacyPolicy.title') }}
             </router-link>
+            <a
+                href="https://compactconnect.zendesk.com/hc/en-us"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="footer-link"
+            >
+                {{ $t('navigation.helpCenter') }}
+            </a>
         </div>
     </div>
 </template>


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Add Zendesk help center link to public dashboard footer
- Fix superficial tabbed focus look for the footer links

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing:
    - Visit the public dashboard page and confirm that the help center link within the footer links section
    - Keyboard tab to these links and confirm the focus outline no longer increases the size of the bullet separator

Closes #1072 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Help Center link to the Public Dashboard footer, opening in a new tab.
  - Introduced English and Spanish translations for the Help Center label.

- Style
  - Improved keyboard focus styling for footer links with a clear focus ring.
  - Prevented double shadow on decorative dot when footer link is focused on desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->