### PR TITLE
Update docs to reflect licenseNumber field as required

### DIFF
--- a/backend/compact-connect/docs/README.md
+++ b/backend/compact-connect/docs/README.md
@@ -51,7 +51,7 @@ leave the field entirely empty. If some of your licenses are missing a required 
 | homeAddressPostalCode* | Postal/ZIP code of provider's home address | String (5-7 chars) | 12345 |
 | homeAddressState* | State/province of provider's home address | String (max 100 chars) | IL |
 | homeAddressStreet1* | First line of provider's street address | String (max 100 chars) | 123 Main St |
-| licenseNumber**         | ** This field is required by compact commission rule, however, to avoid making a breaking change for states that are already integrated, the API does not enforce this rule. States are responsible for enforcing the compact rule themselves. | String (max 100 chars) | OT12345 |
+| licenseNumber**         | License number | String (max 100 chars) | OT12345 |
 | licenseType* | Type of professional license. Types you provide must be associated with the compact you are uploading for. | One of: `audiologist`, `speech-language pathologist`, `occupational therapist`, `occupational therapy assistant`, `licensed professional counselor` | occupational therapist |
 | ssn* | Social Security Number | Format: XXX-XX-XXXX | 123-45-6789 |
 | licenseStatus* | Current status of the license. "active" means they are allowed to practice their profession. *Note: licenses will automatically be displayed as `inactive` after their date of expiration, even if the last upload still showed them as `active`.* | One of: `active`, `inactive` | active |
@@ -63,7 +63,7 @@ leave the field entirely empty. If some of your licenses are missing a required 
 | npi | National Provider Identifier (optional) | 10-digit number | 1234567890 |
 | phoneNumber | Provider's phone number (optional) | [ITU-T E.164 format](https://www.itu.int/rec/T-REC-E.164-201011-I/en) (must include country code, no spaces or dashes) | +12025550123 |
 | suffix | Provider's name suffix (optional) | String (max 100 chars) | Jr. |
-
+** This field is required by compact commission rule, however, to avoid making a breaking change for states that are already integrated, the API does not enforce this rule. States are responsible for enforcing the compact rule themselves.
 #### Example CSV
 ```csv
 dateOfIssuance,npi,licenseNumber,dateOfBirth,licenseType,familyName,homeAddressCity,middleName,licenseStatus,licenseStatusName,compactEligibility,ssn,homeAddressStreet1,homeAddressStreet2,dateOfExpiration,homeAddressState,homeAddressPostalCode,givenName,dateOfRenewal


### PR DESCRIPTION
Previously, we were asked to allow the `licenseNumber` field to be optional. The system was launched with that field set as optional. We have been asked to document that this field is required by compact rule, and the license number field should be included in every license upload. Although we cannot change the API spec to force this field to be required as this would be a breaking change to the states that are already live, we have been asked to update the documentation to reflect this compact rule requirement so that new onboarding states will be aware the compacts expect license numbers to always be present with every license uploaded into the system.

Closes #1182 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an OTCC‑mandated "licenseNumber" field to the public data documentation (marked as required by OTCC but not enforced by the API).
  * Updated CSV examples to include the new licenseNumber column with sample value "OT12345" positioned between homeAddressStreet2 and middleName.
  * Clarified guidance on handling missing required fields to reflect the API non‑enforcement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->