### PR TITLE
Fix/update lambda logger dependency to be compatible with Node.js 24

### DIFF
--- a/backend/compact-connect/lambdas/nodejs/package.json
+++ b/backend/compact-connect/lambdas/nodejs/package.json
@@ -40,7 +40,7 @@
     "typescript": "5.6.3"
   },
   "dependencies": {
-    "@aws-lambda-powertools/logger": "^2.10.0",
+    "@aws-lambda-powertools/logger": "^2.30.0",
     "@aws-sdk/client-dynamodb": "^3.901.0",
     "@aws-sdk/client-s3": "^3.901.0",
     "@aws-sdk/client-sesv2": "^3.901.0",

--- a/backend/compact-connect/lambdas/nodejs/yarn.lock
+++ b/backend/compact-connect/lambdas/nodejs/yarn.lock
@@ -78,17 +78,20 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-lambda-powertools/commons@^2.11.0":
-  version "2.11.0"
-  resolved "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.11.0.tgz"
-  integrity sha512-gtiBeUSyg4VcL4qra5G4AwuOl7CNF6g0oDasAS5KxkEi8IhTku6S7vJTpQ82+12oviwKBD+w27yEcGQmSw5xdg==
-
-"@aws-lambda-powertools/logger@^2.10.0":
-  version "2.11.0"
-  resolved "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.11.0.tgz"
-  integrity sha512-40wST/S644ngwadp7Kk70Rgvh35yQ0R3HqFKxAtlBxQNAGsqxQtjJeBUg/KQDKUhE1IZH0ahXyEN3B7rSxPn0Q==
+"@aws-lambda-powertools/commons@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@aws-lambda-powertools/commons/-/commons-2.30.0.tgz#920d00d560511e76ee7da767f9eeec396a2a527a"
+  integrity sha512-5kjamCPR/dIEHIk4BAFDSO/MgF21qL/q/f5AKi3GEOdvULuLcbw40xneMmPXo4ETaBSe+BHvovWLuI0Jl9BEnw==
   dependencies:
-    "@aws-lambda-powertools/commons" "^2.11.0"
+    "@aws/lambda-invoke-store" "0.2.2"
+
+"@aws-lambda-powertools/logger@^2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@aws-lambda-powertools/logger/-/logger-2.30.0.tgz#9a8c74575cc19ed2c66e9f7c9f58c39b86c025ac"
+  integrity sha512-ejmuzn8KNi7CrhJSnl4a/SLAjcmlHJPvH55QpSZvj8K8aQLhOKcCpd0u+gXp0oYlj50d22h9ZV5qtIn7O8V4Lw==
+  dependencies:
+    "@aws-lambda-powertools/commons" "2.30.0"
+    "@aws/lambda-invoke-store" "0.2.2"
     lodash.merge "^4.6.2"
 
 "@aws-sdk/client-dynamodb@^3.901.0":
@@ -715,6 +718,11 @@
     "@smithy/types" "^4.6.0"
     fast-xml-parser "5.2.5"
     tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz#b00f7d6aedfe832ef6c84488f3a422cce6a47efa"
+  integrity sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==
 
 "@aws/lambda-invoke-store@^0.0.1":
   version "0.0.1"


### PR DESCRIPTION
While smoke testing a new feature, it was discovered that the lambda responsible for sending out Cognito emails was no longer functioning as a result of the recent update to the Node.js 24 runtime with the following error message:
```
[UserLambdaValidationException] Errors were encountered during user creation. Please review the errors and retry.

message: CustomMessage failed with error ERROR: AWS Lambda has removed support for callback-based function handlers starting with Node.js 24. You need to modify this function to use a supported handler signature to use Node.js 24 or later. For more information see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html..
```

Although we confirmed that the lambda handler definition was using the proper async/await syntax, further investigation showed that the lambda is wrapped with a powertools logger decorator which was altering the way the function was called which was incompatible with the Node.js runtime upgrade. The solution was to upgrade the lambda powertools logger dependency to the latest version.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal logging dependency to a newer version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->