### PR TITLE
Feat/license script options

### DIFF
--- a/backend/compact-connect/bin/generate_mock_license_csv_upload_file.py
+++ b/backend/compact-connect/bin/generate_mock_license_csv_upload_file.py
@@ -187,7 +187,7 @@ def _set_dates_and_statuses(license_data: dict, all_active: bool = False) -> dic
     date_of_issuance = min(date_of_birth + timedelta(days=randint(22 * 365, 40 * 365)), now - timedelta(days=1))
     # For simplicity, we'll assume that under-70-year-olds are active, over are inactive.
     # Unless all_active is True, then all licenses are active and eligible
-    if all_active or date_of_birth + 70 * timedelta(days=365) > now:
+    if all_active:
         is_active = True
         # We'll have renewal be within the last year, but on or after issuance.
         date_of_renewal = max(now - timedelta(days=randint(1, 365)), date_of_issuance)
@@ -278,12 +278,15 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--all-active',
-        help='all all licenses to be active and eligible',
+        help='Allow all licenses to be active and eligible',
         action='store_true',
         required=False,
     )
 
     args = parser.parse_args()
+    if len(args.ssn_prefix) != 3 or not args.ssn_prefix.isdigit():
+        parser.error('--ssn-prefix must be exactly 3 digits (000-999).')
+
     _initialize_name_faker(args.us_names_only)
 
     generate_mock_data_file(

--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_reporting.py
@@ -16,8 +16,8 @@ from cc_common.exceptions import CCInternalException
 
 
 class ReportableTransactionStatuses(StrEnum):
-    """Transaction statuses that should be included in financial reports.
-    """
+    """Transaction statuses that should be included in financial reports."""
+
     SettledSuccessfully = 'settledSuccessfully'
 
 


### PR DESCRIPTION
As we have been create mock licenses for our environments, common needs have come up for values we need for these test licenses, such as only creating licenses with english names, and only creating active licenses. This adds some optional parameters to make the script more flexible.

Closes #1073 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI options to control mock data: include international names, custom SSN prefix, and allow inactive licenses.
  * SSNs now use the provided prefix and generated data can include or exclude inactive licenses; inactive mode yields mixed statuses based on age/randomness.
  * JSON output omits empty/null fields for cleaner records.

* **Documentation**
  * Minor docstring wording update for transaction status (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->