### PR TITLE
Fix/Reference provider id from privilege record instead of Authorize.net

### DIFF
--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_history.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_history.py
@@ -97,7 +97,7 @@ def process_settled_transactions(event: dict, context: LambdaContext) -> dict:  
         logger.info('Fetching privilege ids for transactions', compact=compact)
         # first we must add the associated privilege ids to each transaction so we can show the association in our
         # reports
-        transactions_with_privilege_ids = config.transaction_client.add_privilege_ids_to_transactions(
+        transactions_with_privilege_ids = config.transaction_client.add_privilege_information_to_transactions(
             compact=compact, transactions=transaction_response['transactions']
         )
         logger.info('Storing transactions in DynamoDB', compact=compact)


### PR DESCRIPTION
This hot fix was previously merged into main to quickly deploy to production. This merges that same hotfix into our dev branch to keep them in sync

Closes #1150


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction history now enriches line items with privilege details and includes corresponding licensee information for clearer, more informative records.

* **Bug Fixes**
  * Improved accuracy when matching privileges to transaction line items.
  * Prevents privilege details from appearing on non-applicable items (e.g., fees).
  * Validates provider consistency and applies safe fallbacks when data is missing, enhancing reliability and reducing incorrect or incomplete entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->