### PR TITLE
Frontend/permission statefulness fix

### DIFF
--- a/webroot/src/components/Users/UserRowEdit/UserRowEdit.spec.ts
+++ b/webroot/src/components/Users/UserRowEdit/UserRowEdit.spec.ts
@@ -8,7 +8,54 @@
 import { expect } from 'chai';
 import { mountShallow } from '@tests/helpers/setup';
 import UserRowEdit from '@components/Users/UserRowEdit/UserRowEdit.vue';
-import { StaffUser } from '@models/StaffUser/StaffUser.model';
+import { Permission } from '@/app.config';
+import { Compact, CompactType } from '@models/Compact/Compact.model';
+import { MutationTypes } from '@store/user/user.mutations';
+import {
+    StaffUser,
+    CompactPermission,
+    StatePermission
+} from '@models/StaffUser/StaffUser.model';
+
+const compactType = CompactType.ASLP;
+const buildCompactPermission = (
+    compactOverrides: Partial<CompactPermission> = {},
+    stateOverrides: Array<Partial<StatePermission>> = []
+): CompactPermission => ({
+    compact: new Compact({ type: compactType }),
+    isReadPrivate: false,
+    isReadSsn: false,
+    isAdmin: false,
+    states: stateOverrides.map((stateOverride) => ({
+        state: { abbrev: 'ky' } as any,
+        isReadPrivate: false,
+        isReadSsn: false,
+        isWrite: false,
+        isAdmin: false,
+        ...stateOverride,
+    })),
+    ...compactOverrides,
+});
+const setFormData = (wrapper, data: Record<string, unknown>) => {
+    wrapper.vm.formData = Object.keys(data).reduce((preppedData, key) => ({
+        ...preppedData,
+        [key]: {
+            value: data[key],
+            isDisabled: false,
+            isSubmitInput: false,
+        },
+    }), {});
+};
+const storeSetup = (wrapper) => {
+    wrapper.vm.$store.commit(`user/${MutationTypes.STORE_UPDATE_CURRENT_COMPACT}`, new Compact({ type: compactType }));
+    wrapper.vm.$store.commit(`user/${MutationTypes.STORE_UPDATE_USER}`, new StaffUser({
+        permissions: [buildCompactPermission({
+            isReadPrivate: true,
+            isReadSsn: true,
+            isAdmin: true,
+        })],
+    }));
+};
 
 describe('UserRowEdit component', async () => {
     it('should mount the component', async () => {
@@ -20,5 +67,152 @@ describe('UserRowEdit component', async () => {
 
         expect(wrapper.exists()).to.equal(true);
         expect(wrapper.findComponent(UserRowEdit).exists()).to.equal(true);
+    });
+    it('should successfully preserve missing compact permissions', async () => {
+        const wrapper = await mountShallow(UserRowEdit, {
+            props: {
+                user: new StaffUser(),
+            },
+        });
+
+        storeSetup(wrapper);
+        setFormData(wrapper, {
+            compact: compactType,
+            compactPermission: Permission.NONE,
+        });
+
+        const preppedData = wrapper.vm.prepFormData();
+
+        expect(preppedData).to.deep.equal({
+            compact: compactType,
+            states: [],
+        });
+    });
+    it('should successfully remove compact permissions', async () => {
+        const wrapper = await mountShallow(UserRowEdit, {
+            props: {
+                user: new StaffUser({
+                    permissions: [buildCompactPermission({
+                        isReadPrivate: true,
+                        isReadSsn: false,
+                        isAdmin: true,
+                    })],
+                }),
+            },
+        });
+
+        storeSetup(wrapper);
+        setFormData(wrapper, {
+            compact: compactType,
+            compactPermission: Permission.NONE,
+        });
+
+        const preppedData = wrapper.vm.prepFormData();
+
+        expect(preppedData).to.deep.equal({
+            compact: compactType,
+            isReadPrivate: false,
+            isAdmin: false,
+            states: [],
+        });
+    });
+    it('should successfully preserve missing state permissions', async () => {
+        const wrapper = await mountShallow(UserRowEdit, {
+            props: {
+                user: new StaffUser({
+                    permissions: [buildCompactPermission({}, [
+                        { state: { abbrev: 'ky' }},
+                    ])],
+                }),
+            },
+        });
+
+        storeSetup(wrapper);
+        setFormData(wrapper, {
+            compact: compactType,
+            compactPermission: Permission.NONE,
+            'state-option-0': 'ky',
+            'state-permission-0': Permission.NONE,
+        });
+
+        const preppedData = wrapper.vm.prepFormData();
+
+        expect(preppedData).to.deep.equal({
+            compact: compactType,
+            states: [
+                { abbrev: 'ky' },
+            ],
+        });
+    });
+    it('should successfully remove state permissions', async () => {
+        const wrapper = await mountShallow(UserRowEdit, {
+            props: {
+                user: new StaffUser({
+                    permissions: [buildCompactPermission({}, [
+                        {
+                            state: { abbrev: 'ky' } as any,
+                            isReadPrivate: true,
+                            isReadSsn: true,
+                            isWrite: true,
+                            isAdmin: true,
+                        },
+                    ])],
+                }),
+            },
+        });
+
+        storeSetup(wrapper);
+        setFormData(wrapper, {
+            compact: compactType,
+            compactPermission: Permission.NONE,
+            'state-option-0': 'ky',
+            'state-permission-0': Permission.READ_PRIVATE,
+        });
+
+        const preppedData = wrapper.vm.prepFormData();
+
+        expect(preppedData).to.deep.equal({
+            compact: compactType,
+            states: [
+                {
+                    abbrev: 'ky',
+                    isReadPrivate: true,
+                    isReadSsn: false,
+                    isWrite: false,
+                    isAdmin: false,
+                },
+            ],
+        });
+    });
+    it('should successfully update state permissions', async () => {
+        const wrapper = await mountShallow(UserRowEdit, {
+            props: {
+                user: new StaffUser({
+                    permissions: [buildCompactPermission()],
+                }),
+            },
+        });
+
+        storeSetup(wrapper);
+        setFormData(wrapper, {
+            compact: compactType,
+            compactPermission: Permission.NONE,
+            'state-option-0': 'ky',
+            'state-permission-0': Permission.WRITE,
+        });
+
+        const preppedData = wrapper.vm.prepFormData();
+
+        expect(preppedData).to.deep.equal({
+            compact: compactType,
+            states: [
+                {
+                    abbrev: 'ky',
+                    isReadPrivate: true,
+                    isReadSsn: true,
+                    isWrite: true,
+                },
+            ],
+        });
     });
 });

--- a/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
+++ b/webroot/src/components/Users/UserRowEdit/UserRowEdit.ts
@@ -537,15 +537,18 @@ class UserRowEdit extends mixins(MixinForm) {
 
         // Server endpoints may not be idempotent so the frontend needs to handle statefulness;
         // e.g. if the user's server permisson is already false, we may get a server error if we try to send false again.
-        const existingCompactPermission = this.getCompactPermission(this.rowUserCompactPermission);
+        const existingCompactPermission: CompactPermission | null = this.rowUserCompactPermission;
 
-        if (existingCompactPermission !== Permission.READ_PRIVATE && !compactData.isReadPrivate) {
-            delete compactData.isReadPrivate;
-        }
-        if (existingCompactPermission !== Permission.ADMIN && !compactData.isAdmin) {
+        if (!existingCompactPermission?.isAdmin && !compactData.isAdmin) {
             delete compactData.isAdmin;
         }
-        // End: Handle compact statefulness
+        if (!existingCompactPermission?.isReadSsn && !compactData.isReadSsn) {
+            delete compactData.isReadSsn;
+        }
+        if (!existingCompactPermission?.isReadPrivate && !compactData.isReadPrivate) {
+            delete compactData.isReadPrivate;
+        }
+        // End: Handle compact permission statefulness
 
         stateKeys.forEach((stateKey) => {
             const keyNum = stateKey.split('-').pop();
@@ -558,19 +561,22 @@ class UserRowEdit extends mixins(MixinForm) {
 
             // Server endpoints may not be idempotent so the frontend needs to handle statefulness;
             // e.g. if the user's server permisson is already false, we may get a server error if we try to send false again.
-            const existingStatePermission = this.getStatePermission(this.userStatePermissions.find((permission) =>
-                permission.state?.abbrev === stateAbbrev) || null);
+            const existingStatePermission = existingCompactPermission?.states?.find((permission) =>
+                permission.state?.abbrev === stateAbbrev);
 
-            if (existingStatePermission !== Permission.READ_PRIVATE && !stateData.isReadPrivate) {
-                delete stateData.isReadPrivate;
-            }
-            if (existingStatePermission !== Permission.WRITE && !stateData.isWrite) {
-                delete stateData.isWrite;
-            }
-            if (existingStatePermission !== Permission.ADMIN && !stateData.isAdmin) {
+            if (!existingStatePermission?.isAdmin && !stateData.isAdmin) {
                 delete stateData.isAdmin;
             }
-            // End: Handle state statefulness
+            if (!existingStatePermission?.isWrite && !stateData.isWrite) {
+                delete stateData.isWrite;
+            }
+            if (!existingStatePermission?.isReadSsn && !stateData.isReadSsn) {
+                delete stateData.isReadSsn;
+            }
+            if (!existingStatePermission?.isReadPrivate && !stateData.isReadPrivate) {
+                delete stateData.isReadPrivate;
+            }
+            // End: Handle state permission statefulness
 
             compactData.states.push(stateData);
         });

--- a/webroot/src/models/StaffUser/StaffUser.model.spec.ts
+++ b/webroot/src/models/StaffUser/StaffUser.model.spec.ts
@@ -407,4 +407,197 @@ describe('Staff User model', () => {
             },
         });
     });
+    it('should prepare a Staff User for server request through serializer (compact readPrivate key only)', () => {
+        const data = {
+            permissions: [
+                {
+                    compact: CompactType.ASLP,
+                    isReadPrivate: false,
+                    states: [],
+                },
+            ],
+        };
+        const requestData = StaffUserSerializer.toServer(data);
+
+        expect(requestData).to.matchPattern({
+            permissions: {
+                [CompactType.ASLP]: {
+                    actions: {
+                        readPrivate: false,
+                    },
+                },
+            },
+            '...': '',
+        });
+    });
+    it('should prepare a Staff User for server request through serializer (compact readSSN key only)', () => {
+        const data = {
+            permissions: [
+                {
+                    compact: CompactType.ASLP,
+                    isReadSsn: false,
+                    states: [],
+                },
+            ],
+        };
+        const requestData = StaffUserSerializer.toServer(data);
+
+        expect(requestData).to.matchPattern({
+            permissions: {
+                [CompactType.ASLP]: {
+                    actions: {
+                        readSSN: false,
+                    },
+                },
+            },
+            '...': '',
+        });
+    });
+    it('should prepare a Staff User for server request through serializer (compact admin key only)', () => {
+        const data = {
+            permissions: [
+                {
+                    compact: CompactType.ASLP,
+                    isAdmin: false,
+                    states: [],
+                },
+            ],
+        };
+        const requestData = StaffUserSerializer.toServer(data);
+
+        expect(requestData).to.matchPattern({
+            permissions: {
+                [CompactType.ASLP]: {
+                    actions: {
+                        admin: false,
+                    },
+                },
+            },
+            '...': '',
+        });
+    });
+    it('should prepare a Staff User for server request through serializer (state readPrivate key only)', () => {
+        const data = {
+            permissions: [
+                {
+                    compact: CompactType.ASLP,
+                    states: [
+                        {
+                            abbrev: 'co',
+                            isReadPrivate: false,
+                        },
+                    ],
+                },
+            ],
+        };
+        const requestData = StaffUserSerializer.toServer(data);
+
+        expect(requestData).to.matchPattern({
+            permissions: {
+                [CompactType.ASLP]: {
+                    jurisdictions: {
+                        co: {
+                            actions: {
+                                readPrivate: false,
+                            },
+                        },
+                    },
+                },
+            },
+            '...': '',
+        });
+    });
+    it('should prepare a Staff User for server request through serializer (state readSSN key only)', () => {
+        const data = {
+            permissions: [
+                {
+                    compact: CompactType.ASLP,
+                    states: [
+                        {
+                            abbrev: 'co',
+                            isReadSsn: false,
+                        },
+                    ],
+                },
+            ],
+        };
+        const requestData = StaffUserSerializer.toServer(data);
+
+        expect(requestData).to.matchPattern({
+            permissions: {
+                [CompactType.ASLP]: {
+                    jurisdictions: {
+                        co: {
+                            actions: {
+                                readSSN: false,
+                            },
+                        },
+                    },
+                },
+            },
+            '...': '',
+        });
+    });
+    it('should prepare a Staff User for server request through serializer (state write key only)', () => {
+        const data = {
+            permissions: [
+                {
+                    compact: CompactType.ASLP,
+                    states: [
+                        {
+                            abbrev: 'co',
+                            isWrite: false,
+                        },
+                    ],
+                },
+            ],
+        };
+        const requestData = StaffUserSerializer.toServer(data);
+
+        expect(requestData).to.matchPattern({
+            permissions: {
+                [CompactType.ASLP]: {
+                    jurisdictions: {
+                        co: {
+                            actions: {
+                                write: false,
+                            },
+                        },
+                    },
+                },
+            },
+            '...': '',
+        });
+    });
+    it('should prepare a Staff User for server request through serializer (state admin key only)', () => {
+        const data = {
+            permissions: [
+                {
+                    compact: CompactType.ASLP,
+                    states: [
+                        {
+                            abbrev: 'co',
+                            isAdmin: false,
+                        },
+                    ],
+                },
+            ],
+        };
+        const requestData = StaffUserSerializer.toServer(data);
+
+        expect(requestData).to.matchPattern({
+            permissions: {
+                [CompactType.ASLP]: {
+                    jurisdictions: {
+                        co: {
+                            actions: {
+                                admin: false,
+                            },
+                        },
+                    },
+                },
+            },
+            '...': '',
+        });
+    });
 });

--- a/webroot/src/models/StaffUser/StaffUser.model.ts
+++ b/webroot/src/models/StaffUser/StaffUser.model.ts
@@ -439,7 +439,7 @@ export class StaffUserSerializer {
             const hasStateWriteSetting = Object.prototype.hasOwnProperty.call(statePermission, 'isWrite');
             const hasStateAdminSetting = Object.prototype.hasOwnProperty.call(statePermission, 'isAdmin');
 
-            if (hasStateReadPrivateSetting || hasStateWriteSetting || hasStateAdminSetting) {
+            if (hasStateReadPrivateSetting || hasStateReadSsnSetting || hasStateWriteSetting || hasStateAdminSetting) {
                 const actions: any = {};
 
                 jurisdictions[statePermission.abbrev] = { actions };
@@ -465,7 +465,7 @@ export class StaffUserSerializer {
             const hasCompactAdminSetting = Object.prototype.hasOwnProperty.call(compactPermission, 'isAdmin');
             const hasStates = Boolean(compactPermission.states?.length);
 
-            if (hasCompactReadPrivateSetting || hasCompactAdminSetting) {
+            if (hasCompactReadPrivateSetting || hasCompactReadSsnSetting || hasCompactAdminSetting) {
                 const actions: any = {};
 
                 serverData.permissions[compactPermission.compact] = { actions };


### PR DESCRIPTION
### Requirements List
- _None_

### Description List
- Update UserRowEdit staff user permission payload prep
- Update tests

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- Testing
    - Login as compact admin
    - Find a user other than yourself that has compact "Admin" permission (or create one)
    - Then set the compact admin permission on that user to "None"
    - Update should be applied, user's compact level permission should now persist as "None"

Closes #1576 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure SSN read flags are correctly handled when updating compact and state permissions so payloads reflect intended permission changes.

* **Refactor**
  * Improved client-side comparison logic to avoid sending unchanged compact/state permission flags.

* **Tests**
  * Added unit and component tests covering preservation, removal, and updates of compact and state permissions (including SSN).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csg-org/CompactConnect/pull/1577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->