### PR TITLE
Frontend/public profile link fix

### DIFF
--- a/webroot/src/pages/LicenseeProof/LicenseeProof.less
+++ b/webroot/src/pages/LicenseeProof/LicenseeProof.less
@@ -234,14 +234,13 @@
                 font-size: @fontSizeMedium;
                 text-align: center;
 
-                /* stylelint-disable order/properties-order */
                 a {
                     font-weight: @fontWeightBold;
                     white-space: pre-wrap;
                     text-decoration: underline;
-                    overflow-wrap: anywhere;
                     word-break: break-word;
-                    /* stylelint-enable order/properties-order */
+                    overflow-wrap: break-word;
+                    overflow-wrap: anywhere;
                 }
             }
         }


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Fix cutoff issue for the public profile link on privilege verification page on mobile devices

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - Log in as a practitioner and view the public profile link on the privilege verification page (below the QR image)
    - If on localhost, update the link text domain to https://app.compactconnect.org instead of localhost:port
    - In a mobile view, confirm that the link breaks and is entirely visible


Closes #1049 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Long links in the QR-code label now wrap and preserve whitespace to prevent overflow and clipping, improving readability across screen sizes.

- **Style**
  - QR-code section horizontal padding removed while keeping vertical spacing for a more centered layout.
  - Link text handling improved for consistent presentation in narrow or constrained layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->