### PR TITLE
[Cosmetology] Add 'surrender of privilege' encumbrance type

### DIFF
--- a/backend/cosmetology-app/docs/internal/api-specification/latest-oas30.json
+++ b/backend/cosmetology-app/docs/internal/api-specification/latest-oas30.json
@@ -2334,7 +2334,8 @@
                 "enum": [
                   "suspension",
                   "revocation",
-                  "surrender of license"
+                  "surrender of license",
+                  "surrender of privilege"
                 ]
               }
             },
@@ -4008,7 +4009,8 @@
                 "enum": [
                   "suspension",
                   "revocation",
-                  "surrender of license"
+                  "surrender of license",
+                  "surrender of privilege"
                 ]
               }
             },
@@ -4735,7 +4737,8 @@
             "enum": [
               "suspension",
               "revocation",
-              "surrender of license"
+              "surrender of license",
+              "surrender of privilege"
             ]
           }
         },
@@ -4774,7 +4777,8 @@
             "enum": [
               "suspension",
               "revocation",
-              "surrender of license"
+              "surrender of license",
+              "surrender of privilege"
             ]
           }
         },

--- a/backend/cosmetology-app/lambdas/python/common/cc_common/data_model/schema/common.py
+++ b/backend/cosmetology-app/lambdas/python/common/cc_common/data_model/schema/common.py
@@ -380,6 +380,7 @@ class EncumbranceType(CCEnum):
     SUSPENSION = 'suspension'
     REVOCATION = 'revocation'
     SURRENDER_OF_LICENSE = 'surrender of license'
+    SURRENDER_OF_PRIVILEGE = 'surrender of privilege'
 
 
 class ClinicalPrivilegeActionCategory(CCEnum):

--- a/backend/cosmetology-app/stacks/api_stack/v1_api/api_model.py
+++ b/backend/cosmetology-app/stacks/api_stack/v1_api/api_model.py
@@ -807,6 +807,7 @@ class ApiModel:
                 'suspension',
                 'revocation',
                 'surrender of license',
+                'surrender of privilege',
             ],
         )
 

--- a/backend/cosmetology-app/tests/resources/snapshots/LICENSE_ENCUMBRANCE_REQUEST_SCHEMA.json
+++ b/backend/cosmetology-app/tests/resources/snapshots/LICENSE_ENCUMBRANCE_REQUEST_SCHEMA.json
@@ -13,7 +13,8 @@
       "enum": [
         "suspension",
         "revocation",
-        "surrender of license"
+        "surrender of license",
+        "surrender of privilege"
       ],
       "type": "string"
     },

--- a/backend/cosmetology-app/tests/resources/snapshots/PATCH_LICENSE_INVESTIGATION_REQUEST_SCHEMA.json
+++ b/backend/cosmetology-app/tests/resources/snapshots/PATCH_LICENSE_INVESTIGATION_REQUEST_SCHEMA.json
@@ -21,7 +21,8 @@
           "enum": [
             "suspension",
             "revocation",
-            "surrender of license"
+            "surrender of license",
+            "surrender of privilege"
           ],
           "type": "string"
         },

--- a/backend/cosmetology-app/tests/resources/snapshots/PATCH_PRIVILEGE_INVESTIGATION_REQUEST_SCHEMA.json
+++ b/backend/cosmetology-app/tests/resources/snapshots/PATCH_PRIVILEGE_INVESTIGATION_REQUEST_SCHEMA.json
@@ -21,7 +21,8 @@
           "enum": [
             "suspension",
             "revocation",
-            "surrender of license"
+            "surrender of license",
+            "surrender of privilege"
           ],
           "type": "string"
         },

--- a/backend/cosmetology-app/tests/resources/snapshots/PRIVILEGE_ENCUMBRANCE_REQUEST_SCHEMA.json
+++ b/backend/cosmetology-app/tests/resources/snapshots/PRIVILEGE_ENCUMBRANCE_REQUEST_SCHEMA.json
@@ -13,7 +13,8 @@
       "enum": [
         "suspension",
         "revocation",
-        "surrender of license"
+        "surrender of license",
+        "surrender of privilege"
       ],
       "type": "string"
     },

--- a/webroot/src/components/LicenseCard/LicenseCard.ts
+++ b/webroot/src/components/LicenseCard/LicenseCard.ts
@@ -261,6 +261,10 @@ class LicenseCard extends mixins(MixinForm) {
             const includeList = ['suspension', 'revocation', 'surrender of license'];
 
             options = options.filter((option) => includeList.includes(option.value));
+        } else {
+            const excludeList = ['surrender of privilege'];
+
+            options = options.filter((option) => !excludeList.includes(option.value));
         }
 
         options.unshift({

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
@@ -229,7 +229,7 @@ class PrivilegeCard extends mixins(MixinForm) {
         }));
 
         if (this.isAppModeCosmetology) {
-            const includeList = ['suspension', 'revocation', 'surrender of license'];
+            const includeList = ['suspension', 'revocation', 'surrender of privilege'];
 
             options = options.filter((option) => includeList.includes(option.value));
         }

--- a/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
+++ b/webroot/src/components/PrivilegeCard/PrivilegeCard.ts
@@ -232,6 +232,10 @@ class PrivilegeCard extends mixins(MixinForm) {
             const includeList = ['suspension', 'revocation', 'surrender of privilege'];
 
             options = options.filter((option) => includeList.includes(option.value));
+        } else {
+            const excludeList = ['surrender of license'];
+
+            options = options.filter((option) => !excludeList.includes(option.value));
         }
 
         options.unshift({

--- a/webroot/src/locales/en.json
+++ b/webroot/src/locales/en.json
@@ -896,6 +896,10 @@
                 "key": "surrender of license"
             },
             {
+                "name": "Surrender of privilege",
+                "key": "surrender of privilege"
+            },
+            {
                 "name": "Modification of previous action-extension",
                 "key": "modification of previous action-extension"
             },

--- a/webroot/src/locales/es.json
+++ b/webroot/src/locales/es.json
@@ -880,6 +880,10 @@
                 "key": "surrender of license"
             },
             {
+                "name": "Renuncia de privilegio",
+                "key": "surrender of privilege"
+            },
+            {
                 "name": "Modificación de la acción-extensión anterior",
                 "key": "modification of previous action-extension"
             },


### PR DESCRIPTION
During a demo of the Cosmetology features, it was determined that there needs to be a specific encumbrance type to be used when encumbering privileges. This adds the desired discipline action.

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- For API endpoint changes: OpenAPI spec updated to show latest endpoint configuration `run compact-connect/bin/download_oas30.py`
- Code review

Closes #1617 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "surrender of privilege" as an allowed encumbrance type across APIs, request validation, UI discipline options, and English/Spanish translations.
* **Tests**
  * Updated JSON schema snapshots to reflect the expanded encumbranceType enum so requests including the new value validate in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->