### PR TITLE
Set validation error times to current time to avoid race condition

### DIFF
--- a/backend/compact-connect/lambdas/python/common/tests/unit/test_utils.py
+++ b/backend/compact-connect/lambdas/python/common/tests/unit/test_utils.py
@@ -5,7 +5,7 @@ from tests import TstLambdas
 
 
 class TestUtils(TstLambdas):
-    @patch('cc_common.config._Config.license_preprocessing_queue')
+    @patch('cc_common.utils.config.license_preprocessing_queue')
     def test_send_licenses_to_preprocessing_queue_handles_failures(self, mock_preprocessing_queue):
         from cc_common.utils import send_licenses_to_preprocessing_queue
 

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/bulk_upload.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/bulk_upload.py
@@ -211,7 +211,7 @@ def process_bulk_upload_file(
                         'DetailType': 'license.validation-error',
                         'Detail': json.dumps(
                             {
-                                'eventTime': event_time.isoformat(),
+                                'eventTime': config.current_standard_datetime.isoformat(),
                                 'compact': compact,
                                 'jurisdiction': jurisdiction,
                                 'recordNumber': i + 1,

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
@@ -1,5 +1,6 @@
 import csv
 import json
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -7,6 +8,8 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from tests.function import TstFunction
+
+VALIDATION_ERROR_EVENT_TIME = '2024-11-08T23:59:59+00:00'
 
 mock_flag_client = MagicMock()
 mock_flag_client.return_value = True
@@ -191,6 +194,10 @@ class TestProcessObjects(TstFunction):
         self.assertEqual('active', message_data['licenseStatus'])
         self.assertEqual('eligible', message_data['compactEligibility'])
 
+    @patch(
+        'cc_common.config._Config.current_standard_datetime',
+        datetime.fromisoformat(VALIDATION_ERROR_EVENT_TIME),
+    )
     def test_bulk_upload_prevents_compact_jurisdiction_overwrites(self):
         """Test that CSV compact/jurisdiction fields cannot overwrite URL path values."""
         from handlers.bulk_upload import parse_bulk_upload_file
@@ -244,7 +251,7 @@ class TestProcessObjects(TstFunction):
                 'DetailType': 'license.validation-error',
                 'Detail': json.dumps(
                     {
-                        'eventTime': '1970-01-01T00:00:00+00:00',
+                        'eventTime': VALIDATION_ERROR_EVENT_TIME,
                         'compact': 'aslp',
                         'jurisdiction': 'oh',
                         'recordNumber': 1,
@@ -271,6 +278,10 @@ class TestProcessObjects(TstFunction):
 
             self.assertEqual(expected_entry, call_args)
 
+    @patch(
+        'cc_common.config._Config.current_standard_datetime',
+        datetime.fromisoformat(VALIDATION_ERROR_EVENT_TIME),
+    )
     def test_bulk_upload_prevents_repeated_ssns_within_the_same_file_upload(self):
         """Test that duplicate SSNs within a CSV upload are detected and rejected."""
         from handlers.bulk_upload import parse_bulk_upload_file
@@ -324,7 +335,7 @@ class TestProcessObjects(TstFunction):
                 'DetailType': 'license.validation-error',
                 'Detail': json.dumps(
                     {
-                        'eventTime': '1970-01-01T00:00:00+00:00',
+                        'eventTime': VALIDATION_ERROR_EVENT_TIME,
                         'compact': 'aslp',
                         'jurisdiction': 'oh',
                         'recordNumber': 2,

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/unit/test_handlers/test_bulk_upload_unit.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/unit/test_handlers/test_bulk_upload_unit.py
@@ -145,6 +145,7 @@ class TestProcessBulkUploadFile(TstLambdas):
 
         # mock static response for the events client when we put messages on the event bus
         mock_config.events_client.put_events.return_value = {'FailedEntryCount': 0, 'Entries': [{'EventId': '123'}]}
+        mock_config.current_standard_datetime = datetime.now(tz=UTC)
         # this method returns a list of any message ids that failed to send, in this test case, there are no failures
         mock_send_licenses_to_preprocessing_queue.return_value = []
 

--- a/backend/compact-connect/stacks/persistent_stack/data_event_table.py
+++ b/backend/compact-connect/stacks/persistent_stack/data_event_table.py
@@ -104,7 +104,7 @@ class DataEventTable(Table):
             process_function=self.event_handler,
             visibility_timeout=Duration.minutes(1),
             retention_period=Duration.hours(1),
-            max_batching_window=Duration.minutes(5),
+            max_batching_window=Duration.seconds(5),
             max_receive_count=3,
             batch_size=10,
             encryption_key=encryption_key,

--- a/backend/cosmetology-app/lambdas/python/common/tests/unit/test_utils.py
+++ b/backend/cosmetology-app/lambdas/python/common/tests/unit/test_utils.py
@@ -5,7 +5,7 @@ from tests import TstLambdas
 
 
 class TestUtils(TstLambdas):
-    @patch('cc_common.config._Config.license_preprocessing_queue')
+    @patch('cc_common.utils.config.license_preprocessing_queue')
     def test_send_licenses_to_preprocessing_queue_handles_failures(self, mock_preprocessing_queue):
         from cc_common.utils import send_licenses_to_preprocessing_queue
 

--- a/backend/cosmetology-app/lambdas/python/provider-data-v1/handlers/bulk_upload.py
+++ b/backend/cosmetology-app/lambdas/python/provider-data-v1/handlers/bulk_upload.py
@@ -203,7 +203,7 @@ def process_bulk_upload_file(
                         'DetailType': 'license.validation-error',
                         'Detail': json.dumps(
                             {
-                                'eventTime': event_time.isoformat(),
+                                'eventTime': config.current_standard_datetime.isoformat(),
                                 'compact': compact,
                                 'jurisdiction': jurisdiction,
                                 'recordNumber': i + 1,

--- a/backend/cosmetology-app/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
+++ b/backend/cosmetology-app/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
@@ -1,5 +1,6 @@
 import csv
 import json
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -7,6 +8,8 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from tests.function import TstFunction
+
+VALIDATION_ERROR_EVENT_TIME = '2024-11-08T23:59:59+00:00'
 
 mock_flag_client = MagicMock()
 mock_flag_client.return_value = True
@@ -190,6 +193,10 @@ class TestProcessObjects(TstFunction):
         self.assertEqual('active', message_data['licenseStatus'])
         self.assertEqual('eligible', message_data['compactEligibility'])
 
+    @patch(
+        'cc_common.config._Config.current_standard_datetime',
+        datetime.fromisoformat(VALIDATION_ERROR_EVENT_TIME),
+    )
     def test_bulk_upload_prevents_compact_jurisdiction_overwrites(self):
         """Test that CSV compact/jurisdiction fields cannot overwrite URL path values."""
         from handlers.bulk_upload import parse_bulk_upload_file
@@ -243,7 +250,7 @@ class TestProcessObjects(TstFunction):
                 'DetailType': 'license.validation-error',
                 'Detail': json.dumps(
                     {
-                        'eventTime': '1970-01-01T00:00:00+00:00',
+                        'eventTime': VALIDATION_ERROR_EVENT_TIME,
                         'compact': 'cosm',
                         'jurisdiction': 'oh',
                         'recordNumber': 1,
@@ -269,6 +276,10 @@ class TestProcessObjects(TstFunction):
 
             self.assertEqual(expected_entry, call_args)
 
+    @patch(
+        'cc_common.config._Config.current_standard_datetime',
+        datetime.fromisoformat(VALIDATION_ERROR_EVENT_TIME),
+    )
     def test_bulk_upload_prevents_repeated_ssns_within_the_same_file_upload(self):
         """Test that duplicate SSNs within a CSV upload are detected and rejected."""
         from handlers.bulk_upload import parse_bulk_upload_file
@@ -322,7 +333,7 @@ class TestProcessObjects(TstFunction):
                 'DetailType': 'license.validation-error',
                 'Detail': json.dumps(
                     {
-                        'eventTime': '1970-01-01T00:00:00+00:00',
+                        'eventTime': VALIDATION_ERROR_EVENT_TIME,
                         'compact': 'cosm',
                         'jurisdiction': 'oh',
                         'recordNumber': 2,

--- a/backend/cosmetology-app/lambdas/python/provider-data-v1/tests/unit/test_handlers/test_bulk_upload_unit.py
+++ b/backend/cosmetology-app/lambdas/python/provider-data-v1/tests/unit/test_handlers/test_bulk_upload_unit.py
@@ -145,6 +145,7 @@ class TestProcessBulkUploadFile(TstLambdas):
 
         # mock static response for the events client when we put messages on the event bus
         mock_config.events_client.put_events.return_value = {'FailedEntryCount': 0, 'Entries': [{'EventId': '123'}]}
+        mock_config.current_standard_datetime = datetime.now(tz=UTC)
         # this method returns a list of any message ids that failed to send, in this test case, there are no failures
         mock_send_licenses_to_preprocessing_queue.return_value = []
 

--- a/backend/cosmetology-app/stacks/persistent_stack/data_event_table.py
+++ b/backend/cosmetology-app/stacks/persistent_stack/data_event_table.py
@@ -104,7 +104,7 @@ class DataEventTable(Table):
             process_function=self.event_handler,
             visibility_timeout=Duration.minutes(1),
             retention_period=Duration.hours(1),
-            max_batching_window=Duration.minutes(5),
+            max_batching_window=Duration.seconds(5),
             max_receive_count=3,
             batch_size=10,
             encryption_key=encryption_key,

--- a/backend/social-work-app/lambdas/python/common/tests/unit/test_utils.py
+++ b/backend/social-work-app/lambdas/python/common/tests/unit/test_utils.py
@@ -5,7 +5,7 @@ from tests import TstLambdas
 
 
 class TestUtils(TstLambdas):
-    @patch('cc_common.config._Config.license_preprocessing_queue')
+    @patch('cc_common.utils.config.license_preprocessing_queue')
     def test_send_licenses_to_preprocessing_queue_handles_failures(self, mock_preprocessing_queue):
         from cc_common.utils import send_licenses_to_preprocessing_queue
 

--- a/backend/social-work-app/lambdas/python/provider-data-v1/handlers/bulk_upload.py
+++ b/backend/social-work-app/lambdas/python/provider-data-v1/handlers/bulk_upload.py
@@ -198,7 +198,6 @@ def process_bulk_upload_file(
                         record_number=i + 1,
                         license_record=raw_license,
                         errors=e.messages,
-                        event_time=event_time,
                     )
                 )
                 continue

--- a/backend/social-work-app/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
+++ b/backend/social-work-app/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
@@ -1,5 +1,6 @@
 import csv
 import json
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -7,6 +8,8 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from tests.function import TstFunction
+
+VALIDATION_ERROR_EVENT_TIME = '2024-11-08T23:59:59+00:00'
 
 mock_flag_client = MagicMock()
 mock_flag_client.return_value = True
@@ -192,6 +195,10 @@ class TestProcessObjects(TstFunction):
         self.assertEqual('active', message_data['licenseStatus'])
         self.assertEqual('eligible', message_data['compactEligibility'])
 
+    @patch(
+        'cc_common.config._Config.current_standard_datetime',
+        datetime.fromisoformat(VALIDATION_ERROR_EVENT_TIME),
+    )
     def test_bulk_upload_prevents_compact_jurisdiction_overwrites(self):
         """Test that CSV compact/jurisdiction fields cannot overwrite URL path values."""
         from handlers.bulk_upload import parse_bulk_upload_file
@@ -245,7 +252,7 @@ class TestProcessObjects(TstFunction):
                 'DetailType': 'license.validation-error',
                 'Detail': json.dumps(
                     {
-                        'eventTime': '1970-01-01T00:00:00+00:00',
+                        'eventTime': VALIDATION_ERROR_EVENT_TIME,
                         'compact': 'socw',
                         'jurisdiction': 'oh',
                         'recordNumber': 1,
@@ -272,6 +279,10 @@ class TestProcessObjects(TstFunction):
 
             self.assertEqual(expected_entry, call_args)
 
+    @patch(
+        'cc_common.config._Config.current_standard_datetime',
+        datetime.fromisoformat(VALIDATION_ERROR_EVENT_TIME),
+    )
     def test_bulk_upload_prevents_repeated_ssns_within_the_same_file_upload(self):
         """Test that duplicate SSNs within a CSV upload are detected and rejected."""
         from handlers.bulk_upload import parse_bulk_upload_file
@@ -327,7 +338,7 @@ class TestProcessObjects(TstFunction):
                 'DetailType': 'license.validation-error',
                 'Detail': json.dumps(
                     {
-                        'eventTime': '1970-01-01T00:00:00+00:00',
+                        'eventTime': VALIDATION_ERROR_EVENT_TIME,
                         'compact': 'socw',
                         'jurisdiction': 'oh',
                         'recordNumber': 2,

--- a/backend/social-work-app/stacks/persistent_stack/data_event_table.py
+++ b/backend/social-work-app/stacks/persistent_stack/data_event_table.py
@@ -104,7 +104,7 @@ class DataEventTable(Table):
             process_function=self.event_handler,
             visibility_timeout=Duration.minutes(1),
             retention_period=Duration.hours(1),
-            max_batching_window=Duration.minutes(5),
+            max_batching_window=Duration.seconds(5),
             max_receive_count=3,
             batch_size=10,
             encryption_key=encryption_key,


### PR DESCRIPTION
There is a race condition that sometimes occurs when a low volume of invalid licenses are uploaded in a CSV file. We have a error email reporter that sends out license upload failure emails every 15 minutes, and this reporting process looks at the last 15 minutes of events in the DB to see if any upload errors occurred. While beta testing, a state uploaded a single invalid license record. The upload failure event was placed on the data event bus which placed a message on a SQS queue for processing. That queue has a batch size of 10 and it will wait for up to 5 minutes to process messages if the batch size is not met. The one upload failure notification was sitting in the queue long enough that by the time it was stored in the DB, the notification error reporter had already completed its scan for the 15 minutes and never detected the error. This race condition exists in all three compact codebases (JCC, Cosm, and SW). This change reduces the batch window for the data event processor queue from 5 minutes to 5 seconds to address this.

This can also occur if there is a large CSV upload and all of the errors are toward the end of the file. Previously, we were setting the same time stamp for all row failures, so if a large upload took 15 minutes to process, and the errors were toward the end of the file, they wouldn't be stored in the database until after the ingest error reporter had scanned the 15 minute window, so the errors wouldn't be reported. This updates the timestamp to use the actual time that the row was processed and the error was detected. 

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- For API endpoint changes: OpenAPI spec updated to show latest endpoint configuration `run compact-connect/bin/download_oas30.py`
- Code review


Closes #1633 
