### PR TITLE
Frontend/Purchase copy update

### DIFF
--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -634,7 +634,7 @@
         "selectLicense": "Select a license",
         "personalInformation": "Personal information",
         "licenseExpired": "License expired",
-        "purchaseExpirationMessage": "If purchased, these privileges will expire on {date}, the same as the home state license.",
+        "purchaseExpirationMessage": "If purchased, these privileges will expire on {date}.",
         "noRefundsMessage": "All compact privilege purchases are final. Refunds will not be issued.",
         "purchaseFormErrorMessage": "Please correct the errors on the form shown in red",
         "ssn": "SSN",

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -611,7 +611,7 @@
         "ssnLastFour": "Últimos 4 números del SSN",
         "revealFullSsn": "Revelar el SSN completo",
         "incorrectInfoDisclaimer": "La información en esta página fue proporcionada por su estado de origen. Si la información es incorrecta, debe comunicarse con ese estado y pedirles que la corrijan. Consulte la página compacta de Preguntas Frecuentes para obtener más información.",
-        "purchaseExpirationMessage": "Si se adquieren, estos privilegios caducarán el&nbsp; {date}, al igual que la licencia del estado de origen.",
+        "purchaseExpirationMessage": "Si se adquieren, estos privilegios caducarán el {date}.",
         "noRefundsMessage": "Todas las compras de privilegios compactos son definitivas. No se emitirán reembolsos.",
         "purchaseFormErrorMessage": "Por favor, corrija los errores del formulario que se muestran en rojo.",
         "licenseTypeSearch": "Tipo de profesión",


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Update expiration text on privilege purchase Payment Summary screen

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - First checkbox on Payment Summary screen should now read: `If purchased, these privileges will expire on [DATE].`

Closes #1492 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the license expiration message in English and Spanish translations for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csg-org/CompactConnect/pull/1560)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->