### PR TITLE
export public lambda arns to avoid CDK deadly embrace lock in beta deployment

### DIFF
--- a/backend/compact-connect/stacks/api_lambda_stack/__init__.py
+++ b/backend/compact-connect/stacks/api_lambda_stack/__init__.py
@@ -134,6 +134,17 @@ class ApiLambdaStack(AppStack):
             api_lambda_stack=self,
         )
 
+        # The public lookup API routes are not deployed in the beta environment (see
+        # api_stack/v1_api/api.py). Removing those routes removes the API stack's cross-stack
+        # imports of these lambda ARNs, which would otherwise delete the auto-generated
+        # CloudFormation exports created here. CloudFormation refuses to delete an export while
+        # another stack still imports it during the same deployment ("deadly embrace"), so we
+        # retain the exports explicitly to safely break the relationship.
+        # TODO: remove these exports once the API stack no longer imports them in every  # noqa: FIX002
+        #  environment.
+        self.export_value(self.public_lookup_lambdas.get_provider_handler.function_arn)
+        self.export_value(self.public_lookup_lambdas.query_providers_handler.function_arn)
+
         # Purchases lambdas
         self.purchases_lambdas = PurchasesLambdas(
             scope=self,

--- a/backend/cosmetology-app/stacks/api_lambda_stack/__init__.py
+++ b/backend/cosmetology-app/stacks/api_lambda_stack/__init__.py
@@ -87,6 +87,20 @@ class ApiLambdaStack(AppStack):
             api_lambda_stack=self,
         )
 
+        # The public GET provider route is wired to get_provider_handler and is not deployed in the
+        # beta environment (see api_stack/v1_api/api.py). Removing that route removes the API stack's
+        # cross-stack import of this lambda ARN, which would otherwise delete the auto-generated
+        # CloudFormation export created here. CloudFormation refuses to delete an export while another
+        # stack still imports it during the same deployment ("deadly embrace"), so we retain it.
+        # TODO: remove this export once the API stack no longer imports it in every environment.  # noqa: FIX002
+        self.export_value(self.public_lookup_lambdas.get_provider_handler.function_arn)
+
+        # query_providers_handler is no longer wired to the API (the public query providers route now
+        # uses SearchPersistentStack.search_handler.public_handler). We retain its export to avoid the
+        # same deadly embrace while the old cross-stack import is removed from already-deployed stacks.
+        # TODO: remove this export (and the unused lambda) once it is deployed to all environments.  # noqa: FIX002
+        self.export_value(self.public_lookup_lambdas.query_providers_handler.function_arn)
+
         # Staff user lambdas
         self.staff_users_lambdas = StaffUsersLambdas(
             scope=self,

--- a/backend/cosmetology-app/stacks/api_lambda_stack/public_lookup_api.py
+++ b/backend/cosmetology-app/stacks/api_lambda_stack/public_lookup_api.py
@@ -43,6 +43,9 @@ class PublicLookupApiLambdas:
         )
         api_lambda_stack.log_groups.append(self.get_provider_handler.log_group)
 
+        # the public query providers endpoint now uses SearchPersistentStack.public_handler;
+        # this lambda is no longer wired to the API.
+        # TODO: remove this lambda after the stack is deployed to all envs  # noqa: FIX002
         self.query_providers_handler = self._query_providers_handler(
             scope=scope,
             env_vars=lambda_environment,
@@ -53,10 +56,6 @@ class PublicLookupApiLambdas:
         )
         api_lambda_stack.log_groups.append(self.query_providers_handler.log_group)
 
-        # Dummy export to avoid CDK deadly embrace: public query providers now uses
-        # SearchPersistentStack.public_handler; this lambda is no longer wired to the API.
-        # TODO: remove this export (and the lambda above) after the stack is deployed to all envs  # noqa: FIX002
-        stack.export_value(self.query_providers_handler.function_arn)
 
     def _get_provider_handler(
         self,

--- a/backend/cosmetology-app/stacks/api_lambda_stack/public_lookup_api.py
+++ b/backend/cosmetology-app/stacks/api_lambda_stack/public_lookup_api.py
@@ -43,7 +43,7 @@ class PublicLookupApiLambdas:
         )
         api_lambda_stack.log_groups.append(self.get_provider_handler.log_group)
 
-        # the public query providers endpoint now uses SearchPersistentStack.public_handler;
+        # the public query providers endpoint now uses SearchPersistentStack.search_handler.public_handler;
         # this lambda is no longer wired to the API.
         # TODO: remove this lambda after the stack is deployed to all envs  # noqa: FIX002
         self.query_providers_handler = self._query_providers_handler(

--- a/backend/cosmetology-app/stacks/search_persistent_stack/__init__.py
+++ b/backend/cosmetology-app/stacks/search_persistent_stack/__init__.py
@@ -113,6 +113,15 @@ class SearchPersistentStack(AppStack):
             export_results_bucket=self.export_results_bucket,
         )
 
+        # The public query providers route (POST /v1/public/.../providers/query) is wired to this
+        # public_handler and is not deployed in the beta environment (see api_stack/v1_api/api.py).
+        # Removing that route removes the API stack's cross-stack import of this lambda ARN, which
+        # would otherwise delete the auto-generated CloudFormation export here. CloudFormation refuses
+        # to delete an export while another stack still imports it during the same deployment ("deadly
+        # embrace"), so we retain the export explicitly to safely break the relationship.
+        # TODO: remove this export once the API stack no longer imports it in every environment.  # noqa: FIX002
+        self.export_value(self.search_handler.public_handler.function_arn)
+
         # Create the populate provider documents handler for manual invocation
         # This handler is used to bulk index provider documents from DynamoDB into OpenSearch
         self.populate_provider_documents_handler = PopulateProviderDocumentsHandler(


### PR DESCRIPTION
We have removed the public API search endpoints from beta (see #1591). The deployment for that change failed due to the 'deadly embrace' issue in CDK where a stack attempts to remove an unneeded export, but CloudFormation can't allow that deletion until the consuming stack of that export has been updated. This adds dummy exports for those lambdas to fix the deployment and allow all the stacks to be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend stack configurations to improve deployment stability and reliability across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->