### PR TITLE
Block compact and jurisdiction fields in license uploads (#1101)

### DIFF
--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/bulk_upload.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/bulk_upload.py
@@ -128,7 +128,8 @@ def process_bulk_upload_file(
     schema = LicensePostRequestSchema()
     reader = LicenseCSVReader()
 
-    stream = TextIOWrapper(body, encoding='utf-8')
+    # We need to use utf-8-sig to handle potential BOM characters at the beginning of the file
+    stream = TextIOWrapper(body, encoding='utf-8-sig')
 
     # Define batch size for processing to limit memory footprint
     batch_size = 100

--- a/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
+++ b/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
@@ -78,6 +78,15 @@ class UserEmailNotifications(Construct):
         # grant cognito the ability to send email from this identity
         self.email_identity.grant_send_email(ServicePrincipal('cognito-idp.amazonaws.com'))
 
+        # Add SPF record for root domain
+        self.spf_record = TxtRecord(
+            self,
+            'SPFRecord',
+            zone=hosted_zone,
+            record_name=f'{domain_name}',
+            values=['v=spf1 include:amazonses.com ~all'],
+        )
+
         # Add DMARC record to Route 53 with policy set to 'reject'
         # this will cause email servers to reject emails that do not pass SPF and DKIM checks
         # see https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dmarc.html


### PR DESCRIPTION
### Requirements List
- Prevents CSV-uploads from including `compact` and `jurisdiction` fields.
