### PR TITLE
Prevent cross jurisdiction permission patching

### DIFF
--- a/backend/compact-connect/lambdas/python/staff-users/handlers/users.py
+++ b/backend/compact-connect/lambdas/python/staff-users/handlers/users.py
@@ -98,9 +98,16 @@ def patch_user(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argu
     user_id = event['pathParameters']['userId']
     scopes = get_event_scopes(event)
     path_compact = event['pathParameters']['compact']
+    allowed_jurisdictions = get_allowed_jurisdictions(compact=compact, scopes=scopes)
 
     # this will raise an exception if the caller was disabled
     _verify_caller_is_active(event)
+
+    target_user = config.user_client.get_user_in_compact(compact=compact, user_id=user_id)
+    if allowed_jurisdictions is not None:
+        allowed_jurisdictions = set(allowed_jurisdictions)
+        if not allowed_jurisdictions.intersection(target_user['permissions']['jurisdictions'].keys()):
+            raise CCNotFoundException('User not found')
 
     permission_changes = json.loads(event['body']).get('permissions', {}).get(compact, {})
     logger.debug('Requested changes', permission_changes=permission_changes)

--- a/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/compact-connect/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -208,6 +208,27 @@ class TestPatchUser(TstFunction):
         api_user['permissions'] = {'aslp': {'jurisdictions': {}}}
         self.assertEqual(api_user, user)
 
+    def test_patch_user_outside_jurisdiction_returns_404(self):
+        self._load_user_data()
+        self._when_testing_with_valid_jurisdiction(compact='aslp')
+
+        from handlers.users import patch_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # NE admin cannot patch a user who only has OH permissions
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email ne/aslp.admin'
+        event['pathParameters'] = {'compact': 'aslp', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = json.dumps({'permissions': {'aslp': {'jurisdictions': {'ne': {'actions': {'admin': True}}}}}})
+
+        resp = patch_user(event, self.mock_context)
+
+        self.assertEqual(404, resp['statusCode'])
+        self.assertEqual({'message': 'User not found'}, json.loads(resp['body']))
+
     def test_patch_user_forbidden(self):
         self._load_user_data()
         self._when_testing_with_valid_jurisdiction(compact='aslp')

--- a/backend/cosmetology-app/lambdas/python/staff-users/handlers/users.py
+++ b/backend/cosmetology-app/lambdas/python/staff-users/handlers/users.py
@@ -98,9 +98,16 @@ def patch_user(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argu
     user_id = event['pathParameters']['userId']
     scopes = get_event_scopes(event)
     path_compact = event['pathParameters']['compact']
+    allowed_jurisdictions = get_allowed_jurisdictions(compact=compact, scopes=scopes)
 
     # this will raise an exception if the caller was disabled
     _verify_caller_is_active(event)
+
+    target_user = config.user_client.get_user_in_compact(compact=compact, user_id=user_id)
+    if allowed_jurisdictions is not None:
+        allowed_jurisdictions = set(allowed_jurisdictions)
+        if not allowed_jurisdictions.intersection(target_user['permissions']['jurisdictions'].keys()):
+            raise CCNotFoundException('User not found')
 
     permission_changes = json.loads(event['body']).get('permissions', {}).get(compact, {})
     logger.debug('Requested changes', permission_changes=permission_changes)

--- a/backend/cosmetology-app/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/cosmetology-app/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -208,6 +208,27 @@ class TestPatchUser(TstFunction):
         api_user['permissions'] = {'cosm': {'jurisdictions': {}}}
         self.assertEqual(api_user, user)
 
+    def test_patch_user_outside_jurisdiction_returns_404(self):
+        self._load_user_data()
+        self._when_testing_with_valid_jurisdiction(compact='cosm')
+
+        from handlers.users import patch_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # NE admin cannot patch a user who only has OH permissions
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email ne/cosm.admin'
+        event['pathParameters'] = {'compact': 'cosm', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = json.dumps({'permissions': {'cosm': {'jurisdictions': {'ne': {'actions': {'admin': True}}}}}})
+
+        resp = patch_user(event, self.mock_context)
+
+        self.assertEqual(404, resp['statusCode'])
+        self.assertEqual({'message': 'User not found'}, json.loads(resp['body']))
+
     def test_patch_user_forbidden(self):
         self._load_user_data()
         self._when_testing_with_valid_jurisdiction(compact='cosm')

--- a/backend/social-work-app/lambdas/python/staff-users/handlers/users.py
+++ b/backend/social-work-app/lambdas/python/staff-users/handlers/users.py
@@ -98,9 +98,16 @@ def patch_user(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argu
     user_id = event['pathParameters']['userId']
     scopes = get_event_scopes(event)
     path_compact = event['pathParameters']['compact']
+    allowed_jurisdictions = get_allowed_jurisdictions(compact=compact, scopes=scopes)
 
     # this will raise an exception if the caller was disabled
     _verify_caller_is_active(event)
+
+    target_user = config.user_client.get_user_in_compact(compact=compact, user_id=user_id)
+    if allowed_jurisdictions is not None:
+        allowed_jurisdictions = set(allowed_jurisdictions)
+        if not allowed_jurisdictions.intersection(target_user['permissions']['jurisdictions'].keys()):
+            raise CCNotFoundException('User not found')
 
     permission_changes = json.loads(event['body']).get('permissions', {}).get(compact, {})
     logger.debug('Requested changes', permission_changes=permission_changes)

--- a/backend/social-work-app/lambdas/python/staff-users/handlers/users.py
+++ b/backend/social-work-app/lambdas/python/staff-users/handlers/users.py
@@ -73,8 +73,8 @@ def patch_user(event: dict, context: LambdaContext):  # noqa: ARG001 unused-argu
 
     Example: This body would be requesting to:
       - add socw/admin permission
-      - add oh/cosm admin permission
-      - remove oh/cosm write permission
+      - add oh/socw admin permission
+      - remove oh/socw write permission
     ```json
     {
       "permissions": {

--- a/backend/social-work-app/lambdas/python/staff-users/tests/function/test_handlers/test_delete_user.py
+++ b/backend/social-work-app/lambdas/python/staff-users/tests/function/test_handlers/test_delete_user.py
@@ -125,7 +125,7 @@ class TestDeleteUser(TstFunction):
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
 
-        # The user has admin permission for oh/cosm
+        # The user has admin permission for oh/socw
         caller_id = self._when_testing_with_valid_caller()
         event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/socw.admin'

--- a/backend/social-work-app/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/social-work-app/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -238,7 +238,7 @@ class TestPatchUser(TstFunction):
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
 
-        # The user has admin permission for oh/cosm not ne/cosm
+        # The user has admin permission for oh/socw not ne/socw
         caller_id = self._when_testing_with_valid_caller()
         event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/socw.admin'
@@ -257,7 +257,7 @@ class TestPatchUser(TstFunction):
         with open('tests/resources/api-event.json') as f:
             event = json.load(f)
 
-        # The caller has admin permission for oh/cosm not ne/cosm
+        # The caller has admin permission for oh/socw not ne/socw
         caller_id = self._when_testing_with_valid_caller()
         event['requestContext']['authorizer']['claims']['sub'] = caller_id
         event['requestContext']['authorizer']['claims']['scope'] = 'openid email oh/socw.admin'

--- a/backend/social-work-app/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
+++ b/backend/social-work-app/lambdas/python/staff-users/tests/function/test_handlers/test_patch_user.py
@@ -208,6 +208,27 @@ class TestPatchUser(TstFunction):
         api_user['permissions'] = {'socw': {'jurisdictions': {}}}
         self.assertEqual(api_user, user)
 
+    def test_patch_user_outside_jurisdiction_returns_404(self):
+        self._load_user_data()
+        self._when_testing_with_valid_jurisdiction(compact='socw')
+
+        from handlers.users import patch_user
+
+        with open('tests/resources/api-event.json') as f:
+            event = json.load(f)
+
+        # NE admin cannot patch a user who only has OH permissions
+        caller_id = self._when_testing_with_valid_caller()
+        event['requestContext']['authorizer']['claims']['sub'] = caller_id
+        event['requestContext']['authorizer']['claims']['scope'] = 'openid email ne/socw.admin'
+        event['pathParameters'] = {'compact': 'socw', 'userId': 'a4182428-d061-701c-82e5-a3d1d547d797'}
+        event['body'] = json.dumps({'permissions': {'socw': {'jurisdictions': {'ne': {'actions': {'admin': True}}}}}})
+
+        resp = patch_user(event, self.mock_context)
+
+        self.assertEqual(404, resp['statusCode'])
+        self.assertEqual({'message': 'User not found'}, json.loads(resp['body']))
+
     def test_patch_user_forbidden(self):
         self._load_user_data()
         self._when_testing_with_valid_jurisdiction(compact='socw')


### PR DESCRIPTION
The patch_user endpoint is the only staff-user mutation handler that does NOT verify the target user is within the calling jurisdiction admin's purview. All other staff endpoints that modify staff user permissions fetch the target and require the caller to have admin permissions for the target user's jurisdiction. patch_user relies only on `collect_and_authorize_changes`, which validates the requested changes against the caller's scopes but never loads the target to confirm the caller may administer that specific user.

This adds that check so that if the caller does not have the needed jurisdiction admin scopes for the target user, the endpoint returns a 404 not found response.

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- For API endpoint changes: OpenAPI spec updated to show latest endpoint configuration `run compact-connect/bin/download_oas30.py`
- Code review

Closes #1640 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened jurisdiction-based access for admin user edits: admins can only modify users who share at least one allowed jurisdiction; attempts outside permitted jurisdictions now return 404. Caller activity is verified earlier in the request flow.

* **Tests**
  * Added functional tests to cover jurisdiction-scoped access control and the 404 behavior when editing users outside an admin’s allowed jurisdictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->