### PR TITLE
Update weekly report to run Sunday EST

### DIFF
--- a/backend/compact-connect/stacks/reporting_stack.py
+++ b/backend/compact-connect/stacks/reporting_stack.py
@@ -195,8 +195,11 @@ class ReportingStack(AppStack):
             Rule(
                 self,
                 f'{compact.capitalize()}-WeeklyTransactionReportRule',
-                # Send weekly reports every Sunday at 2:00 AM UTC
-                schedule=Schedule.cron(week_day='SUN', hour='2', minute='0', month='*', year='*'),
+                # Send weekly reports every Monday at 4:00 AM UTC (Sunday 11 PM EST)
+                # this gives the transaction collection process several days
+                # to ensure we've collected all transactions from authorize.net
+                # for the previous week, even if authorize.net settles batches late.
+                schedule=Schedule.cron(week_day='MON', hour='4', minute='0', month='*', year='*'),
                 targets=[
                     LambdaFunction(
                         handler=self.transaction_reporter,


### PR DESCRIPTION
Given the severe delays authorize.net has in its transaction reporting API, we need to move the weekly reporting from Saturday to Sunday. This will give the collection process several days to collect all transactions from authorize.net even if it fails to report on its settled transactions for a day.



Closes #1220 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Weekly transaction reports now generate on Mondays at 4:00 UTC instead of Sundays at 2:00 UTC.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->