### PR TITLE
Fix/Reference provider id from privilege record instead of Authorize.net

### DIFF
--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_history.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_history.py
@@ -97,7 +97,7 @@ def process_settled_transactions(event: dict, context: LambdaContext) -> dict:  
         logger.info('Fetching privilege ids for transactions', compact=compact)
         # first we must add the associated privilege ids to each transaction so we can show the association in our
         # reports
-        transactions_with_privilege_ids = config.transaction_client.add_privilege_ids_to_transactions(
+        transactions_with_privilege_ids = config.transaction_client.add_privilege_information_to_transactions(
             compact=compact, transactions=transaction_response['transactions']
         )
         logger.info('Storing transactions in DynamoDB', compact=compact)


### PR DESCRIPTION
It turns out that authorize.net will mask strings in their transaction descriptions if the pattern matches a credit card, and we have a provider id with 16 consecutive digits. Authorize.net masked their id, which caused the transaction reporter to fail since it was unable to look up the provider id. We can no longer trust the licensee ids stored in the transaction descriptions in authorize.net.

To fix this, we are able to pull up the provider id from the CompactConnect system directly by matching the privilege record to the transaction id, and stop referencing the licensee id stored in authorize.net altogether.

This is a hotfix that needs to be rolled out to production as soon as possible.

Closes #1150
