### PR TITLE
Toggle srp auth for zap

### DIFF
--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -196,7 +196,7 @@ class UserPool(CdkUserPool):
                 # (and automated testing in test environments)
                 admin_user_password=True,
                 custom=False,
-                user_srp=False,
+                user_srp=False if self.security_profile == SecurityProfile.RECOMMENDED else True,
                 user_password=False,
             ),
             o_auth=OAuthSettings(


### PR DESCRIPTION
Toggle SRP auth back on for the SecurityProfile.VULNERABLE, to enable our ZAP scan automation in test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the UI sign-in flow to align with the selected security profile. The Recommended profile keeps the simpler password-based sign-in, while stricter profiles now enable an enhanced, challenge-based authentication method. This ensures the login experience and security level are consistent with your chosen profile without impacting other app behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->