### PR TITLE
Set compatible format for duplicate SSN error message

### DIFF
--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
@@ -342,11 +342,9 @@ class TestProcessObjects(TstFunction):
                             'dateOfRenewal': '2025-01-01',
                             'dateOfExpiration': '2026-01-01',
                         },
-                        'errors': [
-                            'Duplicate License SSN detected for license type audiologist. SSN matches with record 1. '
-                            'Every record must have a unique SSN per license type within the same file.'
-                        ],
-                    }
+                        "errors": {"_schema": ["Duplicate License SSN detected for license type audiologist. "
+                                               "SSN matches with record 1. Every record must have a unique SSN per"
+                                               " license type within the same file."]}}
                 ),
                 'EventBusName': 'license-data-events',
             }


### PR DESCRIPTION
We previously added a logic check to ensure that duplicate SSNs are not specified within the same license upload request. The format of the error message is a string, but the downstream event collector expects all errors to be in a dictionary or list. This updates the duplicate SSN error message format so that it is in a compatible form.

### Requirements List
- backwards compatible

### Description List
- Update format of duplicate SSN error message

### Testing List
- Updating functional tests
- Uploaded invalid csv with duplicate SSNs in sandbox environment and verified email is now sent successfully

Closes #1237 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message formatting for duplicate entry detection to improve downstream error reporting in bulk upload operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->