### PR TITLE
Correct link for provider mfa reset in Forgot Password email

### DIFF
--- a/backend/compact-connect/lambdas/nodejs/lib/email/cognito-email-service.ts
+++ b/backend/compact-connect/lambdas/nodejs/lib/email/cognito-email-service.ts
@@ -152,6 +152,7 @@ An authenticator app generates time-based codes that change every 30 seconds. Yo
      */
     private generateForgotPasswordTemplate(codeParameter: string): { subject: string; htmlContent: string } {
         const subject = 'Reset your password';
+        const userPoolType = environmentVariableService.getUserPoolType();
         // Make a deep copy of the template so we can modify it without affecting the original
         const template = this.getNewEmailTemplate();
 
@@ -162,11 +163,13 @@ An authenticator app generates time-based codes that change every 30 seconds. Yo
             true
         );
         this.insertSubHeading(template, codeParameter);
-        this.insertBody(template,
-            `**Important:** If you have lost access to your multi-factor authentication (MFA), you will need to recover your account by visiting the following link instead: ${environmentVariableService.getUiBasePathUrl()}/mfarecoverystart`,
-            'center',
-            true
-        );
+        if (userPoolType === 'provider') {
+            this.insertBody(template,
+                `**Important:** If you have lost access to your multi-factor authentication (MFA), you will need to recover your account by visiting the following link instead: ${environmentVariableService.getUiBasePathUrl()}/MfaResetStart`,
+                'center',
+                true
+            );
+        }
         this.insertFooter(template);
 
         return {

--- a/backend/compact-connect/lambdas/nodejs/tests/lib/email/cognito-email-service.test.ts
+++ b/backend/compact-connect/lambdas/nodejs/tests/lib/email/cognito-email-service.test.ts
@@ -116,17 +116,55 @@ describe('CognitoEmailService', () => {
             });
         });
 
-        it('should generate ForgotPassword message', () => {
-            const { subject, htmlContent } = emailService.generateCognitoMessage(
-                'CustomMessage_ForgotPassword',
-                '{####}'
-            );
+        describe('ForgotPassword template', () => {
+            const mfaRecoveryText = 'If you have lost access to your multi-factor authentication (MFA)';
+            const mfaResetUrl = 'https://app.test.compactconnect.org/MfaResetStart';
 
-            expect(subject).toBe('Reset your password');
-            expect(htmlContent).toContain('You requested to reset your password');
-            expect(htmlContent).toContain('{####}');
-            expect(htmlContent).toContain('<strong>Important:</strong> If you have lost access to your multi-factor authentication (MFA), you will need to recover your account by visiting the following link instead:');
-            expect(htmlContent).toContain('https://app.test.compactconnect.org/mfarecoverystart');
+            it('should include MFA recovery instructions for provider user pool', () => {
+                process.env.USER_POOL_TYPE = 'provider';
+
+                const { subject, htmlContent } = emailService.generateCognitoMessage(
+                    'CustomMessage_ForgotPassword',
+                    '{####}'
+                );
+
+                expect(subject).toBe('Reset your password');
+                expect(htmlContent).toContain('You requested to reset your password');
+                expect(htmlContent).toContain('{####}');
+                expect(htmlContent).toContain('<strong>Important:</strong>');
+                expect(htmlContent).toContain(mfaRecoveryText);
+                expect(htmlContent).toContain(mfaResetUrl);
+            });
+
+            it('should not include MFA recovery instructions for staff user pool', () => {
+                process.env.USER_POOL_TYPE = 'staff';
+
+                const { subject, htmlContent } = emailService.generateCognitoMessage(
+                    'CustomMessage_ForgotPassword',
+                    '{####}'
+                );
+
+                expect(subject).toBe('Reset your password');
+                expect(htmlContent).toContain('You requested to reset your password');
+                expect(htmlContent).toContain('{####}');
+                expect(htmlContent).not.toContain(mfaRecoveryText);
+                expect(htmlContent).not.toContain(mfaResetUrl);
+            });
+
+            it('should not include MFA recovery instructions for unknown user pool type', () => {
+                process.env.USER_POOL_TYPE = 'unknown';
+
+                const { subject, htmlContent } = emailService.generateCognitoMessage(
+                    'CustomMessage_ForgotPassword',
+                    '{####}'
+                );
+
+                expect(subject).toBe('Reset your password');
+                expect(htmlContent).toContain('You requested to reset your password');
+                expect(htmlContent).toContain('{####}');
+                expect(htmlContent).not.toContain(mfaRecoveryText);
+                expect(htmlContent).not.toContain(mfaResetUrl);
+            });
         });
 
         it('should generate UpdateUserAttribute message', () => {

--- a/backend/cosmetology-app/lambdas/nodejs/lib/email/cognito-email-service.ts
+++ b/backend/cosmetology-app/lambdas/nodejs/lib/email/cognito-email-service.ts
@@ -152,11 +152,7 @@ An authenticator app generates time-based codes that change every 30 seconds. Yo
             true
         );
         this.insertSubHeading(template, codeParameter);
-        this.insertBody(template,
-            `**Important:** If you have lost access to your multi-factor authentication (MFA), you will need to recover your account by visiting the following link instead: ${environmentVariableService.getUiBasePathUrl()}/mfarecoverystart`,
-            'center',
-            true
-        );
+
         this.insertFooter(template);
 
         return {

--- a/backend/cosmetology-app/lambdas/nodejs/tests/lib/email/cognito-email-service.test.ts
+++ b/backend/cosmetology-app/lambdas/nodejs/tests/lib/email/cognito-email-service.test.ts
@@ -104,8 +104,6 @@ describe('CognitoEmailService', () => {
             expect(subject).toBe('Reset your password');
             expect(htmlContent).toContain('You requested to reset your password');
             expect(htmlContent).toContain('{####}');
-            expect(htmlContent).toContain('<strong>Important:</strong> If you have lost access to your multi-factor authentication (MFA), you will need to recover your account by visiting the following link instead:');
-            expect(htmlContent).toContain('https://app.test.compactconnect.org/mfarecoverystart');
         });
 
         it('should generate UpdateUserAttribute message', () => {

--- a/backend/social-work-app/lambdas/nodejs/lib/email/cognito-email-service.ts
+++ b/backend/social-work-app/lambdas/nodejs/lib/email/cognito-email-service.ts
@@ -152,11 +152,7 @@ An authenticator app generates time-based codes that change every 30 seconds. Yo
             true
         );
         this.insertSubHeading(template, codeParameter);
-        this.insertBody(template,
-            `**Important:** If you have lost access to your multi-factor authentication (MFA), you will need to recover your account by visiting the following link instead: ${environmentVariableService.getUiBasePathUrl()}/mfarecoverystart`,
-            'center',
-            true
-        );
+
         this.insertFooter(template);
 
         return {

--- a/backend/social-work-app/lambdas/nodejs/tests/lib/email/cognito-email-service.test.ts
+++ b/backend/social-work-app/lambdas/nodejs/tests/lib/email/cognito-email-service.test.ts
@@ -104,8 +104,6 @@ describe('CognitoEmailService', () => {
             expect(subject).toBe('Reset your password');
             expect(htmlContent).toContain('You requested to reset your password');
             expect(htmlContent).toContain('{####}');
-            expect(htmlContent).toContain('<strong>Important:</strong> If you have lost access to your multi-factor authentication (MFA), you will need to recover your account by visiting the following link instead:');
-            expect(htmlContent).toContain('https://app.test.compactconnect.org/mfarecoverystart');
         });
 
         it('should generate UpdateUserAttribute message', () => {


### PR DESCRIPTION
There is a page in the app where practitioners can reset their MFA. The link to that page which we specify in the forgot password message from Cognito did not align with what the frontend client is expecting. This PR corrects the link to match the actual path to that page.

This also removes references to the link for projects that do not have a provider user pool.

Closes #1598 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified password reset email templates across services for improved consistency
  * Updated MFA recovery instructions in password reset flows—now conditional based on account type for certain services
  * Simplified password reset email content by refining MFA-related messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->