### PR TITLE
Fix/Reference provider id from privilege record instead of Authorize.net 

### DIFF
--- a/backend/compact-connect/lambdas/python/purchases/handlers/transaction_history.py
+++ b/backend/compact-connect/lambdas/python/purchases/handlers/transaction_history.py
@@ -97,7 +97,7 @@ def process_settled_transactions(event: dict, context: LambdaContext) -> dict:  
         logger.info('Fetching privilege ids for transactions', compact=compact)
         # first we must add the associated privilege ids to each transaction so we can show the association in our
         # reports
-        transactions_with_privilege_ids = config.transaction_client.add_privilege_ids_to_transactions(
+        transactions_with_privilege_ids = config.transaction_client.add_privilege_information_to_transactions(
             compact=compact, transactions=transaction_response['transactions']
         )
         logger.info('Storing transactions in DynamoDB', compact=compact)


### PR DESCRIPTION
This hot fix was previously merged into main to quickly deploy to production. This merges that same hotfix into our dev branch to keep them in sync

Closes https://github.com/csg-org/CompactConnect/issues/1150


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction history now includes mapped privilege information per line item.
  * Licensee information is automatically derived from the associated provider for each transaction.
* **Bug Fixes**
  * Improved resilience when provider or privilege records are missing or inconsistent; affected line items are clearly marked as UNKNOWN instead of failing.
  * Enhanced accuracy in matching privileges by jurisdiction, improving data integrity in transaction details.
* **Tests**
  * Updated unit tests to validate new privilege and licensee mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->