### PR TITLE
Set testing banner on email notifications

### DIFF
--- a/backend/compact-connect/lambdas/nodejs/lib/email/base-email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/base-email-service.ts
@@ -30,6 +30,7 @@ export abstract class BaseEmailService {
     protected readonly compactConfigurationClient: CompactConfigurationClient;
     protected readonly jurisdictionClient: JurisdictionClient;
     private readonly environmentBannerService = new EnvironmentBannerService();
+    protected readonly shouldShowEnvironmentBannerIfNonProdEnvironment: boolean = true;
     private readonly emailTemplate: TReaderDocument = {
         'root': {
             'type': 'EmailLayout',
@@ -163,7 +164,9 @@ export abstract class BaseEmailService {
         heading: string) {
 
         // Insert environment banner first (above logo)
-        this.environmentBannerService.insertEnvironmentBannerIfNonProd(report);
+        if (this.shouldShowEnvironmentBannerIfNonProdEnvironment) {
+            this.environmentBannerService.insertEnvironmentBannerIfNonProd(report);
+        }
 
         const blockLogoId = 'block-logo';
         const blockHeaderId = 'block-header';
@@ -265,7 +268,9 @@ export abstract class BaseEmailService {
 
     protected insertHeader(report: TReaderDocument, heading: string) {
         // Insert environment banner first (above logo)
-        this.environmentBannerService.insertEnvironmentBannerIfNonProd(report);
+        if (this.shouldShowEnvironmentBannerIfNonProdEnvironment) {
+            this.environmentBannerService.insertEnvironmentBannerIfNonProd(report);
+        }
 
         const blockLogoId = 'block-logo';
         const blockHeaderId = 'block-header';
@@ -578,6 +583,8 @@ export abstract class BaseEmailService {
         report['root']['data']['childrenIds'].push(blockId);
 
         // Insert test email warning footer last (below copyright)
-        this.environmentBannerService.insertTestEmailFooterIfNonProd(report);
+        if (this.shouldShowEnvironmentBannerIfNonProdEnvironment) {
+            this.environmentBannerService.insertTestEmailFooterIfNonProd(report);
+        }
     }
 }

--- a/backend/compact-connect/lambdas/nodejs/lib/email/base-email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/base-email-service.ts
@@ -8,6 +8,7 @@ import { TReaderDocument } from '@usewaypoint/email-builder';
 import { CompactConfigurationClient } from '../compact-configuration-client';
 import { JurisdictionClient } from '../jurisdiction-client';
 import { EnvironmentVariablesService } from '../environment-variables-service';
+import { EnvironmentBannerService } from './environment-banner-service';
 
 const environmentVariableService = new EnvironmentVariablesService();
 
@@ -28,6 +29,7 @@ export abstract class BaseEmailService {
     protected readonly s3Client: S3Client;
     protected readonly compactConfigurationClient: CompactConfigurationClient;
     protected readonly jurisdictionClient: JurisdictionClient;
+    private readonly environmentBannerService = new EnvironmentBannerService();
     private readonly emailTemplate: TReaderDocument = {
         'root': {
             'type': 'EmailLayout',
@@ -160,6 +162,9 @@ export abstract class BaseEmailService {
         jurisdiction: string,
         heading: string) {
 
+        // Insert environment banner first (above logo)
+        this.environmentBannerService.insertEnvironmentBannerIfNonProd(report);
+
         const blockLogoId = 'block-logo';
         const blockHeaderId = 'block-header';
         const blockJurisdictionId = 'block-jurisdiction';
@@ -259,6 +264,9 @@ export abstract class BaseEmailService {
     }
 
     protected insertHeader(report: TReaderDocument, heading: string) {
+        // Insert environment banner first (above logo)
+        this.environmentBannerService.insertEnvironmentBannerIfNonProd(report);
+
         const blockLogoId = 'block-logo';
         const blockHeaderId = 'block-header';
 
@@ -568,5 +576,8 @@ export abstract class BaseEmailService {
         };
 
         report['root']['data']['childrenIds'].push(blockId);
+
+        // Insert test email warning footer last (below copyright)
+        this.environmentBannerService.insertTestEmailFooterIfNonProd(report);
     }
 }

--- a/backend/compact-connect/lambdas/nodejs/lib/email/cognito-email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/cognito-email-service.ts
@@ -8,6 +8,9 @@ const environmentVariableService = new EnvironmentVariablesService();
  * Email service for handling Cognito custom messages
  */
 export class CognitoEmailService extends BaseEmailService {
+    // We don't want to show the environment banner for Cognito emails
+    // so that users know the welcome email is valid and not a test email
+    protected readonly shouldShowEnvironmentBannerIfNonProdEnvironment: boolean = false;
     /**
      * Generates the appropriate email template based on Cognito trigger source
      * @param triggerSource - The Cognito trigger source

--- a/backend/compact-connect/lambdas/nodejs/lib/email/encumbrance-notification-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/encumbrance-notification-service.ts
@@ -158,7 +158,7 @@ export class EncumbranceNotificationService extends BaseEmailService {
             const subject = `License Encumbrance Notification - ${providerFirstName} ${providerLastName}`;
             const bodyText = `This message is to notify you that the *${licenseType}* license held by ${providerFirstName} ${providerLastName} ` +
                 `in ${affectedJurisdictionConfig.jurisdictionName} was encumbered, effective **${effectiveStartDate}**.\n\n` +
-                `This encumbrance restricts the provider's ability to practice under the ${compactConfig.compactName} compact.` +
+                `This encumbrance restricts the provider's ability to practice under the ${compactConfig.compactName} compact.\n\n` +
                 `Provider Details: ${environmentVariableService.getUiBasePathUrl()}/${compact}/Licensing/${providerId}\n\n` +
                 'If the above link does not work, you can copy and paste the url into a browser tab, where you are already logged in.';
 

--- a/backend/compact-connect/lambdas/nodejs/lib/email/environment-banner-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/environment-banner-service.ts
@@ -43,6 +43,7 @@ export class EnvironmentBannerService {
     private shouldShowBanner(): boolean {
         try {
             const envName = this.environmentVariablesService.getEnvironmentName().toLowerCase().trim();
+
             return envName !== 'prod';
         } catch (error) {
             // If environment detection fails, default to not showing banner
@@ -122,7 +123,7 @@ export class EnvironmentBannerService {
                     }
                 },
                 'props': {
-                    'text': "You're viewing a test email.",
+                    'text': 'You\'re viewing a test email.',
                     'markdown': false
                 }
             }

--- a/backend/compact-connect/lambdas/nodejs/lib/email/environment-banner-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/environment-banner-service.ts
@@ -1,0 +1,134 @@
+import * as crypto from 'crypto';
+import { TReaderDocument } from '@usewaypoint/email-builder';
+import { EnvironmentVariablesService } from '../environment-variables-service';
+
+/**
+ * Service for adding environment-specific banners and footers to email templates
+ */
+export class EnvironmentBannerService {
+    private readonly environmentVariablesService = new EnvironmentVariablesService();
+
+    /**
+     * Inserts environment banner if current environment is non-production
+     */
+    public insertEnvironmentBannerIfNonProd(template: TReaderDocument): void {
+        try {
+            if (this.shouldShowBanner()) {
+                this.insertBanner(template, this.getBannerText());
+            }
+        } catch (error) {
+            // Log error but don't throw - email should still send without banner
+            console.error('Error inserting environment banner:', error);
+        }
+    }
+
+    /**
+     * Inserts red "test email" footer if current environment is non-production
+     */
+    public insertTestEmailFooterIfNonProd(template: TReaderDocument): void {
+        try {
+            if (this.shouldShowBanner()) {
+                this.insertTestWarningFooter(template);
+            }
+        } catch (error) {
+            // Log error but don't throw - email should still send without footer
+            console.error('Error inserting test email footer:', error);
+        }
+    }
+
+    /**
+     * Determines if banner/footer should be shown based on environment
+     * Returns true for all environments except production
+     */
+    private shouldShowBanner(): boolean {
+        try {
+            const envName = this.environmentVariablesService.getEnvironmentName().toLowerCase().trim();
+            return envName !== 'prod';
+        } catch (error) {
+            // If environment detection fails, default to not showing banner
+            // (better to not show than to show the banner in a prod environment)
+            console.error('Error detecting environment, defaulting to not showing banner:', error);
+            return false;
+        }
+    }
+
+    /**
+     * Gets environment-specific banner text
+     */
+    private getBannerText(): string {
+        try {
+            const envName = this.environmentVariablesService.getEnvironmentName().toLowerCase().trim();
+
+            return `⚠️ TEST: The info in this email is from a ${envName} environment and is for testing purposes only.`;
+        } catch (error) {
+            console.error('Error getting banner text, using default:', error);
+            return '⚠️ TEST: The info in this email is from a non-production environment and is for testing purposes only.';
+        }
+    }
+
+    /**
+     * Inserts the environment banner at the top of the email template
+     */
+    private insertBanner(template: TReaderDocument, bannerText: string): void {
+        const blockId = `block-environment-banner-${crypto.randomUUID()}`;
+
+        template[blockId] = {
+            'type': 'Text',
+            'data': {
+                'style': {
+                    'backgroundColor': '#FFA726',
+                    'color': '#000000',
+                    'fontSize': 14,
+                    'fontWeight': 'bold',
+                    'textAlign': 'center',
+                    'padding': {
+                        'top': 16,
+                        'bottom': 16,
+                        'right': 24,
+                        'left': 24
+                    }
+                },
+                'props': {
+                    'text': `${bannerText}`,
+                    'markdown': false
+                }
+            }
+        };
+
+        // Insert banner at the beginning of the email (before existing content)
+        template['root']['data']['childrenIds'].unshift(blockId);
+    }
+
+    /**
+     * Inserts the test email warning footer at the bottom of the email template
+     */
+    private insertTestWarningFooter(template: TReaderDocument): void {
+        const blockId = `block-test-warning-footer-${crypto.randomUUID()}`;
+
+        template[blockId] = {
+            'type': 'Text',
+            'data': {
+                'style': {
+                    'backgroundColor': null,
+                    'color': '#DA2525',
+                    'fontSize': 13,
+                    'fontWeight': 'normal',
+                    'textAlign': 'center',
+                    'padding': {
+                        'top': 16,
+                        'bottom': 24,
+                        'right': 24,
+                        'left': 24
+                    }
+                },
+                'props': {
+                    'text': "You're viewing a test email.",
+                    'markdown': false
+                }
+            }
+        };
+
+        // Insert footer at the end of the email (after existing content)
+        template['root']['data']['childrenIds'].push(blockId);
+    }
+}

--- a/backend/compact-connect/lambdas/nodejs/lib/email/environment-banner-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/environment-banner-service.ts
@@ -57,14 +57,7 @@ export class EnvironmentBannerService {
      * Gets environment-specific banner text
      */
     private getBannerText(): string {
-        try {
-            const envName = this.environmentVariablesService.getEnvironmentName().toLowerCase().trim();
-
-            return `⚠️ TEST: The info in this email is from a ${envName} environment and is for testing purposes only.`;
-        } catch (error) {
-            console.error('Error getting banner text, using default:', error);
-            return '⚠️ TEST: The info in this email is from a non-production environment and is for testing purposes only.';
-        }
+        return `⚠️ TEST: The info in this email is from a testing environment and is for testing purposes only.`;
     }
 
     /**
@@ -110,7 +103,6 @@ export class EnvironmentBannerService {
             'type': 'Text',
             'data': {
                 'style': {
-                    'backgroundColor': null,
                     'color': '#DA2525',
                     'fontSize': 13,
                     'fontWeight': 'normal',

--- a/backend/compact-connect/lambdas/nodejs/lib/email/environment-banner-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/environment-banner-service.ts
@@ -44,7 +44,8 @@ export class EnvironmentBannerService {
         try {
             const envName = this.environmentVariablesService.getEnvironmentName().toLowerCase().trim();
 
-            return envName !== 'prod';
+            // only show banner for non-production environments and if the environment is defined
+            return envName !== 'prod' && envName !== '';
         } catch (error) {
             // If environment detection fails, default to not showing banner
             // (better to not show than to show the banner in a prod environment)

--- a/backend/compact-connect/lambdas/nodejs/lib/email/index.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/index.ts
@@ -2,3 +2,4 @@ export { CognitoEmailService } from './cognito-email-service';
 export { EmailNotificationService } from './email-notification-service';
 export { EncumbranceNotificationService } from './encumbrance-notification-service';
 export { IngestEventEmailService } from './ingest-event-email-service';
+export { EnvironmentBannerService } from './environment-banner-service';

--- a/backend/compact-connect/lambdas/nodejs/lib/environment-variables-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/environment-variables-service.ts
@@ -7,6 +7,7 @@ export class EnvironmentVariablesService {
     private readonly debugVariable = 'DEBUG';
     private readonly transactionReportsBucketNameVariable = 'TRANSACTION_REPORTS_BUCKET_NAME';
     private readonly userPoolTypeVariable = 'USER_POOL_TYPE';
+    private readonly environmentNameVariable = 'ENVIRONMENT_NAME';
 
     public getEnvVar(name: string): string {
         return process.env[name]?.trim() || '';
@@ -42,5 +43,9 @@ export class EnvironmentVariablesService {
 
     public getUserPoolType() {
         return this.getEnvVar(this.userPoolTypeVariable);
+    }
+
+    public getEnvironmentName() {
+        return this.getEnvVar(this.environmentNameVariable);
     }
 }

--- a/backend/compact-connect/lambdas/nodejs/tests/lib/email/base-email-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lib/email/base-email-service.test.ts
@@ -1,0 +1,115 @@
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-jest';
+import { Logger } from '@aws-lambda-powertools/logger';
+import { SESClient } from '@aws-sdk/client-ses';
+import { S3Client } from '@aws-sdk/client-s3';
+import { BaseEmailService } from '../../../lib/email/base-email-service';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+const asSESClient = (mock: ReturnType<typeof mockClient>) =>
+    mock as unknown as SESClient;
+
+const asS3Client = (mock: ReturnType<typeof mockClient>) =>
+    mock as unknown as S3Client;
+
+// Create a concrete test implementation of BaseEmailService
+class TestEmailService extends BaseEmailService {
+    public generateTestEmail(): string {
+        const template = this.getNewEmailTemplate();
+
+        this.insertHeader(template, 'Test Email');
+        this.insertFooter(template);
+        
+        // Return the template for inspection
+        return JSON.stringify(template);
+    }
+}
+
+describe('BaseEmailService Environment Banner', () => {
+    let emailService: TestEmailService;
+    let mockSESClient: ReturnType<typeof mockClient>;
+    let mockS3Client: ReturnType<typeof mockClient>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockSESClient = mockClient(SESClient);
+        mockS3Client = mockClient(S3Client);
+
+        // Reset environment variables
+        delete process.env.ENVIRONMENT_NAME;
+        process.env.FROM_ADDRESS = 'noreply@example.org';
+        process.env.UI_BASE_PATH_URL = 'https://app.test.compactconnect.org';
+
+        emailService = new TestEmailService({
+            logger: new Logger({ serviceName: 'test' }),
+            sesClient: asSESClient(mockSESClient),
+            s3Client: asS3Client(mockS3Client),
+            compactConfigurationClient: {} as any,
+            jurisdictionClient: {} as any
+        });
+    });
+
+    // Helper methods to reduce test duplication
+    const expectBannerPresent = (template: any) => {
+        const childrenIds = template.root.data.childrenIds;
+
+        expect(childrenIds.length).toBeGreaterThan(0);
+
+        // Find banner block (should be first element)
+        const bannerBlockId = childrenIds[0];
+        const bannerBlock = template[bannerBlockId];
+        
+        expect(bannerBlock).toBeDefined();
+        expect(bannerBlock.type).toBe('Text');
+        expect(bannerBlock.data.style.backgroundColor).toBe('#FFA726');
+        expect(bannerBlock.data.style.color).toBe('#000000');
+        expect(bannerBlock.data.props.text).toContain('⚠️ TEST: The info in this email is from a testing environment');
+    };
+
+    const expectFooterPresent = (template: any) => {
+        const childrenIds = template.root.data.childrenIds;
+        
+        // Find footer warning block (should be last element)
+        const footerWarningBlockId = childrenIds[childrenIds.length - 1];
+        const footerWarningBlock = template[footerWarningBlockId];
+        
+        expect(footerWarningBlock).toBeDefined();
+        expect(footerWarningBlock.type).toBe('Text');
+        expect(footerWarningBlock.data.props.text).toBe('You\'re viewing a test email.');
+    };
+
+    const expectNoBannerOrFooter = (templateJson: string) => {
+        // Simply check that the banner text doesn't appear anywhere in the email content
+        expect(templateJson).not.toContain('⚠️ TEST: The info in this email is from a testing environment');
+        expect(templateJson).not.toContain('You\'re viewing a test email.');
+    };
+
+    const testEnvironment = (environmentName: string | undefined, shouldShowBanner: boolean, description: string) => {
+        it(description, () => {
+            // Set environment
+            if (environmentName === undefined) {
+                delete process.env.ENVIRONMENT_NAME;
+            } else {
+                process.env.ENVIRONMENT_NAME = environmentName;
+            }
+
+            const templateJson = emailService.generateTestEmail();
+            const template = JSON.parse(templateJson);
+
+            if (shouldShowBanner) {
+                expectBannerPresent(template);
+                expectFooterPresent(template);
+            } else {
+                expectNoBannerOrFooter(templateJson);
+            }
+        });
+    };
+
+    describe('Environment Banner Behavior', () => {
+        // Test cases: [environmentName, shouldShowBanner, description]
+        testEnvironment('beta', true, 'should include environment banner and footer in beta environment');
+        testEnvironment('test', true, 'should include environment banner and footer in test environment');
+        testEnvironment('prod', false, 'should NOT include environment banner and footer in production environment');
+        testEnvironment(undefined, false, 'should NOT include environment banner and footer when environment name is undefined');
+    });
+});


### PR DESCRIPTION
Several users were getting confused by receiving test emails from our non-production environments, assuming they were actual production messages. This adds a banner at the top of our email messages from non-production environments notifying them that the message is just a test notification.

Note that we don't set these banners on emails from Cognito, since we do not want to confuse users into thinking their beta invite emails are just test notifications.


Closes #1021 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-production emails show a prominent “test environment” banner at the top and a test-only footer; account-related (Cognito) emails remain excluded.
* **Style**
  * Improved spacing in license encumbrance notification emails (extra blank line before “Provider Details”) for readability.
* **Tests**
  * Added tests validating banner/footer presence in non-prod and absence in prod/undefined environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->