### PR TITLE
Add backend check to prevent state admin from granting compact permission

### DIFF
--- a/backend/compact-connect/lambdas/python/common/cc_common/utils.py
+++ b/backend/compact-connect/lambdas/python/common/cc_common/utils.py
@@ -681,6 +681,8 @@ def collect_and_authorize_changes(*, path_compact: str, scopes: set, compact_cha
             raise CCAccessDeniedException('Only compact admins can affect compact-level admin permissions')
         if action == CCPermissionsAction.READ_PRIVATE and f'{path_compact}/{CCPermissionsAction.ADMIN}' not in scopes:
             raise CCAccessDeniedException('Only compact admins can affect compact-level access to private information')
+        if action == CCPermissionsAction.READ_SSN and f'{path_compact}/{CCPermissionsAction.ADMIN}' not in scopes:
+            raise CCAccessDeniedException('Only compact admins can affect compact-level access to SSN information')
 
         # dropping the read action as this is now implicitly granted to all users
         if action == CCPermissionsAction.READ:

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -228,6 +228,26 @@ class TestPatchUser(TstFunction):
 
         self.assertEqual(403, resp['statusCode'])
 
+    def test_patch_user_forbidden_compact_read_ssn(self):
+        self._load_user_data()
+        self._when_testing_with_valid_jurisdiction(compact='aslp')
+
+        from handlers.users import patch_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for oh/aslp, not compact-level admin
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = json.dumps({'permissions': {'aslp': {'actions': {'readSSN': True}}}})
+
+        resp = patch_user(event, self.mock_context)
+
+        self.assertEqual(403, resp['statusCode'])
+
     def test_patch_user_not_found(self):
         from handlers.users import patch_user
 
@@ -248,6 +268,57 @@ class TestPatchUser(TstFunction):
 
         self.assertEqual(404, resp['statusCode'])
         self.assertEqual({'message': 'User not found'}, json.loads(resp['body']))
+
+    def test_patch_user_allows_adding_read_ssn_permission(self):
+        self._load_user_data()
+        self._when_testing_with_valid_jurisdiction(compact='aslp')
+
+        from cc_common.data_model.schema.common import StaffUserStatus
+        from handlers.users import patch_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # The user has admin permission for compact and oh
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin aslp/admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = json.dumps(
+            {
+                'permissions': {
+                    'aslp': {
+                        'actions': {
+                            'readSSN': True,
+                        },
+                        'jurisdictions': {'oh': {'actions': {'readSSN': True}}},
+                    }
+                }
+            }
+        )
+
+        resp = patch_user(event, self.mock_context)
+
+        self.assertEqual(200, resp['statusCode'])
+        user = json.loads(resp['body'])
+        self.assertEqual(
+            {
+                'attributes': {'email': 'justin@example.org', 'familyName': 'Williams', 'givenName': 'Justin'},
+                'dateOfUpdate': '2024-09-12T23:59:59+00:00',
+                'status': StaffUserStatus.INACTIVE.value,
+                'permissions': {
+                    'aslp': {
+                        # test user starts with compact readPrivate, which should still be there
+                        'actions': {'readPrivate': True, 'readSSN': True},
+                        # test user starts with the write permission, so it should still be there
+                        'jurisdictions': {'oh': {'actions': {'write': True, 'readSSN': True}}},
+                    },
+                },
+                'type': 'user',
+                'userId': 'a4182428-d061-701c-82e5-a3d1d547d797',
+            },
+            user,
+        )
 
     def test_patch_user_allows_adding_read_private_permission(self):
         self._load_user_data()

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_post_user.py
@@ -113,6 +113,30 @@ class TestPostUser(TstFunction):
 
         self.assertEqual(403, resp['statusCode'])
 
+    def test_post_user_forbidden_compact_read_ssn(self):
+        from handlers.users import post_user
+
+        self._when_testing_with_valid_jurisdiction()
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        with open('tests/resources/api/user-post.json') as f:
+            api_user = json.load(f)
+
+        api_user['permissions'] = {'aslp': {'actions': {'readSSN': True}, 'jurisdictions': {'oh': {'actions': {}}}}}
+        event['body'] = json.dumps(api_user)
+
+        # The user has admin permission for oh/aslp, not compact-level admin
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/aslp.admin'
+        event['pathParameters'] = {'compact': 'aslp'}
+
+        resp = post_user(event, self.mock_context)
+
+        self.assertEqual(403, resp['statusCode'])
+
     def test_post_user_returns_400_if_invalid_jurisdiction_permission_set(self):
         from handlers.users import post_user
 

--- a/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_collect_changes.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/unit/test_collect_changes.py
@@ -70,6 +70,17 @@ class TestCollectChanges(TstLambdas):
                 compact_changes={'actions': {'admin': True}, 'jurisdictions': {}},
             )
 
+    def test_jurisdiction_admin_disallowed_compact_read_ssn_changes(self):
+        from cc_common.exceptions import CCAccessDeniedException
+        from cc_common.utils import collect_and_authorize_changes
+
+        with self.assertRaises(CCAccessDeniedException):
+            collect_and_authorize_changes(
+                path_compact='aslp',
+                scopes={'openid', 'email', 'oh/aslp.admin'},
+                compact_changes={'actions': {'readSSN': True}, 'jurisdictions': {}},
+            )
+
     @patch('cc_common.utils.config.compact_configuration_client')
     def test_compact_and_jurisdiction_changes(self, mock_compact_configuration_client):
         from cc_common.utils import collect_and_authorize_changes


### PR DESCRIPTION
When the readSSN permission was added during development, the check for how it is granted at the compact level was not included in the utility function which verifies the caller's permission scopes to ensure a state admin cannot add permissions at the compact level. The UI prevents this, but in theory a state admin could call the API directly outside of the app UI, so this adds that auth check to prevent that. 
