### PR TITLE
fix/ zap scan

### DIFF
--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -1,9 +1,6 @@
 name: ZAP-Scan-Test
 
 on:
-  pull_request:
-    branches:
-      - main
   # Weekly scheduled scan of the deployed test environment
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      security-events: write
 
     steps:
       - name: Log trigger info
@@ -59,6 +60,12 @@ jobs:
         uses: zaproxy/action-af@v0.1.0
         with:
           plan: 'owasp-zap/data/test-automation.yml'
+
+      - name: Upload SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: report/zap-results.sarif
 
       - name: Upload Report
         if: always()

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -1,44 +1,35 @@
-# Compact Connect - Web Frontend Deployment - Development
-
 name: ZAP-Scan-Test
 
-# Controls when the action will run.
 on:
-  pull_request:
-    branches:
-      - main
+  # Weekly scheduled scan of the deployed test environment
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Manual trigger for ad-hoc runs
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   ZapScan:
-    # Runner OS
     runs-on: ubuntu-latest
 
-    # Job needs id-token access to work with GitHub OIDC to AWS IAM Role
     permissions:
       id-token: write
       contents: read
 
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Log trigger info
+        run: |
+          echo "Triggered by: ${{ github.event_name }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "Ref: ${{ github.ref }}"
 
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: '22.1.0'
 
-      # Use any cached yarn dependencies (saves build time)
       - uses: actions/cache@v4
         with:
           path: '**/node_modules'
@@ -56,8 +47,12 @@ jobs:
           COGNITO_PASSWORD: ${{ secrets.TEST_ZAP_PASSWORD_STAFF }}
         run: |
           token=$(node main.js | jq -r '.accessToken')
-          [[ -z "$token" ]] && exit 1
+          if [[ -z "$token" || "$token" == "null" ]]; then
+            echo "::error::Failed to obtain authentication token"
+            exit 1
+          fi
           echo "ZAP_AUTH_HEADER_VALUE=$token" >> "$GITHUB_ENV"
+          echo "Authentication successful"
         working-directory: 'owasp-zap/authenticator'
 
       - name: ZAP Scan

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -18,7 +18,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      security-events: write
 
     steps:
       - name: Log trigger info
@@ -69,12 +68,6 @@ jobs:
         uses: zaproxy/action-af@v0.1.0
         with:
           plan: 'owasp-zap/data/test-automation.yml'
-
-      - name: Upload SARIF to GitHub Security
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: report/zap-results.sarif.json
 
       - name: Upload Report
         if: always()

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: report/zap-results.sarif.json
 

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -68,7 +68,7 @@ jobs:
         if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: report/zap-results.sarif
+          sarif_file: report/zap-results.sarif.json
 
       - name: Upload Report
         if: always()

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -63,6 +63,9 @@ jobs:
           python3 owasp-zap/enrich-oas-for-zap.py \
             backend/compact-connect/docs/internal/api-specification/latest-oas30.json \
             backend/compact-connect/docs/internal/api-specification/latest-oas30-zap.json
+          python3 owasp-zap/enrich-oas-for-zap.py \
+            backend/compact-connect/docs/search-internal/api-specification/latest-oas30.json \
+            backend/compact-connect/docs/search-internal/api-specification/latest-oas30-zap.json
 
       - name: ZAP Scan
         uses: zaproxy/action-af@v0.1.0

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -59,6 +59,12 @@ jobs:
           echo "Authentication successful"
         working-directory: 'owasp-zap/authenticator'
 
+      - name: Enrich OpenAPI specs with valid parameter examples
+        run: |
+          python3 owasp-zap/enrich-oas-for-zap.py \
+            backend/compact-connect/docs/internal/api-specification/latest-oas30.json \
+            backend/compact-connect/docs/internal/api-specification/latest-oas30-zap.json
+
       - name: ZAP Scan
         uses: zaproxy/action-af@v0.1.0
         with:

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -1,9 +1,9 @@
 name: ZAP-Scan-Test
 
 on:
-   pull_request:
-     branches:
-       - main
+  pull_request:
+    branches:
+      - main
   # Weekly scheduled scan of the deployed test environment
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC

--- a/.github/workflows/zap-scan-test.yml
+++ b/.github/workflows/zap-scan-test.yml
@@ -1,6 +1,9 @@
 name: ZAP-Scan-Test
 
 on:
+   pull_request:
+     branches:
+       - main
   # Weekly scheduled scan of the deployed test environment
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -3,8 +3,10 @@ env:
   - name: test
     urls:
     - https://api.test.compactconnect.org
+    - https://search.test.compactconnect.org
     includePaths:
     - https://api.test.compactconnect.org.*
+    - https://search.test.compactconnect.org.*
     authentication:
       verification:
         method: response
@@ -40,6 +42,13 @@ jobs:
     apiFile: /zap/wrk/backend/compact-connect/docs/internal/api-specification/latest-oas30-zap.json
     apiUrl: ""
     targetUrl: "https://api.test.compactconnect.org"
+    context: test
+    user: ""
+- type: openapi
+  parameters:
+    apiFile: /zap/wrk/backend/compact-connect/docs/search-internal/api-specification/latest-oas30-zap.json
+    apiUrl: ""
+    targetUrl: "https://search.test.compactconnect.org"
     context: test
     user: ""
 # Suppress known false positives

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -44,6 +44,54 @@ jobs:
     targetUrl: "https://api.test.compactconnect.org"
     context: test
     user: ""
+# Seed requests with valid test data so ZAP gets 200 responses to fuzz from.
+# Without these, ZAP uses literal parameter names as values (e.g. "compact"
+# instead of "aslp") and every request fails validation.
+# Public endpoints (no auth required)
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/public/compacts
+    method: GET
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/public/compacts/aslp/jurisdictions
+    method: GET
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/public/jurisdictions
+    method: GET
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/public/compacts/aslp/providers/query
+    method: POST
+    data: '{"query":{"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2026-12-31T00:00:00Z"}}'
+    headers:
+      Content-Type: application/json
+# Authenticated endpoints with valid test data
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/59f0f54f-7bd6-463d-96eb-1fd9d804d2fc
+    method: GET
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/579371d3-b7e0-4bc6-a4e2-aac28a5bda67
+    method: GET
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/8a5c974c-fe70-43a9-9186-eca2e6ad9802
+    method: GET
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh/licenses/bulk-upload
+    method: GET
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/ky/licenses/bulk-upload
+    method: GET
+- type: requestor
+  parameters:
+    url: https://api.test.compactconnect.org/v1/compacts/aslp/staff-users/me
+    method: GET
 - type: passiveScan-config
   parameters: {}
 - type: spider

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -44,47 +44,6 @@ jobs:
     targetUrl: "https://api.test.compactconnect.org"
     context: test
     user: ""
-# Seed requests with valid test data so ZAP gets 200 responses to fuzz from.
-# Without these, ZAP uses literal parameter names as values (e.g. "compact"
-# instead of "aslp") and every request fails validation.
-- type: requestor
-  parameters: {}
-  requests:
-  # Public endpoints (no auth required)
-  - url: https://api.test.compactconnect.org/v1/public/compacts
-    method: GET
-    responseCode: 200
-  - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/jurisdictions
-    method: GET
-    responseCode: 200
-  - url: https://api.test.compactconnect.org/v1/public/jurisdictions
-    method: GET
-    responseCode: 200
-  - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/providers/query
-    method: POST
-    data: '{"query":{"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2026-12-31T00:00:00Z"}}'
-    responseCode: 200
-  # Authenticated endpoints — providers with real test data
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/59f0f54f-7bd6-463d-96eb-1fd9d804d2fc
-    method: GET
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/33f813a7-9526-4bba-95d6-570fcc2a5a12
-    method: GET
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/8a5c974c-fe70-43a9-9186-eca2e6ad9802
-    method: GET
-  # Staff user endpoints
-  - url: https://api.test.compactconnect.org/v1/staff-users/me
-    method: GET
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/staff-users
-    method: GET
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/staff-users/740864a8-8091-7097-3bb4-d96fb1619a15
-    method: GET
-  # Jurisdiction and license endpoints
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh/licenses/bulk-upload
-    method: GET
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/ky/licenses/bulk-upload
-    method: GET
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh
-    method: GET
 - type: passiveScan-config
   parameters: {}
 - type: spider

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -64,19 +64,26 @@ jobs:
     method: POST
     data: '{"query":{"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2026-12-31T00:00:00Z"}}'
     responseCode: 200
-  # Authenticated endpoints with valid test provider IDs
+  # Authenticated endpoints — providers with real test data
   - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/59f0f54f-7bd6-463d-96eb-1fd9d804d2fc
     method: GET
-  - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/579371d3-b7e0-4bc6-a4e2-aac28a5bda67
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/33f813a7-9526-4bba-95d6-570fcc2a5a12
     method: GET
   - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/8a5c974c-fe70-43a9-9186-eca2e6ad9802
     method: GET
-  # Authenticated staff endpoints
+  # Staff user endpoints
+  - url: https://api.test.compactconnect.org/v1/staff-users/me
+    method: GET
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/staff-users
+    method: GET
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/staff-users/740864a8-8091-7097-3bb4-d96fb1619a15
+    method: GET
+  # Jurisdiction and license endpoints
   - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh/licenses/bulk-upload
     method: GET
   - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/ky/licenses/bulk-upload
     method: GET
-  - url: https://api.test.compactconnect.org/v1/staff-users/me
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh
     method: GET
 - type: passiveScan-config
   parameters: {}

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -2,10 +2,8 @@ env:
   contexts:
   - name: test
     urls:
-    - https://app.test.compactconnect.org
     - https://api.test.compactconnect.org
     includePaths:
-    - https://app.test.compactconnect.org.*
     - https://api.test.compactconnect.org.*
     authentication:
       verification:
@@ -44,21 +42,18 @@ jobs:
     targetUrl: "https://api.test.compactconnect.org"
     context: test
     user: ""
+# Suppress known false positives
+- type: alertFilter
+  alertFilters:
+  # SQL Injection on initiateRecovery — API uses DynamoDB not SQL.
+  # ZAP flags this because the 400 validation error reflects input back,
+  # which looks like successful boolean-based injection.
+  - ruleId: 40018
+    newRisk: "False Positive"
+    url: https://api.test.compactconnect.org/v1/provider-users/initiateRecovery
+    urlRegex: false
 - type: passiveScan-config
   parameters: {}
-- type: spider
-  parameters:
-    context: test
-    maxDuration: 5
-    maxDepth: 5
-    maxChildren: 20
-  tests:
-  - name: At least 20 URLs found
-    type: stats
-    onFail: WARN
-    statistic: automation.spider.urls.added
-    operator: '>='
-    value: 20
 - type: passiveScan-wait
   parameters: {}
 - type: activeScan

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -39,7 +39,7 @@ jobs:
     inline: ""
 - type: openapi
   parameters:
-    apiFile: /zap/wrk/backend/compact-connect/docs/internal/api-specification/latest-oas30.json
+    apiFile: /zap/wrk/backend/compact-connect/docs/internal/api-specification/latest-oas30-zap.json
     apiUrl: ""
     targetUrl: "https://api.test.compactconnect.org"
     context: test

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -135,18 +135,6 @@ jobs:
   - reportParameters
   - requestHeader
   - summaries
-- type: report
-  parameters:
-    template: sarif-json
-    reportDir: /zap/wrk/report
-    reportFile: zap-results.sarif
-    reportTitle: ZAP SARIF Report
-    reportDescription: Test environment ZAP SARIF report for GitHub Security tab
-    displayReport: false
-  risks:
-  - low
-  - medium
-  - high
 - type: exitStatus
   parameters:
     warnExitValue: 0

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -4,11 +4,9 @@ env:
     urls:
     - https://app.test.compactconnect.org
     - https://api.test.compactconnect.org
-    - https://state-api.test.compactconnect.org
     includePaths:
     - https://app.test.compactconnect.org.*
     - https://api.test.compactconnect.org.*
-    - https://state-api.test.compactconnect.org.*
     authentication:
       verification:
         method: response
@@ -39,13 +37,6 @@ jobs:
     engine: ""
     target: ""
     inline: ""
-- type: openapi
-  parameters:
-    apiFile: /zap/wrk/backend/compact-connect/docs/api-specification/latest-oas30.json
-    apiUrl: ""
-    targetUrl: "https://state-api.test.compactconnect.org"
-    context: test
-    user: ""
 - type: openapi
   parameters:
     apiFile: /zap/wrk/backend/compact-connect/docs/internal/api-specification/latest-oas30.json

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -62,9 +62,6 @@ jobs:
     responseCode: 200
   - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/providers/query
     method: POST
-    headers:
-    - name: Content-Type
-      value: application/json
     data: '{"query":{"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2026-12-31T00:00:00Z"}}'
     responseCode: 200
   # Authenticated endpoints with valid test provider IDs

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -48,38 +48,39 @@ jobs:
 # Without these, ZAP uses literal parameter names as values (e.g. "compact"
 # instead of "aslp") and every request fails validation.
 - type: requestor
-  parameters:
-    requests:
-    # Public endpoints (no auth required)
-    - url: https://api.test.compactconnect.org/v1/public/compacts
-      method: GET
-      responseCode: 200
-    - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/jurisdictions
-      method: GET
-      responseCode: 200
-    - url: https://api.test.compactconnect.org/v1/public/jurisdictions
-      method: GET
-      responseCode: 200
-    - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/providers/query
-      method: POST
-      headers:
-      - "Content-Type: application/json"
-      data: '{"query":{"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2026-12-31T00:00:00Z"}}'
-      responseCode: 200
-    # Authenticated endpoints with valid test provider IDs
-    - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/59f0f54f-7bd6-463d-96eb-1fd9d804d2fc
-      method: GET
-    - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/579371d3-b7e0-4bc6-a4e2-aac28a5bda67
-      method: GET
-    - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/8a5c974c-fe70-43a9-9186-eca2e6ad9802
-      method: GET
-    # Authenticated staff endpoints
-    - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh/licenses/bulk-upload
-      method: GET
-    - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/ky/licenses/bulk-upload
-      method: GET
-    - url: https://api.test.compactconnect.org/v1/staff-users/me
-      method: GET
+  parameters: {}
+  requests:
+  # Public endpoints (no auth required)
+  - url: https://api.test.compactconnect.org/v1/public/compacts
+    method: GET
+    responseCode: 200
+  - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/jurisdictions
+    method: GET
+    responseCode: 200
+  - url: https://api.test.compactconnect.org/v1/public/jurisdictions
+    method: GET
+    responseCode: 200
+  - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/providers/query
+    method: POST
+    headers:
+    - name: Content-Type
+      value: application/json
+    data: '{"query":{"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2026-12-31T00:00:00Z"}}'
+    responseCode: 200
+  # Authenticated endpoints with valid test provider IDs
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/59f0f54f-7bd6-463d-96eb-1fd9d804d2fc
+    method: GET
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/579371d3-b7e0-4bc6-a4e2-aac28a5bda67
+    method: GET
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/8a5c974c-fe70-43a9-9186-eca2e6ad9802
+    method: GET
+  # Authenticated staff endpoints
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh/licenses/bulk-upload
+    method: GET
+  - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/ky/licenses/bulk-upload
+    method: GET
+  - url: https://api.test.compactconnect.org/v1/staff-users/me
+    method: GET
 - type: passiveScan-config
   parameters: {}
 - type: spider

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -114,6 +114,18 @@ jobs:
   - reportParameters
   - requestHeader
   - summaries
+- type: report
+  parameters:
+    template: sarif-json
+    reportDir: /zap/wrk/report
+    reportFile: zap-results.sarif
+    reportTitle: ZAP SARIF Report
+    reportDescription: Test environment ZAP SARIF report for GitHub Security tab
+    displayReport: false
+  risks:
+  - low
+  - medium
+  - high
 - type: exitStatus
   parameters:
     warnExitValue: 0

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -61,6 +61,14 @@ jobs:
     newRisk: "False Positive"
     url: https://api.test.compactconnect.org/v1/provider-users/initiateRecovery
     urlRegex: false
+  # SQL Injection on payment-processor — ZAP sends injection payloads in
+  # apiLoginId, which gets forwarded to Authorize.net. The different error
+  # message makes ZAP think injection succeeded, but it's just the payment
+  # processor rejecting invalid credentials.
+  - ruleId: 40018
+    newRisk: "False Positive"
+    url: https://api.test.compactconnect.org/v1/compacts/aslp/credentials/payment-processor
+    urlRegex: false
 - type: passiveScan-config
   parameters: {}
 - type: passiveScan-wait

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -47,51 +47,39 @@ jobs:
 # Seed requests with valid test data so ZAP gets 200 responses to fuzz from.
 # Without these, ZAP uses literal parameter names as values (e.g. "compact"
 # instead of "aslp") and every request fails validation.
-# Public endpoints (no auth required)
 - type: requestor
   parameters:
-    url: https://api.test.compactconnect.org/v1/public/compacts
-    method: GET
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/public/compacts/aslp/jurisdictions
-    method: GET
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/public/jurisdictions
-    method: GET
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/public/compacts/aslp/providers/query
-    method: POST
-    data: '{"query":{"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2026-12-31T00:00:00Z"}}'
-    headers:
-      Content-Type: application/json
-# Authenticated endpoints with valid test data
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/59f0f54f-7bd6-463d-96eb-1fd9d804d2fc
-    method: GET
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/579371d3-b7e0-4bc6-a4e2-aac28a5bda67
-    method: GET
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/8a5c974c-fe70-43a9-9186-eca2e6ad9802
-    method: GET
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh/licenses/bulk-upload
-    method: GET
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/ky/licenses/bulk-upload
-    method: GET
-- type: requestor
-  parameters:
-    url: https://api.test.compactconnect.org/v1/compacts/aslp/staff-users/me
-    method: GET
+    requests:
+    # Public endpoints (no auth required)
+    - url: https://api.test.compactconnect.org/v1/public/compacts
+      method: GET
+      responseCode: 200
+    - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/jurisdictions
+      method: GET
+      responseCode: 200
+    - url: https://api.test.compactconnect.org/v1/public/jurisdictions
+      method: GET
+      responseCode: 200
+    - url: https://api.test.compactconnect.org/v1/public/compacts/aslp/providers/query
+      method: POST
+      headers:
+      - "Content-Type: application/json"
+      data: '{"query":{"startDateTime":"2024-01-01T00:00:00Z","endDateTime":"2026-12-31T00:00:00Z"}}'
+      responseCode: 200
+    # Authenticated endpoints with valid test provider IDs
+    - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/59f0f54f-7bd6-463d-96eb-1fd9d804d2fc
+      method: GET
+    - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/579371d3-b7e0-4bc6-a4e2-aac28a5bda67
+      method: GET
+    - url: https://api.test.compactconnect.org/v1/compacts/aslp/providers/8a5c974c-fe70-43a9-9186-eca2e6ad9802
+      method: GET
+    # Authenticated staff endpoints
+    - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/oh/licenses/bulk-upload
+      method: GET
+    - url: https://api.test.compactconnect.org/v1/compacts/aslp/jurisdictions/ky/licenses/bulk-upload
+      method: GET
+    - url: https://api.test.compactconnect.org/v1/staff-users/me
+      method: GET
 - type: passiveScan-config
   parameters: {}
 - type: spider

--- a/owasp-zap/data/test-automation.yml
+++ b/owasp-zap/data/test-automation.yml
@@ -95,28 +95,24 @@ jobs:
 - type: passiveScan-config
   parameters: {}
 - type: spider
-  parameters: {}
+  parameters:
+    context: test
+    maxDuration: 5
+    maxDepth: 5
+    maxChildren: 20
   tests:
-  - name: At least 50 URLs found
+  - name: At least 20 URLs found
     type: stats
-    onFail: INFO
+    onFail: WARN
     statistic: automation.spider.urls.added
     operator: '>='
-    value: 50
-- type: spiderAjax
-  parameters: {}
-  tests:
-  - name: At least 50 URLs found
-    type: stats
-    onFail: INFO
-    statistic: spiderAjax.urls.added
-    operator: '>='
-    value: 50
+    value: 20
 - type: passiveScan-wait
   parameters: {}
 - type: activeScan
-  parameters: {}
-  policyDefinition: {}
+  parameters:
+    context: test
+    maxScanDurationInMins: 45
 - type: report
   parameters:
     template: risk-confidence-html

--- a/owasp-zap/enrich-oas-for-zap.py
+++ b/owasp-zap/enrich-oas-for-zap.py
@@ -17,10 +17,10 @@ PARAM_EXAMPLES = {
     "compact": "aslp",
     "jurisdiction": "oh",
     "licenseType": "audiologist",
-    "providerId": "59f0f54f-7bd6-463d-96eb-1fd9d804d2fc",
-    "userId": "00000000-0000-4000-8000-000000000000",
+    "providerId": "33f813a7-9526-4bba-95d6-570fcc2a5a12",
+    "userId": "740864a8-8091-7097-3bb4-d96fb1619a15",
     "attestationId": "00000000-0000-4000-8000-000000000000",
-    "encumbranceId": "00000000-0000-4000-8000-000000000000",
+    "encumbranceId": "c8083de6-19a7-4e9c-8411-09e883fbc8ff",
     "flagId": "00000000-0000-4000-8000-000000000000",
     "investigationId": "00000000-0000-4000-8000-000000000000",
 }

--- a/owasp-zap/enrich-oas-for-zap.py
+++ b/owasp-zap/enrich-oas-for-zap.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Enrich OpenAPI specs with example path parameter values for ZAP scanning.
+
+ZAP's openapi import replaces {paramName} with the literal string "paramName"
+when no example value is provided. This script patches the generated OAS specs
+to include valid example values so ZAP constructs real, reachable URLs.
+
+Usage:
+    python3 enrich-oas-for-zap.py <input.json> <output.json>
+"""
+
+import json
+import sys
+
+# Known valid values for path parameters in the test environment
+PARAM_EXAMPLES = {
+    "compact": "aslp",
+    "jurisdiction": "oh",
+    "licenseType": "audiologist",
+    "providerId": "59f0f54f-7bd6-463d-96eb-1fd9d804d2fc",
+    "userId": "00000000-0000-4000-8000-000000000000",
+    "attestationId": "00000000-0000-4000-8000-000000000000",
+    "encumbranceId": "00000000-0000-4000-8000-000000000000",
+    "flagId": "00000000-0000-4000-8000-000000000000",
+    "investigationId": "00000000-0000-4000-8000-000000000000",
+}
+
+
+def enrich_spec(spec):
+    """Add example values to all path parameters in the spec."""
+    for path, methods in spec.get("paths", {}).items():
+        for method, operation in methods.items():
+            if not isinstance(operation, dict):
+                continue
+            for param in operation.get("parameters", []):
+                if param.get("in") == "path" and "example" not in param:
+                    name = param.get("name", "")
+                    if name in PARAM_EXAMPLES:
+                        param["example"] = PARAM_EXAMPLES[name]
+    return spec
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <input.json> <output.json>", file=sys.stderr)
+        sys.exit(1)
+
+    input_path, output_path = sys.argv[1], sys.argv[2]
+
+    with open(input_path) as f:
+        spec = json.load(f)
+
+    spec = enrich_spec(spec)
+
+    with open(output_path, "w") as f:
+        json.dump(spec, f, indent=2)
+
+    # Count how many parameters were enriched
+    count = 0
+    for path, methods in spec.get("paths", {}).items():
+        for method, operation in methods.items():
+            if not isinstance(operation, dict):
+                continue
+            for param in operation.get("parameters", []):
+                if param.get("in") == "path" and "example" in param:
+                    count += 1
+    print(f"Enriched {count} path parameters with example values")
+
+
+if __name__ == "__main__":
+    main()

--- a/owasp-zap/enrich-oas-for-zap.py
+++ b/owasp-zap/enrich-oas-for-zap.py
@@ -19,7 +19,7 @@ PARAM_EXAMPLES = {
     "licenseType": "audiologist",
     "providerId": "33f813a7-9526-4bba-95d6-570fcc2a5a12",
     "userId": "740864a8-8091-7097-3bb4-d96fb1619a15",
-    "attestationId": "00000000-0000-4000-8000-000000000000",
+    "attestationId": "jurisprudence-confirmation",
     "encumbranceId": "c8083de6-19a7-4e9c-8411-09e883fbc8ff",
     "flagId": "00000000-0000-4000-8000-000000000000",
     "investigationId": "3758ff63-1271-41d5-9257-54689192ac6a",

--- a/owasp-zap/enrich-oas-for-zap.py
+++ b/owasp-zap/enrich-oas-for-zap.py
@@ -22,7 +22,7 @@ PARAM_EXAMPLES = {
     "attestationId": "00000000-0000-4000-8000-000000000000",
     "encumbranceId": "c8083de6-19a7-4e9c-8411-09e883fbc8ff",
     "flagId": "00000000-0000-4000-8000-000000000000",
-    "investigationId": "00000000-0000-4000-8000-000000000000",
+    "investigationId": "442d180d-4bfd-4af1-b4e0-206e449860b6",
 }
 
 

--- a/owasp-zap/enrich-oas-for-zap.py
+++ b/owasp-zap/enrich-oas-for-zap.py
@@ -22,7 +22,7 @@ PARAM_EXAMPLES = {
     "attestationId": "00000000-0000-4000-8000-000000000000",
     "encumbranceId": "c8083de6-19a7-4e9c-8411-09e883fbc8ff",
     "flagId": "00000000-0000-4000-8000-000000000000",
-    "investigationId": "442d180d-4bfd-4af1-b4e0-206e449860b6",
+    "investigationId": "3758ff63-1271-41d5-9257-54689192ac6a",
 }
 
 

--- a/owasp-zap/enrich-oas-for-zap.py
+++ b/owasp-zap/enrich-oas-for-zap.py
@@ -26,9 +26,20 @@ PARAM_EXAMPLES = {
 }
 
 
+# HTTP methods to strip from the spec before ZAP ingests it.
+# DELETE is excluded to prevent ZAP from deleting staff users during scans.
+EXCLUDED_METHODS = {"delete"}
+
+
 def enrich_spec(spec):
     """Add example values to path parameters and fix schema issues."""
-    for path, methods in spec.get("paths", {}).items():
+    for path, methods in list(spec.get("paths", {}).items()):
+        # Remove excluded HTTP methods
+        for method in EXCLUDED_METHODS:
+            if method in methods:
+                del methods[method]
+                print(f"Removed {method.upper()} {path}")
+
         for method, operation in methods.items():
             if not isinstance(operation, dict):
                 continue

--- a/owasp-zap/enrich-oas-for-zap.py
+++ b/owasp-zap/enrich-oas-for-zap.py
@@ -27,7 +27,7 @@ PARAM_EXAMPLES = {
 
 
 def enrich_spec(spec):
-    """Add example values to all path parameters in the spec."""
+    """Add example values to path parameters and fix schema issues."""
     for path, methods in spec.get("paths", {}).items():
         for method, operation in methods.items():
             if not isinstance(operation, dict):
@@ -37,7 +37,24 @@ def enrich_spec(spec):
                     name = param.get("name", "")
                     if name in PARAM_EXAMPLES:
                         param["example"] = PARAM_EXAMPLES[name]
+
+    # Fix arrays missing 'items' — CDK-generated specs sometimes omit this,
+    # which is technically invalid OpenAPI and causes ZAP's parser to fail.
+    for name, schema in spec.get("components", {}).get("schemas", {}).items():
+        _fix_missing_array_items(schema)
+
     return spec
+
+
+def _fix_missing_array_items(obj):
+    """Recursively add items: {type: string} to arrays missing an items field."""
+    if not isinstance(obj, dict):
+        return
+    if obj.get("type") == "array" and "items" not in obj:
+        obj["items"] = {"type": "string"}
+    for value in obj.values():
+        if isinstance(value, dict):
+            _fix_missing_array_items(value)
 
 
 def main():


### PR DESCRIPTION
## Summary

The ZAP scan has been failing on every PR since we switched from a two-branch model (`development` + `main`) to a single `main` branch with tag-based deployments. Two root causes:

- **Secrets inaccessible**: Since IA opens PRs from their fork of CompactConnect, the GitHub Actions `pull_request` trigger gets `Secret source: None` — the Cognito auth step fails immediately.
- **Scanning the wrong state**: The scan targets the deployed test environment, but PR code isn't deployed to test yet, so results are meaningless for the PR anyway.

This PR moves the ZAP scan to a **weekly schedule + manual dispatch**, which matches the original sprint-cadence intent and runs in a context where secrets are available.

### Scan improvements

- **Enriched OAS specs with real test data** — ZAP was using literal parameter names as URL values (e.g. `/compacts/compact/` instead of `/compacts/aslp/`), causing every request to fail validation. A new enrichment script (`owasp-zap/enrich-oas-for-zap.py`) patches the CDK-generated specs with real provider IDs, jurisdiction codes, etc. before ZAP ingests them. New endpoints added to the spec are automatically covered.
- **Removed state API** — it uses a separate Cognito pool (`StateAuthUsers`) from the staff pool, so every request returned 401. Excluded until a state API test credential is provisioned.
- **Removed frontend** (`app.test.compactconnect.org`) — it's an S3-hosted SPA where all findings were CloudFront header configuration issues, not application vulnerabilities.
- **Added search API** (`search.test.compactconnect.org`) to scan coverage.
- **Suppressed known false positives** — SQL injection alerts on `/provider-users/initiateRecovery` (DynamoDB, not SQL) and `/credentials/payment-processor` (error from Authorize.net, not injection).
- **Stripped DELETE endpoints** from the spec to prevent ZAP from deleting staff users during scans.
- **Capped active scan at 45 minutes** to stay under Cognito token expiry (~60m).

### Test user changes

Updated the ZAP scan staff user to have `aslp/admin` compact-level permissions plus full `oh` and `ky` jurisdiction permissions, expanding scope coverage from 4/100 to covering most ASLP endpoints.
 
 
 ### Follow-up
  - Add provider user scanning. Requires a test provider user credential + separate token.
  - Add state API scanning (state-api.test.compactconnect.org) 