### PR TITLE
Configure dependabot integration to automate dependency update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,9 +40,7 @@ updates:
   #---------------------------------------------------------------------------
   - package-ecosystem: "npm"
     directories:
-      - "/backend/compact-connect/lambdas/nodejs"
-      - "/backend/compact-connect-ui-app/lambdas/nodejs"
-      - "/backend/cosmetology-app/lambdas/nodejs"
+      - "/backend/*/lambdas/nodejs"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -50,6 +48,8 @@ updates:
     labels:
       - "dependencies"
       - "node"
+    # Require packages to be at least 7 days old before proposing updates.
+    # This does NOT apply to security updates, which are always immediate.
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
As the number of compacts we support in this repo grows, we need an automated process to detect dependency updates and generate PRs for them if we are to keep these systems up to date. This adds a dependabot config file which will generate PRs for all backend python dependency updates, backend Node updates, frontend dependency updates, and GitHub actions updates.

Closes #1318 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configuration to enable weekly automated dependency update PRs for Python, backend Node.js, frontend Node.js, and GitHub Actions.
  * Limits open update PRs, applies a short cooldown between non-security updates, and groups updates to minor and patch releases with ecosystem-specific labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->