### PR TITLE
Remove space from email display name

### DIFF
--- a/backend/compact-connect/README.md
+++ b/backend/compact-connect/README.md
@@ -1,4 +1,4 @@
-# Compact Connect - Backend developer documentation
+# CompactConnect - Backend developer documentation
 
 ## Looking for technical user documentation?
 [Find it here](./docs/README.md)

--- a/backend/compact-connect/app_clients/README.md
+++ b/backend/compact-connect/app_clients/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This document is a guide for technical staff for managing Cognito app clients for machine-to-machine authentication in
-the State API. All app clients must be documented in the external 'Compact Connect App Client Registry' Google Sheet
+the State API. All app clients must be documented in the external 'CompactConnect App Client Registry' Google Sheet
 (If you do not have access to said registry, contact a maintainer of the project and request access).
 
 ## Creating a New App Client

--- a/backend/compact-connect/app_clients/bin/create_app_client.py
+++ b/backend/compact-connect/app_clients/bin/create_app_client.py
@@ -407,7 +407,7 @@ def print_email_template(environment, compact, state):
     license_upload_url = f'{api_base_urls.get(environment)}/v1/compacts/{compact}/jurisdictions/{state}/licenses'
 
     email_template = f"""
-Thank you for integrating with Compact Connect! You have been designated as the IT professional who is able to handle
+Thank you for integrating with CompactConnect! You have been designated as the IT professional who is able to handle
 credentials for secure machine-to-machine authentication between your state and CompactConnect.
 
 Details for these credentials are:

--- a/backend/compact-connect/docs/README.md
+++ b/backend/compact-connect/docs/README.md
@@ -1,4 +1,4 @@
-# Compact Connect - technical user guide
+# CompactConnect - technical user guide
 
 This documentation is intended for technical IT staff that plan to integrate with this data system. It will likely grow
 as the features of this system grow. For technical documentation of the internal design of the CompactConnect backend,

--- a/backend/compact-connect/docs/attestations/README.md
+++ b/backend/compact-connect/docs/attestations/README.md
@@ -1,6 +1,6 @@
-# Compact Connect Attestation Versioning Design
+# CompactConnect Attestation Versioning Design
 
-The Compact Connect system defines a set of attestations that providers must accept when purchasing privileges. Attestations are legally binding statements that providers must agree to, and they are versioned to ensure providers always see and accept the most current version.
+The CompactConnect system defines a set of attestations that providers must accept when purchasing privileges. Attestations are legally binding statements that providers must agree to, and they are versioned to ensure providers always see and accept the most current version.
 
 ## Required Attestations
 

--- a/backend/compact-connect/docs/devops/README.md
+++ b/backend/compact-connect/docs/devops/README.md
@@ -1,4 +1,4 @@
 # DevOps Documentation
 
-This directory contains internal operations and support procedures for the Compact Connect development and support teams.
+This directory contains internal operations and support procedures for the CompactConnect development and support teams.
 This documentation is **NOT** intended for external IT staff.

--- a/backend/compact-connect/docs/devops/STAFF_USER_MFA_RECOVERY.md
+++ b/backend/compact-connect/docs/devops/STAFF_USER_MFA_RECOVERY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-When a staff user loses access to their Multi-Factor Authentication (MFA) device, they cannot log into the Compact Connect system. 
+When a staff user loses access to their Multi-Factor Authentication (MFA) device, they cannot log into the CompactConnect system. 
 
 A staff user account consists of two parts: a Cognito user to track login information, and a DynamoDB record in the staff
 users DynamoDB table to track permissions and other account data about the user.

--- a/backend/compact-connect/docs/onboarding/JURISDICTION_COMPACT_ONBOARDING.md
+++ b/backend/compact-connect/docs/onboarding/JURISDICTION_COMPACT_ONBOARDING.md
@@ -1,35 +1,35 @@
-# Jurisdiction and Compact Onboarding for Compact Connect
+# Jurisdiction and Compact Onboarding for CompactConnect
 
-Before a jurisdiction (i.e. state) can be onboarded to the Compact Connect system, there is certain information that
+Before a jurisdiction (i.e. state) can be onboarded to the CompactConnect system, there is certain information that
 must be provided for that jurisdiction. This document is intended to be referenced by State IT staff/CSG maintainers
 that will need to assist with onboarding new jurisdictions or compacts into the system. It outlines the information
 that is required and how that information is to be defined in the system. The following steps must be taken to onboard
-a jurisdiction to the Compact Connect system:
+a jurisdiction to the CompactConnect system:
 
 ## Inviting users to the system
-Compact Administrators can invite state administrators to Compact Connect by creating user accounts for them through the administrative interface. The process works as follows:
+Compact Administrators can invite state administrators to CompactConnect by creating user accounts for them through the administrative interface. The process works as follows:
 
-1. The Compact Administrator logs into the Compact Connect system and navigates to the User Management section.
+1. The Compact Administrator logs into the CompactConnect system and navigates to the User Management section.
 2. They create a new user account for the state administrator, specifying their email address, name, and appropriate jurisdiction-level permissions.
 3. Upon creation, the system automatically sends an email to the state administrator containing temporary credentials (username and temporary password).
-4. The state administrator uses these temporary credentials to log in to Compact Connect for the first time.
+4. The state administrator uses these temporary credentials to log in to CompactConnect for the first time.
 5. During the first login, the system prompts the state administrator to set a permanent password.
 6. Once logged in, state administrators can access the settings panel (the cog icon) and set the needed configuration as described below.
 
 ## Jurisdiction Onboarding Overview
 
-Before a jurisdiction (i.e. state) can be onboarded to the Compact Connect system, the following information must be provided and configured through the Compact Connect UI:
+Before a jurisdiction (i.e. state) can be onboarded to the CompactConnect system, the following information must be provided and configured through the CompactConnect UI:
 
 1. Jurisdiction Fee for Compact Privileges
 2. Contact Details for System Notifications
 3. Jurisprudence Requirements
 4. Licensee Registration Settings
 
-These settings are managed by jurisdiction administrators through the Compact Connect administrative interface.
+These settings are managed by jurisdiction administrators through the CompactConnect administrative interface.
 
 ### Jurisdiction Fee for a Compact Privilege
 
-Jurisdiction administrators must set the fee that the jurisdiction will charge for a compact privilege. This is configured in the Jurisdiction Settings section of the Compact Connect UI. This is set per license type offered by the compact.
+Jurisdiction administrators must set the fee that the jurisdiction will charge for a compact privilege. This is configured in the Jurisdiction Settings section of the CompactConnect UI. This is set per license type offered by the compact.
 
 #### Military Rate Configuration
 
@@ -101,13 +101,13 @@ Both jurisdiction and compact administrators must provide contact details for sy
 > **Recommendation**: While the system supports multiple email addresses for each notification type, we recommend using distribution lists that users can subscribe to or unsubscribe from without requiring configuration changes.
 
 ## Uploading Authorize.net API Keys
-Compact administrators can configure their Authorize.net payment processing credentials through the Compact Connect UI. These 
+Compact administrators can configure their Authorize.net payment processing credentials through the CompactConnect UI. These 
 credentials are used to securely process payments for compact privilege applications. For detailed instructions on how to generate 
 these keys in your Authorize.net account, please visit the [Authorize.net documentation](https://support.authorize.net/knowledgebase/
 Knowledgearticle/?code=000001271). Once these credentials have been generated, the compact admin can set up payment processing for your 
 compact using the following steps:
 
-1. Log in to the Compact Connect UI as a compact administrator
+1. Log in to the CompactConnect UI as a compact administrator
 2. Navigate to the Compact Settings page (gear icon in the bottom left corner of the side navigation bar)
 3. Locate the "Authorize.net Credentials" section
 4. Enter the following Authorize.net credentials into the form and press "Submit":
@@ -117,7 +117,7 @@ compact using the following steps:
 If the request is successful, payment processing will be enabled for your compact.
 
 **Important Security Notes:**
-- If your credentials are ever compromised, or you suspect they might have been compromised, generate new ones immediately in your Authorize.net account and update them through the Compact Connect UI.
+- If your credentials are ever compromised, or you suspect they might have been compromised, generate new ones immediately in your Authorize.net account and update them through the CompactConnect UI.
 
 ## Access Management
 

--- a/backend/compact-connect/lambdas/nodejs/lib/email/base-email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/base-email-service.ts
@@ -90,7 +90,7 @@ export abstract class BaseEmailService {
                     }
                 },
                 // We're required by the IAM policy to use this display name
-                FromEmailAddress: `Compact Connect <${environmentVariableService.getFromAddress()}>`,
+                FromEmailAddress: `CompactConnect <${environmentVariableService.getFromAddress()}>`,
             });
 
             return (await this.sesClient.send(command)).MessageId;
@@ -121,7 +121,7 @@ export abstract class BaseEmailService {
 
             // Create the email message
             const message = {
-                from: `Compact Connect <${environmentVariableService.getFromAddress()}>`,
+                from: `CompactConnect <${environmentVariableService.getFromAddress()}>`,
                 to: recipients,
                 subject: subject,
                 html: htmlContent,

--- a/backend/compact-connect/lambdas/nodejs/lib/email/email-notification-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/email-notification-service.ts
@@ -358,7 +358,7 @@ export class EmailNotificationService extends BaseEmailService {
 
         const emailContent = this.getNewEmailTemplate();
         const headerText = `Privilege Purchase Confirmation`;
-        const subject = `Compact Connect Privilege Purchase Confirmation`;
+        const subject = `CompactConnect Privilege Purchase Confirmation`;
         const bodyText = `This email is to confirm you successfully purchased the following privileges on ${transactionDate}`;
 
         this.insertHeader(emailContent, headerText);
@@ -414,9 +414,9 @@ export class EmailNotificationService extends BaseEmailService {
         }
 
         const report = this.getNewEmailTemplate();
-        const subject = `Registration Attempt Notification - Compact Connect`;
+        const subject = `Registration Attempt Notification - CompactConnect`;
         const loginUrl = `${environmentVariableService.getUiBasePathUrl()}/Dashboard`;
-        const bodyText = `A registration attempt was made in the Compact Connect system for an account associated with this email address. This email address is already registered in our system.\n\nIf you originally registered within the past 24 hours, make sure to login with your temporary password sent to this same email address. You may log in to your existing account using the link below:\n\n${loginUrl}\n\nFor your security, we recommend that you log in to your account to verify your account information and ensure your account remains secure.`;
+        const bodyText = `A registration attempt was made in the CompactConnect system for an account associated with this email address. This email address is already registered in our system.\n\nIf you originally registered within the past 24 hours, make sure to login with your temporary password sent to this same email address. You may log in to your existing account using the link below:\n\n${loginUrl}\n\nFor your security, we recommend that you log in to your account to verify your account information and ensure your account remains secure.`;
 
         this.insertHeader(report, 'Registration Attempt');
         this.insertBody(report, bodyText, 'center', true);
@@ -443,7 +443,7 @@ export class EmailNotificationService extends BaseEmailService {
         const recipients = [providerEmail];
 
         const report = this.getNewEmailTemplate();
-        const subject = `Verify Your New Email Address - Compact Connect`;
+        const subject = `Verify Your New Email Address - CompactConnect`;
         const bodyText = `Please use the following verification code to complete your email address change:\n\n## ${verificationCode}\n\nThis code will expire in 15 minutes.\n\nIf you did not request this email change, please contact support immediately.`;
 
         this.insertHeader(report, 'Email Update Verification');
@@ -471,8 +471,8 @@ export class EmailNotificationService extends BaseEmailService {
         const recipients = [oldEmailAddress];
 
         const report = this.getNewEmailTemplate();
-        const subject = `Email Address Changed - Compact Connect`;
-        const bodyText = `This is to notify you that your Compact Connect account email address has been changed to the following:\n\n${newEmailAddress}\n\nPlease use the new email address to login to your account from now on. If you did not make this change, please contact support immediately.`;
+        const subject = `Email Address Changed - CompactConnect`;
+        const bodyText = `This is to notify you that your CompactConnect account email address has been changed to the following:\n\n${newEmailAddress}\n\nPlease use the new email address to login to your account from now on. If you did not make this change, please contact support immediately.`;
 
         this.insertHeader(report, 'Email Address Changed');
         this.insertBody(report, bodyText, 'center');
@@ -505,12 +505,12 @@ export class EmailNotificationService extends BaseEmailService {
         }
 
         const emailContent = this.getNewEmailTemplate();
-        const subject = 'Confirm Account Recovery - Compact Connect';
+        const subject = 'Confirm Account Recovery - CompactConnect';
 
         const baseUrl = environmentVariableService.getUiBasePathUrl();
         const recoveryUrl = `${baseUrl}/Dashboard?bypass=recovery-practitioner&compact=${compact}&providerId=${providerId}&recoveryId=${recoveryToken}`;
 
-        const bodyText = `A request was made to recover access to your Compact Connect user account.\n\n` +
+        const bodyText = `A request was made to recover access to your CompactConnect user account.\n\n` +
             `If you initiated this request, please confirm by clicking the link below to continue account recovery. ` +
             `\n\n${recoveryUrl}\n\n` +
             `**If you did not request this, your password has likely been compromised and you should reset your password immediately**. To reset your password, please visit the following link:\n\n${baseUrl}/Dashboard?bypass=login-practitioner\n\n Select 'Forgot your password?' and follow the instructions.`;
@@ -542,7 +542,7 @@ export class EmailNotificationService extends BaseEmailService {
         }
 
         const report = this.getNewEmailTemplate();
-        const subject = 'Military Status Documentation Approved - Compact Connect';
+        const subject = 'Military Status Documentation Approved - CompactConnect';
         const bodyText = 'This message is to notify you that your military status documentation has been reviewed and approved by the compact staff.';
 
         this.insertHeader(report, subject);
@@ -574,7 +574,7 @@ export class EmailNotificationService extends BaseEmailService {
         }
 
         const report = this.getNewEmailTemplate();
-        const subject = 'Military Status Documentation Declined - Compact Connect';
+        const subject = 'Military Status Documentation Declined - CompactConnect';
         let bodyText = 'This message is to notify you that your military status documentation has been reviewed and declined by the compact staff.';
         
         if (auditNote && auditNote.trim().length > 0) {
@@ -690,7 +690,7 @@ export class EmailNotificationService extends BaseEmailService {
         const expirationDateSlash = formatIsoDateAsSlashFormat(expirationDate);
 
         const emailContent = this.getNewEmailTemplate();
-        const subject = `Your Compact Connect Privileges Expire on ${expirationDateDisplay}`;
+        const subject = `Your CompactConnect Privileges Expire on ${expirationDateDisplay}`;
 
         // Logo at the top
         this.insertLogo(emailContent);
@@ -725,7 +725,7 @@ export class EmailNotificationService extends BaseEmailService {
             { 'padding': { 'top': 24, 'bottom': 24, 'right': 32, 'left': 32 }}
         );
 
-        // Dashboard link so the user can navigate to Compact Connect
+        // Dashboard link so the user can navigate to CompactConnect
         const dashboardUrl = `${environmentVariableService.getUiBasePathUrl()}/Dashboard`;
 
         this.insertBody(

--- a/backend/compact-connect/lambdas/nodejs/package.json
+++ b/backend/compact-connect/lambdas/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "compact-connect",
   "version": "1.0.0",
   "type": "commonjs",
-  "description": "NodeJS lambdas for Compact Connect",
+  "description": "NodeJS lambdas for CompactConnect",
   "resolutions": {
     "fast-xml-parser": "5.5.7"
   },
@@ -49,7 +49,7 @@
     "@aws-sdk/client-sesv2": "^3.901.0",
     "@aws-sdk/util-dynamodb": "^3.901.0",
     "@csg-org/email-builder": "^0.0.12",
-    "nodemailer": "^7.0.11",
+    "nodemailer": "^8.0.5",
     "zod": "^3.23.8"
   }
 }

--- a/backend/compact-connect/lambdas/nodejs/package.json
+++ b/backend/compact-connect/lambdas/nodejs/package.json
@@ -20,7 +20,7 @@
     "@types/aws-lambda": "8.10.145",
     "@types/jest": "^29.5.12",
     "@types/node": "22.5.4",
-    "@types/nodemailer": "^7.0.9",
+    "@types/nodemailer": "^8.0.0",
     "@types/react": "^18.3.12",
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",

--- a/backend/compact-connect/lambdas/nodejs/tests/email-notification-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/email-notification-service.test.ts
@@ -170,7 +170,7 @@ describe('EmailNotificationServiceLambda', () => {
                     }
                 }
             },
-            FromEmailAddress: 'Compact Connect <noreply@example.org>'
+            FromEmailAddress: 'CompactConnect <noreply@example.org>'
         });
     });
 
@@ -504,7 +504,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             }
             );
         });
@@ -547,7 +547,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
 
             });
         });
@@ -613,11 +613,11 @@ describe('EmailNotificationServiceLambda', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Compact Connect Privilege Purchase Confirmation'
+                            Data: 'CompactConnect Privilege Purchase Confirmation'
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -669,7 +669,7 @@ describe('EmailNotificationServiceLambda', () => {
             const input = sendCall.args[0].input;
 
             expect(input.Destination?.ToAddresses).toEqual(['provider@example.com']);
-            expect(input.Content?.Simple?.Subject?.Data).toBe('Your Compact Connect Privileges Expire on February 16, 2026');
+            expect(input.Content?.Simple?.Subject?.Data).toBe('Your CompactConnect Privileges Expire on February 16, 2026');
             const htmlData = input.Content?.Simple?.Body?.Html?.Data ?? '';
 
             expect(htmlData).toContain('Hi Mary,');
@@ -780,11 +780,11 @@ describe('EmailNotificationServiceLambda', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Registration Attempt Notification - Compact Connect'
+                            Data: 'Registration Attempt Notification - CompactConnect'
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -840,7 +840,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -912,7 +912,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1004,7 +1004,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1077,7 +1077,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1144,7 +1144,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1215,7 +1215,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1284,7 +1284,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1356,7 +1356,7 @@ describe('EmailNotificationServiceLambda', () => {
                             Data: 'Privilege Encumbrance Lifted Notification - John Doe'
                         }
                     }},
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1416,11 +1416,11 @@ describe('EmailNotificationServiceLambda', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Verify Your New Email Address - Compact Connect'
+                            Data: 'Verify Your New Email Address - CompactConnect'
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
 
             // Get the actual HTML content for detailed validation
@@ -1491,10 +1491,10 @@ describe('EmailNotificationServiceLambda', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Email Address Changed - Compact Connect'
+                            Data: 'Email Address Changed - CompactConnect'
                         }
                     }},
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
 
             // Get the actual HTML content for detailed validation
@@ -1502,7 +1502,7 @@ describe('EmailNotificationServiceLambda', () => {
             const htmlContent = emailCall.args[0].input.Content?.Simple?.Body?.Html?.Data;
 
             expect(htmlContent).toBeDefined();
-            expect(htmlContent).toContain('This is to notify you that your Compact Connect account email address has been changed to the following:');
+            expect(htmlContent).toContain('This is to notify you that your CompactConnect account email address has been changed to the following:');
             expect(htmlContent).toContain('newuser@example.com');
         });
 
@@ -1563,10 +1563,10 @@ describe('EmailNotificationServiceLambda', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Confirm Account Recovery - Compact Connect'
+                            Data: 'Confirm Account Recovery - CompactConnect'
                         }
                     }},
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
 
             // Get the actual HTML content for detailed validation
@@ -1574,7 +1574,7 @@ describe('EmailNotificationServiceLambda', () => {
             const htmlContent = emailCall.args[0].input.Content?.Simple?.Body?.Html?.Data;
 
             expect(htmlContent).toBeDefined();
-            expect(htmlContent).toContain('A request was made to recover access to your Compact Connect user account.');
+            expect(htmlContent).toContain('A request was made to recover access to your CompactConnect user account.');
             expect(htmlContent).toContain('Confirm Account Recovery');
 
             // Verify recovery URL is correctly formatted (HTML encoded in email)
@@ -1652,11 +1652,11 @@ describe('EmailNotificationServiceLambda', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Military Status Documentation Approved - Compact Connect'
+                            Data: 'Military Status Documentation Approved - CompactConnect'
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
 
             // Get the actual HTML content for detailed validation
@@ -1665,7 +1665,7 @@ describe('EmailNotificationServiceLambda', () => {
 
             expect(htmlContent).toBeDefined();
             expect(htmlContent).toContain('This message is to notify you that your military status documentation has been reviewed and approved by the compact staff.');
-            expect(htmlContent).toContain('Military Status Documentation Approved - Compact Connect');
+            expect(htmlContent).toContain('Military Status Documentation Approved - CompactConnect');
         });
 
         it('should throw error when no recipients found', async () => {
@@ -1713,11 +1713,11 @@ describe('EmailNotificationServiceLambda', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Military Status Documentation Declined - Compact Connect'
+                            Data: 'Military Status Documentation Declined - CompactConnect'
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
 
             // Get the actual HTML content for detailed validation
@@ -1726,7 +1726,7 @@ describe('EmailNotificationServiceLambda', () => {
 
             expect(htmlContent).toBeDefined();
             expect(htmlContent).toContain('This message is to notify you that your military status documentation has been reviewed and declined by the compact staff.');
-            expect(htmlContent).toContain('Military Status Documentation Declined - Compact Connect');
+            expect(htmlContent).toContain('Military Status Documentation Declined - CompactConnect');
             expect(htmlContent).toContain('The documentation provided was incomplete and did not meet the required standards.');
         });
 
@@ -1805,7 +1805,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1897,7 +1897,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1987,7 +1987,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -2079,7 +2079,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 

--- a/backend/compact-connect/lambdas/nodejs/tests/lib/email/email-notification-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lib/email/email-notification-service.test.ts
@@ -144,7 +144,7 @@ describe('EmailNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -178,7 +178,7 @@ describe('EmailNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -237,7 +237,7 @@ describe('EmailNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -273,7 +273,7 @@ describe('EmailNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -321,7 +321,7 @@ describe('EmailNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -388,7 +388,7 @@ describe('EmailNotificationService', () => {
 
             // Verify email was sent with correct parameters
             expect(MOCK_TRANSPORT.sendMail).toHaveBeenCalledWith({
-                from: 'Compact Connect <noreply@example.org>',
+                from: 'CompactConnect <noreply@example.org>',
                 to: ['summary@example.com'],
                 subject: 'Weekly Report for Audiology and Speech Language Pathology',
                 html: expect.any(String),
@@ -518,7 +518,7 @@ describe('EmailNotificationService', () => {
 
             // Verify email was sent with correct parameters
             expect(MOCK_TRANSPORT.sendMail).toHaveBeenCalledWith({
-                from: 'Compact Connect <noreply@example.org>',
+                from: 'CompactConnect <noreply@example.org>',
                 to: ['oh-summary@example.com'],
                 subject: 'Ohio Weekly Report for Audiology and Speech Language Pathology',
                 html: expect.any(String),
@@ -621,16 +621,16 @@ describe('EmailNotificationService', () => {
                                 Html: {
                                     Charset: 'UTF-8',
                                     Data: expect.stringContaining(
-                                        'A registration attempt was made in the Compact Connect system ')
+                                        'A registration attempt was made in the CompactConnect system ')
                                 }
                             },
                             Subject: {
                                 Charset: 'UTF-8',
-                                Data: 'Registration Attempt Notification - Compact Connect'
+                                Data: 'Registration Attempt Notification - CompactConnect'
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -658,7 +658,7 @@ describe('EmailNotificationService', () => {
                             Subject: expect.any(Object)
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -686,7 +686,7 @@ describe('EmailNotificationService', () => {
                             Subject: expect.any(Object)
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -745,11 +745,11 @@ describe('EmailNotificationService', () => {
                             },
                             Subject: {
                                 Charset: 'UTF-8',
-                                Data: 'Compact Connect Privilege Purchase Confirmation'
+                                Data: 'CompactConnect Privilege Purchase Confirmation'
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -804,11 +804,11 @@ describe('EmailNotificationService', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Verify Your New Email Address - Compact Connect'
+                            Data: 'Verify Your New Email Address - CompactConnect'
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
 
             // Get the actual HTML content for detailed validation
@@ -847,11 +847,11 @@ describe('EmailNotificationService', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Email Address Changed - Compact Connect'
+                            Data: 'Email Address Changed - CompactConnect'
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
 
             // Get the actual HTML content for detailed validation
@@ -893,11 +893,11 @@ describe('EmailNotificationService', () => {
                         },
                         Subject: {
                             Charset: 'UTF-8',
-                            Data: 'Confirm Account Recovery - Compact Connect'
+                            Data: 'Confirm Account Recovery - CompactConnect'
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
 
             // Get the actual HTML content for detailed validation
@@ -905,7 +905,7 @@ describe('EmailNotificationService', () => {
             const htmlContent = emailCall.args[0].input.Content?.Simple?.Body?.Html?.Data;
 
             expect(htmlContent).toBeDefined();
-            expect(htmlContent).toContain('A request was made to recover access to your Compact Connect user account.');
+            expect(htmlContent).toContain('A request was made to recover access to your CompactConnect user account.');
             expect(htmlContent).toContain('If you initiated this request, please confirm by clicking the link below to continue account recovery.');
             expect(htmlContent).toContain('Confirm Account Recovery');
 
@@ -993,7 +993,7 @@ describe('EmailNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
 
@@ -1107,11 +1107,11 @@ describe('EmailNotificationService', () => {
                             },
                             Subject: {
                                 Charset: 'UTF-8',
-                                Data: 'Your Compact Connect Privileges Expire on February 16, 2026',
+                                Data: 'Your CompactConnect Privileges Expire on February 16, 2026',
                             },
                         },
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>',
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>',
                 }
             );
 
@@ -1130,7 +1130,7 @@ describe('EmailNotificationService', () => {
             // Verify two-column table headers
             expect(htmlContent).toContain('Privilege');
             expect(htmlContent).toContain('Expires');
-            // Verify dashboard link is present so user can navigate to Compact Connect
+            // Verify dashboard link is present so user can navigate to CompactConnect
             expect(htmlContent).toContain('https://app.test.compactconnect.org/Dashboard');
             expect(htmlContent).toMatch(/<a[^>]+href=["']https:\/\/app\.test\.compactconnect\.org\/Dashboard["'][^>]*>/);
         });

--- a/backend/compact-connect/lambdas/nodejs/tests/lib/email/encumbrance-notification-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lib/email/encumbrance-notification-service.test.ts
@@ -146,7 +146,7 @@ describe('EncumbranceNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -196,7 +196,7 @@ describe('EncumbranceNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -274,7 +274,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -330,7 +330,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -409,7 +409,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -465,7 +465,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
 
@@ -568,7 +568,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -624,7 +624,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
 

--- a/backend/compact-connect/lambdas/nodejs/tests/lib/email/ingest-event-email-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lib/email/ingest-event-email-service.test.ts
@@ -111,7 +111,7 @@ describe('IngestEventEmailService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             }
         );
     });
@@ -158,7 +158,7 @@ describe('IngestEventEmailService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             }
         );
     });
@@ -191,7 +191,7 @@ describe('IngestEventEmailService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             }
         );
     });

--- a/backend/compact-connect/lambdas/nodejs/tests/lib/email/investigation-notification-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lib/email/investigation-notification-service.test.ts
@@ -146,7 +146,7 @@ describe('InvestigationNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -198,7 +198,7 @@ describe('InvestigationNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
     });
@@ -233,7 +233,7 @@ describe('InvestigationNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
     });
@@ -268,7 +268,7 @@ describe('InvestigationNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
     });

--- a/backend/compact-connect/lambdas/nodejs/yarn.lock
+++ b/backend/compact-connect/lambdas/nodejs/yarn.lock
@@ -2450,10 +2450,10 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/nodemailer@^7.0.9":
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-7.0.9.tgz#a19e3fa222b21213b481cdbdbc70a06787ea49e8"
-  integrity sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow==
+"@types/nodemailer@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-8.0.0.tgz#ea189a9c151c04cc65c8a2a4c668c65d952a24e2"
+  integrity sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==
   dependencies:
     "@types/node" "*"
 

--- a/backend/compact-connect/lambdas/nodejs/yarn.lock
+++ b/backend/compact-connect/lambdas/nodejs/yarn.lock
@@ -4610,10 +4610,10 @@ node-releases@^2.0.27:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
-nodemailer@^7.0.11:
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-7.0.13.tgz#74acaa55f0c6f9476384c29f27f53e467e8483cd"
-  integrity sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==
+nodemailer@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.5.tgz#2076fb2b5c1ccfe1c88f6e1aa47c0229ea642e0c"
+  integrity sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==
 
 normalize-path@^3.0.0:
   version "3.0.0"

--- a/backend/compact-connect/lambdas/python/cognito-backup/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/cognito-backup/requirements-dev.txt
@@ -5,14 +5,14 @@
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/cognito-backup/requirements-dev.in
 #
 aws-lambda-powertools==3.27.0
-    # via -r cognito-backup/requirements-dev.in
-boto3==1.42.83
+    # via -r lambdas/python/cognito-backup/requirements-dev.in
+boto3==1.42.89
     # via
-    #   -r cognito-backup/requirements-dev.in
+    #   -r lambdas/python/cognito-backup/requirements-dev.in
     #   moto
-botocore==1.42.84
+botocore==1.42.89
     # via
-    #   -r cognito-backup/requirements-dev.in
+    #   -r lambdas/python/cognito-backup/requirements-dev.in
     #   boto3
     #   moto
     #   s3transfer
@@ -22,7 +22,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   joserfc
     #   moto
@@ -37,14 +37,14 @@ jmespath==1.1.0
     #   aws-lambda-powertools
     #   boto3
     #   botocore
-joserfc==1.6.3
+joserfc==1.6.4
     # via moto
 markupsafe==3.0.3
     # via
     #   jinja2
     #   werkzeug
 moto[cognitoidp,s3]==5.1.22
-    # via -r cognito-backup/requirements-dev.in
+    # via -r lambdas/python/cognito-backup/requirements-dev.in
 packaging==26.0
     # via pytest
 pluggy==1.6.0
@@ -55,8 +55,8 @@ pycparser==3.0
     # via cffi
 pygments==2.20.0
     # via pytest
-pytest==9.0.2
-    # via -r cognito-backup/requirements-dev.in
+pytest==9.0.3
+    # via -r lambdas/python/cognito-backup/requirements-dev.in
 python-dateutil==2.9.0.post0
     # via
     #   botocore

--- a/backend/compact-connect/lambdas/python/common/requirements-dev.in
+++ b/backend/compact-connect/lambdas/python/common/requirements-dev.in
@@ -1,6 +1,6 @@
 # Keep attrs on 25.x to match root requirements.txt (jsii/cattrs); avoids pip-sync conflicts.
 moto[all]>=5.0.12, <6
 boto3-stubs[full]
-Faker>=37, <38
+Faker>=40, <41
 cryptography>=46, <47
 attrs>=25, <26

--- a/backend/compact-connect/lambdas/python/common/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/common/requirements-dev.txt
@@ -10,7 +10,7 @@ antlr4-python3-runtime==4.13.2
     # via moto
 attrs==25.4.0
     # via
-    #   -r common/requirements-dev.in
+    #   -r lambdas/python/common/requirements-dev.in
     #   jsonschema
     #   referencing
 aws-sam-translator==1.103.0
@@ -19,15 +19,15 @@ aws-sam-translator==1.103.0
     #   moto
 aws-xray-sdk==2.15.0
     # via moto
-boto3==1.42.83
+boto3==1.42.89
     # via
     #   aws-sam-translator
     #   moto
-boto3-stubs[full]==1.42.84
-    # via -r common/requirements-dev.in
-boto3-stubs-full==1.42.83
+boto3-stubs[full]==1.42.89
+    # via -r lambdas/python/common/requirements-dev.in
+boto3-stubs-full==1.42.88
     # via boto3-stubs
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   aws-xray-sdk
     #   boto3
@@ -43,15 +43,15 @@ cfn-lint==1.41.0
     # via moto
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via
-    #   -r common/requirements-dev.in
+    #   -r lambdas/python/common/requirements-dev.in
     #   joserfc
     #   moto
 docker==7.1.0
     # via moto
-faker==37.12.0
-    # via -r common/requirements-dev.in
+faker==40.13.0
+    # via -r lambdas/python/common/requirements-dev.in
 graphql-core==3.2.8
     # via moto
 idna==3.11
@@ -62,7 +62,7 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-joserfc==1.6.3
+joserfc==1.6.4
     # via moto
 jsonpatch==1.33
     # via cfn-lint
@@ -89,7 +89,7 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 moto[all]==5.1.22
-    # via -r common/requirements-dev.in
+    # via -r lambdas/python/common/requirements-dev.in
 mpmath==1.3.0
     # via sympy
 multipart==1.3.1
@@ -177,8 +177,6 @@ typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings
-tzdata==2026.1
-    # via faker
 urllib3==2.6.3
     # via
     #   botocore

--- a/backend/compact-connect/lambdas/python/common/requirements.txt
+++ b/backend/compact-connect/lambdas/python/common/requirements.txt
@@ -5,14 +5,14 @@
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/common/requirements.in
 #
 argon2-cffi==25.1.0
-    # via -r common/requirements.in
+    # via -r lambdas/python/common/requirements.in
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
 aws-lambda-powertools==3.27.0
-    # via -r common/requirements.in
-boto3==1.42.83
-    # via -r common/requirements.in
-botocore==1.42.84
+    # via -r lambdas/python/common/requirements.in
+boto3==1.42.89
+    # via -r lambdas/python/common/requirements.in
+botocore==1.42.89
     # via
     #   boto3
     #   s3transfer
@@ -24,8 +24,8 @@ cffi==2.0.0
     #   cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
-    # via -r common/requirements.in
+cryptography==46.0.7
+    # via -r lambdas/python/common/requirements.in
 idna==3.11
     # via requests
 jmespath==1.1.0
@@ -34,7 +34,7 @@ jmespath==1.1.0
     #   boto3
     #   botocore
 marshmallow==3.26.2
-    # via -r common/requirements.in
+    # via -r lambdas/python/common/requirements.in
 packaging==26.0
     # via marshmallow
 pycparser==3.0
@@ -42,7 +42,7 @@ pycparser==3.0
 python-dateutil==2.9.0.post0
     # via botocore
 requests==2.33.1
-    # via -r common/requirements.in
+    # via -r lambdas/python/common/requirements.in
 s3transfer==0.16.0
     # via boto3
 six==1.17.0

--- a/backend/compact-connect/lambdas/python/compact-configuration/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/compact-configuration/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/compact-configuration/requirements-dev.in
 #
-boto3==1.42.83
+boto3==1.42.89
     # via moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -34,7 +34,7 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 moto[dynamodb,s3]==5.1.22
-    # via -r compact-configuration/requirements-dev.in
+    # via -r lambdas/python/compact-configuration/requirements-dev.in
 py-partiql-parser==0.6.3
     # via moto
 pycparser==3.0

--- a/backend/compact-connect/lambdas/python/custom-resources/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/custom-resources/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/custom-resources/requirements-dev.in
 #
-boto3==1.42.83
+boto3==1.42.89
     # via moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -34,7 +34,7 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 moto[dynamodb,s3]==5.1.22
-    # via -r custom-resources/requirements-dev.in
+    # via -r lambdas/python/custom-resources/requirements-dev.in
 py-partiql-parser==0.6.3
     # via moto
 pycparser==3.0

--- a/backend/compact-connect/lambdas/python/data-events/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/data-events/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/data-events/requirements-dev.in
 #
-boto3==1.42.83
+boto3==1.42.89
     # via moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -34,7 +34,7 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 moto[dynamodb,s3]==5.1.22
-    # via -r data-events/requirements-dev.in
+    # via -r lambdas/python/data-events/requirements-dev.in
 py-partiql-parser==0.6.3
     # via moto
 pycparser==3.0

--- a/backend/compact-connect/lambdas/python/disaster-recovery/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/disaster-recovery/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/disaster-recovery/requirements-dev.in
 #
-boto3==1.42.83
+boto3==1.42.89
     # via moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -34,7 +34,7 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 moto[dynamodb,s3]==5.1.22
-    # via -r disaster-recovery/requirements-dev.in
+    # via -r lambdas/python/disaster-recovery/requirements-dev.in
 py-partiql-parser==0.6.3
     # via moto
 pycparser==3.0

--- a/backend/compact-connect/lambdas/python/provider-data-v1/requirements-dev.in
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/requirements-dev.in
@@ -1,2 +1,2 @@
 moto[dynamodb, s3]>=5.0.12, <6
-Faker>=37, <38
+Faker>=40, <41

--- a/backend/compact-connect/lambdas/python/provider-data-v1/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/provider-data-v1/requirements-dev.in
 #
-boto3==1.42.83
+boto3==1.42.89
     # via moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -17,12 +17,12 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
-faker==37.12.0
-    # via -r provider-data-v1/requirements-dev.in
+faker==40.13.0
+    # via -r lambdas/python/provider-data-v1/requirements-dev.in
 idna==3.11
     # via requests
 jinja2==3.1.6
@@ -36,7 +36,7 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 moto[dynamodb,s3]==5.1.22
-    # via -r provider-data-v1/requirements-dev.in
+    # via -r lambdas/python/provider-data-v1/requirements-dev.in
 py-partiql-parser==0.6.3
     # via moto
 pycparser==3.0
@@ -60,8 +60,6 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-tzdata==2026.1
-    # via faker
 urllib3==2.6.3
     # via
     #   botocore

--- a/backend/compact-connect/lambdas/python/purchases/requirements-dev.in
+++ b/backend/compact-connect/lambdas/python/purchases/requirements-dev.in
@@ -5,7 +5,7 @@ coverage
 ruff
 pip-tools
 pip-audit
-Faker>=37, <38
+Faker>=40, <41
 
 # Dependencies normally provided via the common lambda layer
 argon2-cffi>=25.1.0, <26.0.0

--- a/backend/compact-connect/lambdas/python/purchases/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/purchases/requirements-dev.txt
@@ -5,23 +5,23 @@
 #    pip-compile --no-emit-index-url --no-strip-extras requirements-dev.in
 #
 argon2-cffi==25.1.0
-    # via -r purchases/requirements-dev.in
+    # via -r requirements-dev.in
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
 aws-lambda-powertools==3.27.0
-    # via -r purchases/requirements-dev.in
+    # via -r requirements-dev.in
 boolean-py==5.0
     # via license-expression
-boto3==1.42.83
+boto3==1.42.89
     # via
-    #   -r purchases/requirements-dev.in
+    #   -r requirements-dev.in
     #   moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
     #   s3transfer
-build==1.4.2
+build==1.4.3
     # via pip-tools
 cachecontrol[filecache]==0.14.4
     # via
@@ -39,11 +39,11 @@ click==8.3.2
     # via pip-tools
 coverage[toml]==7.13.5
     # via
-    #   -r purchases/requirements-dev.in
+    #   -r requirements-dev.in
     #   pytest-cov
-cryptography==46.0.6
+cryptography==46.0.7
     # via
-    #   -r purchases/requirements-dev.in
+    #   -r requirements-dev.in
     #   moto
 cyclonedx-python-lib==11.7.0
     # via pip-audit
@@ -51,8 +51,8 @@ defusedxml==0.7.1
     # via py-serializable
 docker==7.1.0
     # via moto
-faker==37.12.0
-    # via -r purchases/requirements-dev.in
+faker==40.13.0
+    # via -r requirements-dev.in
 filelock==3.25.2
     # via cachecontrol
 idna==3.11
@@ -75,11 +75,11 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 marshmallow==3.26.2
-    # via -r purchases/requirements-dev.in
+    # via -r requirements-dev.in
 mdurl==0.1.2
     # via markdown-it-py
 moto[dynamodb,s3]==5.1.22
-    # via -r purchases/requirements-dev.in
+    # via -r requirements-dev.in
 msgpack==1.1.2
     # via cachecontrol
 packageurl-python==0.17.6
@@ -95,12 +95,12 @@ packaging==26.0
 pip-api==0.0.34
     # via pip-audit
 pip-audit==2.10.0
-    # via -r purchases/requirements-dev.in
+    # via -r requirements-dev.in
 pip-requirements-parser==32.0.1
     # via pip-audit
 pip-tools==7.5.3
-    # via -r purchases/requirements-dev.in
-platformdirs==4.9.4
+    # via -r requirements-dev.in
+platformdirs==4.9.6
     # via pip-audit
 pluggy==1.6.0
     # via
@@ -122,12 +122,12 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.0.2
+pytest==9.0.3
     # via
-    #   -r purchases/requirements-dev.in
+    #   -r requirements-dev.in
     #   pytest-cov
 pytest-cov==7.1.0
-    # via -r purchases/requirements-dev.in
+    # via -r requirements-dev.in
 python-dateutil==2.9.0.post0
     # via
     #   botocore
@@ -138,7 +138,7 @@ pyyaml==6.0.3
     #   responses
 requests==2.33.1
     # via
-    #   -r purchases/requirements-dev.in
+    #   -r requirements-dev.in
     #   cachecontrol
     #   docker
     #   moto
@@ -146,10 +146,10 @@ requests==2.33.1
     #   responses
 responses==0.26.0
     # via moto
-rich==14.3.3
+rich==15.0.0
     # via pip-audit
-ruff==0.15.9
-    # via -r purchases/requirements-dev.in
+ruff==0.15.10
+    # via -r requirements-dev.in
 s3transfer==0.16.0
     # via boto3
 six==1.17.0
@@ -161,12 +161,12 @@ tomli==2.4.1
 tomli-w==1.2.0
     # via pip-audit
 typing-extensions==4.15.0
-    # via aws-lambda-powertools
-tzdata==2026.1
-    # via faker
+    # via
+    #   aws-lambda-powertools
+    #   cyclonedx-python-lib
 urllib3==2.6.3
     # via
-    #   -r purchases/requirements-dev.in
+    #   -r requirements-dev.in
     #   botocore
     #   docker
     #   requests

--- a/backend/compact-connect/lambdas/python/search/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/search/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/search/requirements-dev.in
 #
-boto3==1.42.83
+boto3==1.42.89
     # via moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -34,7 +34,7 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 moto[dynamodb]==5.1.22
-    # via -r search/requirements-dev.in
+    # via -r lambdas/python/search/requirements-dev.in
 py-partiql-parser==0.6.3
     # via moto
 pycparser==3.0

--- a/backend/compact-connect/lambdas/python/staff-user-pre-token/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/staff-user-pre-token/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/staff-user-pre-token/requirements-dev.in
 #
-boto3==1.42.83
+boto3==1.42.89
     # via moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -17,7 +17,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -34,7 +34,7 @@ markupsafe==3.0.3
     #   jinja2
     #   werkzeug
 moto[dynamodb,s3]==5.1.22
-    # via -r staff-user-pre-token/requirements-dev.in
+    # via -r lambdas/python/staff-user-pre-token/requirements-dev.in
 py-partiql-parser==0.6.3
     # via moto
 pycparser==3.0

--- a/backend/compact-connect/lambdas/python/staff-users/requirements-dev.in
+++ b/backend/compact-connect/lambdas/python/staff-users/requirements-dev.in
@@ -1,2 +1,2 @@
 moto[dynamodb, s3, cognitoidp]>=5.0.15, <6
-Faker>=37, <38
+Faker>=40, <41

--- a/backend/compact-connect/lambdas/python/staff-users/requirements-dev.txt
+++ b/backend/compact-connect/lambdas/python/staff-users/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/staff-users/requirements-dev.in
 #
-boto3==1.42.83
+boto3==1.42.89
     # via moto
-botocore==1.42.84
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -17,14 +17,14 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   joserfc
     #   moto
 docker==7.1.0
     # via moto
-faker==37.12.0
-    # via -r staff-users/requirements-dev.in
+faker==40.13.0
+    # via -r lambdas/python/staff-users/requirements-dev.in
 idna==3.11
     # via requests
 jinja2==3.1.6
@@ -33,14 +33,14 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-joserfc==1.6.3
+joserfc==1.6.4
     # via moto
 markupsafe==3.0.3
     # via
     #   jinja2
     #   werkzeug
 moto[cognitoidp,dynamodb,s3]==5.1.22
-    # via -r staff-users/requirements-dev.in
+    # via -r lambdas/python/staff-users/requirements-dev.in
 py-partiql-parser==0.6.3
     # via moto
 pycparser==3.0
@@ -64,8 +64,6 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-tzdata==2026.1
-    # via faker
 urllib3==2.6.3
     # via
     #   botocore

--- a/backend/compact-connect/requirements-dev.in
+++ b/backend/compact-connect/requirements-dev.in
@@ -4,4 +4,4 @@ coverage
 ruff
 pip-tools
 pip-audit
-Faker>=37, <38
+Faker>=40, <41

--- a/backend/compact-connect/requirements-dev.txt
+++ b/backend/compact-connect/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 boolean-py==5.0
     # via license-expression
-build==1.4.2
+build==1.4.3
     # via pip-tools
 cachecontrol[filecache]==0.14.4
     # via
@@ -26,7 +26,7 @@ cyclonedx-python-lib==11.7.0
     # via pip-audit
 defusedxml==0.7.1
     # via py-serializable
-faker==37.12.0
+faker==40.13.0
     # via -r requirements-dev.in
 filelock==3.25.2
     # via cachecontrol
@@ -59,7 +59,7 @@ pip-requirements-parser==32.0.1
     # via pip-audit
 pip-tools==7.5.3
     # via -r requirements-dev.in
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via pip-audit
 pluggy==1.6.0
     # via
@@ -77,7 +77,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -87,9 +87,9 @@ requests==2.33.1
     # via
     #   cachecontrol
     #   pip-audit
-rich==14.3.3
+rich==15.0.0
     # via pip-audit
-ruff==0.15.9
+ruff==0.15.10
     # via -r requirements-dev.in
 sortedcontainers==2.4.0
     # via cyclonedx-python-lib
@@ -97,8 +97,6 @@ tomli==2.4.1
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
-tzdata==2026.1
-    # via faker
 urllib3==2.6.3
     # via requests
 wheel==0.46.3

--- a/backend/compact-connect/requirements.txt
+++ b/backend/compact-connect/requirements.txt
@@ -12,11 +12,11 @@ aws-cdk-asset-awscli-v1==2.2.273
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.1
     # via aws-cdk-lib
-aws-cdk-aws-lambda-python-alpha==2.248.0a0
+aws-cdk-aws-lambda-python-alpha==2.249.0a0
     # via -r requirements.in
-aws-cdk-cloud-assembly-schema==53.13.0
+aws-cdk-cloud-assembly-schema==53.14.0
     # via aws-cdk-lib
-aws-cdk-lib==2.248.0
+aws-cdk-lib==2.249.0
     # via
     #   -r requirements.in
     #   aws-cdk-aws-lambda-python-alpha
@@ -31,9 +31,9 @@ constructs==10.6.0
     #   aws-cdk-aws-lambda-python-alpha
     #   aws-cdk-lib
     #   cdk-nag
-importlib-resources==6.5.2
+importlib-resources==7.1.0
     # via jsii
-jsii==1.127.0
+jsii==1.128.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-node-proxy-agent-v6

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -402,21 +402,24 @@ class PersistentStack(AppStack):
                 ),
             )
 
-        lambda_function.role.add_to_principal_policy(
-            PolicyStatement(
-                actions=['ses:SendEmail', 'ses:SendRawEmail'],
-                resources=ses_resources,
-                effect=Effect.ALLOW,
-                conditions={
-                    # To mitigate the pretty open resources section for sandbox environments, we'll restrict the use of
-                    # this action by specifying what From address and display name the principal must use.
-                    'StringEquals': {
-                        'ses:FromAddress': f'noreply@{self.user_email_notifications.email_identity.email_identity_name}',  # noqa: E501 line too long
-                        'ses:FromDisplayName': 'Compact Connect',
-                    }
-                },
+        # Two statements so either display name is allowed during migration from "Compact Connect" to "CompactConnect".
+        # TODO: Remove the "Compact Connect" display name once all Lambda code exclusively uses "CompactConnect".
+        for display_name in ('Compact Connect', 'CompactConnect'):
+            lambda_function.role.add_to_principal_policy(
+                PolicyStatement(
+                    actions=['ses:SendEmail', 'ses:SendRawEmail'],
+                    resources=ses_resources,
+                    effect=Effect.ALLOW,
+                    conditions={
+                        # To mitigate the pretty open resources section for sandbox environments, we'll restrict the use of
+                        # this action by specifying what From address and display name the principal must use.
+                        'StringEquals': {
+                            'ses:FromAddress': f'noreply@{self.user_email_notifications.email_identity.email_identity_name}',  # noqa: E501 line too long
+                            'ses:FromDisplayName': display_name,
+                        }
+                    },
+                )
             )
-        )
 
     def get_ui_base_path_url(self) -> str:
         """Returns the base URL for the UI."""

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -403,7 +403,7 @@ class PersistentStack(AppStack):
             )
 
         # Two statements so either display name is allowed during migration from "Compact Connect" to "CompactConnect".
-        # TODO: Remove the "Compact Connect" display name once all Lambda code exclusively uses "CompactConnect".
+        # TODO: Remove the "Compact Connect" display name once all Lambda code exclusively uses "CompactConnect".  # noqa: FIX002, E501
         for display_name in ('Compact Connect', 'CompactConnect'):
             lambda_function.role.add_to_principal_policy(
                 PolicyStatement(
@@ -411,8 +411,8 @@ class PersistentStack(AppStack):
                     resources=ses_resources,
                     effect=Effect.ALLOW,
                     conditions={
-                        # To mitigate the pretty open resources section for sandbox environments, we'll restrict the use of
-                        # this action by specifying what From address and display name the principal must use.
+                        # To mitigate the pretty open resources section for sandbox environments, we'll restrict the
+                        # use of this action by specifying what From address and display name the principal must use.
                         'StringEquals': {
                             'ses:FromAddress': f'noreply@{self.user_email_notifications.email_identity.email_identity_name}',  # noqa: E501 line too long
                             'ses:FromDisplayName': display_name,

--- a/backend/cosmetology-app/README.md
+++ b/backend/cosmetology-app/README.md
@@ -1,4 +1,4 @@
-# Compact Connect - Backend developer documentation
+# CompactConnect - Backend developer documentation
 
 ## Looking for technical user documentation?
 [Find it here](./docs/README.md)

--- a/backend/cosmetology-app/app_clients/README.md
+++ b/backend/cosmetology-app/app_clients/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This document is a guide for technical staff for managing Cognito app clients for machine-to-machine authentication in
-the State API. All app clients must be documented in the external 'Compact Connect App Client Registry' Google Sheet
+the State API. All app clients must be documented in the external 'CompactConnect App Client Registry' Google Sheet
 (If you do not have access to said registry, contact a maintainer of the project and request access).
 
 ## Creating a New App Client

--- a/backend/cosmetology-app/app_clients/bin/create_app_client.py
+++ b/backend/cosmetology-app/app_clients/bin/create_app_client.py
@@ -281,7 +281,7 @@ def print_email_template(environment, compact, state):
     license_upload_url = f'{api_base_urls.get(environment)}/v1/compacts/{compact}/jurisdictions/{state}/licenses'
 
     email_template = f"""
-Thank you for integrating with Compact Connect! You have been designated as the IT professional who is able to handle
+Thank you for integrating with CompactConnect! You have been designated as the IT professional who is able to handle
 credentials for secure machine-to-machine authentication between your state and CompactConnect.
 
 Details for these credentials are:

--- a/backend/cosmetology-app/docs/README.md
+++ b/backend/cosmetology-app/docs/README.md
@@ -1,4 +1,4 @@
-# Compact Connect - technical user guide
+# CompactConnect - technical user guide
 
 This documentation is intended for technical IT staff that plan to integrate with this data system. It will likely grow
 as the features of this system grow. For technical documentation of the internal design of the CompactConnect backend,

--- a/backend/cosmetology-app/docs/devops/README.md
+++ b/backend/cosmetology-app/docs/devops/README.md
@@ -1,4 +1,4 @@
 # DevOps Documentation
 
-This directory contains internal operations and support procedures for the Compact Connect development and support teams.
+This directory contains internal operations and support procedures for the CompactConnect development and support teams.
 This documentation is **NOT** intended for external IT staff.

--- a/backend/cosmetology-app/docs/devops/STAFF_USER_MFA_RECOVERY.md
+++ b/backend/cosmetology-app/docs/devops/STAFF_USER_MFA_RECOVERY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-When a staff user loses access to their Multi-Factor Authentication (MFA) device, they cannot log into the Compact Connect system. 
+When a staff user loses access to their Multi-Factor Authentication (MFA) device, they cannot log into the CompactConnect system. 
 
 A staff user account consists of two parts: a Cognito user to track login information, and a DynamoDB record in the staff
 users DynamoDB table to track permissions and other account data about the user.

--- a/backend/cosmetology-app/lambdas/nodejs/email-notification-service/README.md
+++ b/backend/cosmetology-app/lambdas/nodejs/email-notification-service/README.md
@@ -1,6 +1,6 @@
 # Email Notification Service Lambda
 
-This package contains code required to generate system emails for users in compact connect, as well as
+This package contains code required to generate system emails for users in CompactConnect, as well as
 compacts/jurisdictions staff. It leverages [EmailBuilderJS](https://github.com/usewaypoint/email-builder-js) to dynamically render email HTML content that should
 be rendered consistently across email clients.
 

--- a/backend/cosmetology-app/lambdas/nodejs/lib/email/base-email-service.ts
+++ b/backend/cosmetology-app/lambdas/nodejs/lib/email/base-email-service.ts
@@ -87,7 +87,7 @@ export abstract class BaseEmailService {
                     }
                 },
                 // We're required by the IAM policy to use this display name
-                FromEmailAddress: `Compact Connect <${environmentVariableService.getFromAddress()}>`,
+                FromEmailAddress: `CompactConnect <${environmentVariableService.getFromAddress()}>`,
             });
 
             return (await this.sesClient.send(command)).MessageId;
@@ -119,7 +119,7 @@ export abstract class BaseEmailService {
 
             // Create the email message
             const message = {
-                from: `Compact Connect <${environmentVariableService.getFromAddress()}>`,
+                from: `CompactConnect <${environmentVariableService.getFromAddress()}>`,
                 to: recipients,
                 subject: subject,
                 html: htmlContent,

--- a/backend/cosmetology-app/lambdas/nodejs/package.json
+++ b/backend/cosmetology-app/lambdas/nodejs/package.json
@@ -20,7 +20,7 @@
     "@types/aws-lambda": "8.10.145",
     "@types/jest": "^29.5.12",
     "@types/node": "22.5.4",
-    "@types/nodemailer": "^7.0.4",
+    "@types/nodemailer": "^8.0.0",
     "@types/react": "^18.3.12",
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",

--- a/backend/cosmetology-app/lambdas/nodejs/package.json
+++ b/backend/cosmetology-app/lambdas/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "compact-connect",
   "version": "1.0.0",
   "type": "commonjs",
-  "description": "NodeJS lambdas for Compact Connect",
+  "description": "NodeJS lambdas for CompactConnect",
   "resolutions": {
     "fast-xml-parser": "5.5.7"
   },

--- a/backend/cosmetology-app/lambdas/nodejs/tests/email-notification-service.test.ts
+++ b/backend/cosmetology-app/lambdas/nodejs/tests/email-notification-service.test.ts
@@ -171,7 +171,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -243,7 +243,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -335,7 +335,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -408,7 +408,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -475,7 +475,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -546,7 +546,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -615,7 +615,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -687,7 +687,7 @@ describe('EmailNotificationServiceLambda', () => {
                             Data: 'Privilege Encumbrance Lifted Notification - John Doe'
                         }
                     }},
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -777,7 +777,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -869,7 +869,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -959,7 +959,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -1051,7 +1051,7 @@ describe('EmailNotificationServiceLambda', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 

--- a/backend/cosmetology-app/lambdas/nodejs/tests/lib/email/encumbrance-notification-service.test.ts
+++ b/backend/cosmetology-app/lambdas/nodejs/tests/lib/email/encumbrance-notification-service.test.ts
@@ -137,7 +137,7 @@ describe('EncumbranceNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -187,7 +187,7 @@ describe('EncumbranceNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -265,7 +265,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -321,7 +321,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -400,7 +400,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -456,7 +456,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
 
@@ -559,7 +559,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
         });
@@ -615,7 +615,7 @@ describe('EncumbranceNotificationService', () => {
                             }
                         }
                     },
-                    FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                    FromEmailAddress: 'CompactConnect <noreply@example.org>'
                 }
             );
 

--- a/backend/cosmetology-app/lambdas/nodejs/tests/lib/email/ingest-event-email-service.test.ts
+++ b/backend/cosmetology-app/lambdas/nodejs/tests/lib/email/ingest-event-email-service.test.ts
@@ -110,7 +110,7 @@ describe('IngestEventEmailService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             }
         );
     });
@@ -157,7 +157,7 @@ describe('IngestEventEmailService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             }
         );
     });
@@ -190,7 +190,7 @@ describe('IngestEventEmailService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             }
         );
     });

--- a/backend/cosmetology-app/lambdas/nodejs/tests/lib/email/investigation-notification-service.test.ts
+++ b/backend/cosmetology-app/lambdas/nodejs/tests/lib/email/investigation-notification-service.test.ts
@@ -137,7 +137,7 @@ describe('InvestigationNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
 
@@ -189,7 +189,7 @@ describe('InvestigationNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
     });
@@ -224,7 +224,7 @@ describe('InvestigationNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
     });
@@ -259,7 +259,7 @@ describe('InvestigationNotificationService', () => {
                         }
                     }
                 },
-                FromEmailAddress: 'Compact Connect <noreply@example.org>'
+                FromEmailAddress: 'CompactConnect <noreply@example.org>'
             });
         });
     });

--- a/backend/cosmetology-app/lambdas/nodejs/yarn.lock
+++ b/backend/cosmetology-app/lambdas/nodejs/yarn.lock
@@ -2450,10 +2450,10 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/nodemailer@^7.0.4":
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-7.0.9.tgz#a19e3fa222b21213b481cdbdbc70a06787ea49e8"
-  integrity sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow==
+"@types/nodemailer@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-8.0.0.tgz#ea189a9c151c04cc65c8a2a4c668c65d952a24e2"
+  integrity sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==
   dependencies:
     "@types/node" "*"
 

--- a/backend/cosmetology-app/lambdas/python/cognito-backup/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/cognito-backup/requirements-dev.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/cognito-backup/requirements-dev.in
 #
-aws-lambda-powertools==3.26.0
+aws-lambda-powertools==3.27.0
     # via -r lambdas/python/cognito-backup/requirements-dev.in
-boto3==1.42.80
+boto3==1.42.89
     # via
     #   -r lambdas/python/cognito-backup/requirements-dev.in
     #   moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   -r lambdas/python/cognito-backup/requirements-dev.in
     #   boto3
@@ -20,9 +20,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   joserfc
     #   moto
@@ -37,7 +37,7 @@ jmespath==1.1.0
     #   aws-lambda-powertools
     #   boto3
     #   botocore
-joserfc==1.6.3
+joserfc==1.6.4
     # via moto
 markupsafe==3.0.3
     # via
@@ -55,7 +55,7 @@ pycparser==3.0
     # via cffi
 pygments==2.20.0
     # via pytest
-pytest==9.0.2
+pytest==9.0.3
     # via -r lambdas/python/cognito-backup/requirements-dev.in
 python-dateutil==2.9.0.post0
     # via
@@ -82,7 +82,7 @@ urllib3==2.6.3
     #   botocore
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/cognito-backup/requirements.txt
+++ b/backend/cosmetology-app/lambdas/python/cognito-backup/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/cognito-backup/requirements.in
 #
-aws-lambda-powertools==3.26.0
+aws-lambda-powertools==3.27.0
     # via -r lambdas/python/cognito-backup/requirements.in
-boto3==1.42.80
+boto3==1.42.89
     # via -r lambdas/python/cognito-backup/requirements.in
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   -r lambdas/python/cognito-backup/requirements.in
     #   boto3

--- a/backend/cosmetology-app/lambdas/python/common/cc_common/data_model/provider_record_util.py
+++ b/backend/cosmetology-app/lambdas/python/common/cc_common/data_model/provider_record_util.py
@@ -482,18 +482,14 @@ class ProviderUserRecords:
                 inv_records = self.get_investigation_records_for_privilege(
                     jurisdiction, license_type_abbr, include_closed=False
                 )
-                if (
-                    not is_eligible
-                    and not include_inactive_privileges
-                    and not privilege_aa
-                    and not inv_records
-                ):
-                    logger.debug('Not returning a privilege for this jurisdiction because the home '
-                    'license is not compact eligible and there are no matching privilege adverse '
-                    'actions or open investigations.',
-                    jurisdiction=jurisdiction,
-                    home_jurisdiction=home_jurisdiction,
-                    license_type_abbr=license_type_abbr,
+                if not is_eligible and not include_inactive_privileges and not privilege_aa and not inv_records:
+                    logger.debug(
+                        'Not returning a privilege for this jurisdiction because the home '
+                        'license is not compact eligible and there are no matching privilege adverse '
+                        'actions or open investigations.',
+                        jurisdiction=jurisdiction,
+                        home_jurisdiction=home_jurisdiction,
+                        license_type_abbr=license_type_abbr,
                     )
                     continue
                 privilege_dict = {

--- a/backend/cosmetology-app/lambdas/python/common/requirements-dev.in
+++ b/backend/cosmetology-app/lambdas/python/common/requirements-dev.in
@@ -2,6 +2,6 @@
 attrs>=25.4,<26
 moto[all]>=5.0.12, <6
 boto3-stubs[full]
-Faker>=37, <38
+Faker>=40, <41
 cryptography>=46, <47
 attrs>=25, <26

--- a/backend/cosmetology-app/lambdas/python/common/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/common/requirements-dev.txt
@@ -50,7 +50,7 @@ cryptography==46.0.7
     #   moto
 docker==7.1.0
     # via moto
-faker==37.12.0
+faker==40.13.0
     # via -r lambdas/python/common/requirements-dev.in
 graphql-core==3.2.8
     # via moto
@@ -177,8 +177,6 @@ typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings
-tzdata==2026.1
-    # via faker
 urllib3==2.6.3
     # via
     #   botocore

--- a/backend/cosmetology-app/lambdas/python/common/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/common/requirements-dev.txt
@@ -19,15 +19,15 @@ aws-sam-translator==1.103.0
     #   moto
 aws-xray-sdk==2.15.0
     # via moto
-boto3==1.42.80
+boto3==1.42.89
     # via
     #   aws-sam-translator
     #   moto
-boto3-stubs[full]==1.42.80
+boto3-stubs[full]==1.42.89
     # via -r lambdas/python/common/requirements-dev.in
-boto3-stubs-full==1.42.80
+boto3-stubs-full==1.42.88
     # via boto3-stubs
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   aws-xray-sdk
     #   boto3
@@ -41,9 +41,9 @@ cffi==2.0.0
     # via cryptography
 cfn-lint==1.41.0
     # via moto
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   -r lambdas/python/common/requirements-dev.in
     #   joserfc
@@ -62,7 +62,7 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-joserfc==1.6.3
+joserfc==1.6.4
     # via moto
 jsonpatch==1.33
     # via cfn-lint
@@ -139,7 +139,7 @@ referencing==0.37.0
     #   jsonschema-path
     #   jsonschema-specifications
     #   openapi-schema-validator
-regex==2026.3.32
+regex==2026.4.4
     # via cfn-lint
 requests==2.33.1
     # via
@@ -177,7 +177,7 @@ typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings
-tzdata==2025.3
+tzdata==2026.1
     # via faker
 urllib3==2.6.3
     # via
@@ -185,7 +185,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 wrapt==2.1.2
     # via aws-xray-sdk

--- a/backend/cosmetology-app/lambdas/python/common/requirements.txt
+++ b/backend/cosmetology-app/lambdas/python/common/requirements.txt
@@ -8,11 +8,11 @@ argon2-cffi==25.1.0
     # via -r lambdas/python/common/requirements.in
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-aws-lambda-powertools==3.26.0
+aws-lambda-powertools==3.27.0
     # via -r lambdas/python/common/requirements.in
-boto3==1.42.80
+boto3==1.42.89
     # via -r lambdas/python/common/requirements.in
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   s3transfer
@@ -22,9 +22,9 @@ cffi==2.0.0
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via -r lambdas/python/common/requirements.in
 idna==3.11
     # via requests

--- a/backend/cosmetology-app/lambdas/python/compact-configuration/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/compact-configuration/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/compact-configuration/requirements-dev.in
 #
-boto3==1.42.80
+boto3==1.42.89
     # via moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -15,9 +15,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -64,7 +64,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/custom-resources/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/custom-resources/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/custom-resources/requirements-dev.in
 #
-boto3==1.42.80
+boto3==1.42.89
     # via moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -15,9 +15,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -64,7 +64,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/data-events/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/data-events/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/data-events/requirements-dev.in
 #
-boto3==1.42.80
+boto3==1.42.89
     # via moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -15,9 +15,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -64,7 +64,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/disaster-recovery/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/disaster-recovery/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/disaster-recovery/requirements-dev.in
 #
-boto3==1.42.80
+boto3==1.42.89
     # via moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -15,9 +15,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -64,7 +64,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/provider-data-v1/requirements-dev.in
+++ b/backend/cosmetology-app/lambdas/python/provider-data-v1/requirements-dev.in
@@ -1,2 +1,2 @@
 moto[dynamodb, s3]>=5.0.12, <6
-Faker>=37, <38
+Faker>=40, <41

--- a/backend/cosmetology-app/lambdas/python/provider-data-v1/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/provider-data-v1/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/provider-data-v1/requirements-dev.in
 #
-boto3==1.42.80
+boto3==1.42.89
     # via moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -15,9 +15,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -60,7 +60,7 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-tzdata==2025.3
+tzdata==2026.1
     # via faker
 urllib3==2.6.3
     # via
@@ -68,7 +68,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/provider-data-v1/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/provider-data-v1/requirements-dev.txt
@@ -21,7 +21,7 @@ cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
-faker==37.12.0
+faker==40.13.0
     # via -r lambdas/python/provider-data-v1/requirements-dev.in
 idna==3.11
     # via requests
@@ -60,8 +60,6 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-tzdata==2026.1
-    # via faker
 urllib3==2.6.3
     # via
     #   botocore

--- a/backend/cosmetology-app/lambdas/python/search/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/search/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/search/requirements-dev.in
 #
-boto3==1.42.80
+boto3==1.42.89
     # via moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -15,9 +15,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -62,7 +62,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/search/requirements.txt
+++ b/backend/cosmetology-app/lambdas/python/search/requirements.txt
@@ -8,7 +8,7 @@ certifi==2026.2.25
     # via
     #   opensearch-py
     #   requests
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
 events==0.5
     # via opensearch-py

--- a/backend/cosmetology-app/lambdas/python/staff-user-pre-token/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/staff-user-pre-token/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/staff-user-pre-token/requirements-dev.in
 #
-boto3==1.42.80
+boto3==1.42.89
     # via moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -15,9 +15,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via moto
 docker==7.1.0
     # via moto
@@ -64,7 +64,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/staff-users/requirements-dev.in
+++ b/backend/cosmetology-app/lambdas/python/staff-users/requirements-dev.in
@@ -1,2 +1,2 @@
 moto[dynamodb, s3, cognitoidp]>=5.0.15, <6
-Faker>=37, <38
+Faker>=40, <41

--- a/backend/cosmetology-app/lambdas/python/staff-users/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/staff-users/requirements-dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --no-strip-extras lambdas/python/staff-users/requirements-dev.in
 #
-boto3==1.42.80
+boto3==1.42.89
     # via moto
-botocore==1.42.80
+botocore==1.42.89
     # via
     #   boto3
     #   moto
@@ -15,9 +15,9 @@ certifi==2026.2.25
     # via requests
 cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   joserfc
     #   moto
@@ -33,7 +33,7 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-joserfc==1.6.3
+joserfc==1.6.4
     # via moto
 markupsafe==3.0.3
     # via
@@ -64,7 +64,7 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-tzdata==2025.3
+tzdata==2026.1
     # via faker
 urllib3==2.6.3
     # via
@@ -72,7 +72,7 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/backend/cosmetology-app/lambdas/python/staff-users/requirements-dev.txt
+++ b/backend/cosmetology-app/lambdas/python/staff-users/requirements-dev.txt
@@ -23,7 +23,7 @@ cryptography==46.0.7
     #   moto
 docker==7.1.0
     # via moto
-faker==37.12.0
+faker==40.13.0
     # via -r lambdas/python/staff-users/requirements-dev.in
 idna==3.11
     # via requests
@@ -64,8 +64,6 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-tzdata==2026.1
-    # via faker
 urllib3==2.6.3
     # via
     #   botocore

--- a/backend/cosmetology-app/requirements-dev.in
+++ b/backend/cosmetology-app/requirements-dev.in
@@ -4,4 +4,4 @@ coverage
 ruff
 pip-tools
 pip-audit
-Faker>=37, <38
+Faker>=40, <41

--- a/backend/cosmetology-app/requirements-dev.txt
+++ b/backend/cosmetology-app/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 boolean-py==5.0
     # via license-expression
-build==1.4.2
+build==1.4.3
     # via pip-tools
 cachecontrol[filecache]==0.14.4
     # via
@@ -14,9 +14,9 @@ cachecontrol[filecache]==0.14.4
     #   pip-audit
 certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.2
     # via pip-tools
 coverage[toml]==7.13.5
     # via
@@ -59,7 +59,7 @@ pip-requirements-parser==32.0.1
     # via pip-audit
 pip-tools==7.5.3
     # via -r requirements-dev.in
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via pip-audit
 pluggy==1.6.0
     # via
@@ -77,7 +77,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -87,9 +87,9 @@ requests==2.33.1
     # via
     #   cachecontrol
     #   pip-audit
-rich==14.3.3
+rich==15.0.0
     # via pip-audit
-ruff==0.15.8
+ruff==0.15.10
     # via -r requirements-dev.in
 sortedcontainers==2.4.0
     # via cyclonedx-python-lib
@@ -97,7 +97,7 @@ tomli==2.4.1
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
-tzdata==2025.3
+tzdata==2026.1
     # via faker
 urllib3==2.6.3
     # via requests

--- a/backend/cosmetology-app/requirements-dev.txt
+++ b/backend/cosmetology-app/requirements-dev.txt
@@ -26,7 +26,7 @@ cyclonedx-python-lib==11.7.0
     # via pip-audit
 defusedxml==0.7.1
     # via py-serializable
-faker==37.12.0
+faker==40.13.0
     # via -r requirements-dev.in
 filelock==3.25.2
     # via cachecontrol
@@ -97,8 +97,6 @@ tomli==2.4.1
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
-tzdata==2026.1
-    # via faker
 urllib3==2.6.3
     # via requests
 wheel==0.46.3

--- a/backend/cosmetology-app/requirements.txt
+++ b/backend/cosmetology-app/requirements.txt
@@ -8,15 +8,15 @@ attrs==25.4.0
     # via
     #   cattrs
     #   jsii
-aws-cdk-asset-awscli-v1==2.2.263
+aws-cdk-asset-awscli-v1==2.2.273
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.1
     # via aws-cdk-lib
-aws-cdk-aws-lambda-python-alpha==2.246.0a0
+aws-cdk-aws-lambda-python-alpha==2.249.0a0
     # via -r requirements.in
-aws-cdk-cloud-assembly-schema==53.11.0
+aws-cdk-cloud-assembly-schema==53.14.0
     # via aws-cdk-lib
-aws-cdk-lib==2.246.0
+aws-cdk-lib==2.249.0
     # via
     #   -r requirements.in
     #   aws-cdk-aws-lambda-python-alpha
@@ -31,9 +31,9 @@ constructs==10.6.0
     #   aws-cdk-aws-lambda-python-alpha
     #   aws-cdk-lib
     #   cdk-nag
-importlib-resources==6.5.2
+importlib-resources==7.1.0
     # via jsii
-jsii==1.127.0
+jsii==1.128.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-node-proxy-agent-v6

--- a/backend/cosmetology-app/stacks/persistent_stack/__init__.py
+++ b/backend/cosmetology-app/stacks/persistent_stack/__init__.py
@@ -369,7 +369,7 @@ class PersistentStack(AppStack):
             )
 
         # Two statements so either display name is allowed during migration from "Compact Connect" to "CompactConnect".
-        # TODO: Remove the "Compact Connect" display name once all Lambda code exclusively uses "CompactConnect".
+        # TODO: Remove the "Compact Connect" display name once all Lambda code exclusively uses "CompactConnect".  # noqa: FIX002, E501
         for display_name in ('Compact Connect', 'CompactConnect'):
             lambda_function.role.add_to_principal_policy(
                 PolicyStatement(
@@ -377,8 +377,8 @@ class PersistentStack(AppStack):
                     resources=ses_resources,
                     effect=Effect.ALLOW,
                     conditions={
-                        # To mitigate the pretty open resources section for sandbox environments, we'll restrict the use of
-                        # this action by specifying what From address and display name the principal must use.
+                        # To mitigate the pretty open resources section for sandbox environments, we'll restrict the
+                        # use of this action by specifying what From address and display name the principal must use.
                         'StringEquals': {
                             'ses:FromAddress': f'noreply@{self.user_email_notifications.email_identity.email_identity_name}',  # noqa: E501 line too long
                             'ses:FromDisplayName': display_name,

--- a/backend/cosmetology-app/stacks/persistent_stack/__init__.py
+++ b/backend/cosmetology-app/stacks/persistent_stack/__init__.py
@@ -368,7 +368,6 @@ class PersistentStack(AppStack):
                 ),
             )
 
-
         lambda_function.role.add_to_principal_policy(
             PolicyStatement(
                 actions=['ses:SendEmail', 'ses:SendRawEmail'],

--- a/backend/cosmetology-app/stacks/persistent_stack/__init__.py
+++ b/backend/cosmetology-app/stacks/persistent_stack/__init__.py
@@ -368,24 +368,22 @@ class PersistentStack(AppStack):
                 ),
             )
 
-        # Two statements so either display name is allowed during migration from "Compact Connect" to "CompactConnect".
-        # TODO: Remove the "Compact Connect" display name once all Lambda code exclusively uses "CompactConnect".  # noqa: FIX002, E501
-        for display_name in ('Compact Connect', 'CompactConnect'):
-            lambda_function.role.add_to_principal_policy(
-                PolicyStatement(
-                    actions=['ses:SendEmail', 'ses:SendRawEmail'],
-                    resources=ses_resources,
-                    effect=Effect.ALLOW,
-                    conditions={
-                        # To mitigate the pretty open resources section for sandbox environments, we'll restrict the
-                        # use of this action by specifying what From address and display name the principal must use.
-                        'StringEquals': {
-                            'ses:FromAddress': f'noreply@{self.user_email_notifications.email_identity.email_identity_name}',  # noqa: E501 line too long
-                            'ses:FromDisplayName': display_name,
-                        }
-                    },
-                )
+
+        lambda_function.role.add_to_principal_policy(
+            PolicyStatement(
+                actions=['ses:SendEmail', 'ses:SendRawEmail'],
+                resources=ses_resources,
+                effect=Effect.ALLOW,
+                conditions={
+                    # To mitigate the pretty open resources section for sandbox environments, we'll restrict the
+                    # use of this action by specifying what From address and display name the principal must use.
+                    'StringEquals': {
+                        'ses:FromAddress': f'noreply@{self.user_email_notifications.email_identity.email_identity_name}',  # noqa: E501 line too long
+                        'ses:FromDisplayName': 'CompactConnect',
+                    }
+                },
             )
+        )
 
     def get_ui_base_path_url(self) -> str:
         """Returns the base URL for the UI."""

--- a/backend/cosmetology-app/stacks/persistent_stack/__init__.py
+++ b/backend/cosmetology-app/stacks/persistent_stack/__init__.py
@@ -368,21 +368,24 @@ class PersistentStack(AppStack):
                 ),
             )
 
-        lambda_function.role.add_to_principal_policy(
-            PolicyStatement(
-                actions=['ses:SendEmail', 'ses:SendRawEmail'],
-                resources=ses_resources,
-                effect=Effect.ALLOW,
-                conditions={
-                    # To mitigate the pretty open resources section for sandbox environments, we'll restrict the use of
-                    # this action by specifying what From address and display name the principal must use.
-                    'StringEquals': {
-                        'ses:FromAddress': f'noreply@{self.user_email_notifications.email_identity.email_identity_name}',  # noqa: E501 line too long
-                        'ses:FromDisplayName': 'Compact Connect',
-                    }
-                },
+        # Two statements so either display name is allowed during migration from "Compact Connect" to "CompactConnect".
+        # TODO: Remove the "Compact Connect" display name once all Lambda code exclusively uses "CompactConnect".
+        for display_name in ('Compact Connect', 'CompactConnect'):
+            lambda_function.role.add_to_principal_policy(
+                PolicyStatement(
+                    actions=['ses:SendEmail', 'ses:SendRawEmail'],
+                    resources=ses_resources,
+                    effect=Effect.ALLOW,
+                    conditions={
+                        # To mitigate the pretty open resources section for sandbox environments, we'll restrict the use of
+                        # this action by specifying what From address and display name the principal must use.
+                        'StringEquals': {
+                            'ses:FromAddress': f'noreply@{self.user_email_notifications.email_identity.email_identity_name}',  # noqa: E501 line too long
+                            'ses:FromDisplayName': display_name,
+                        }
+                    },
+                )
             )
-        )
 
     def get_ui_base_path_url(self) -> str:
         """Returns the base URL for the UI."""


### PR DESCRIPTION
The display name for the email addresses was originally configured with a space between Compact and Connect. This display name is specified by an IAM policy that must be updated in order to specify the corrected 'CompactConnect' display name. To avoid downtime, we need to update the policy to support both during the first deployment, then remove the old policy once the change is verified in production. 

This also makes several needed dependency updates in an attempt to cut down on the many Dependabot PRs we currently have in place.

Closes #1428 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized branding from "Compact Connect" → "CompactConnect" across outgoing emails, templates, documentation, package metadata, and IAM/email permissions.
  * Bumped multiple Python and Node.js dependency versions (AWS SDKs, testing tools, nodemailer types, etc.).

* **Tests**
  * Updated test expectations to match the revised sender display name and adjusted email subjects/bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->