### PR TITLE
Add compact auth check for staff privilege history endpoint

### DIFF
--- a/backend/compact-connect/lambdas/nodejs/package.json
+++ b/backend/compact-connect/lambdas/nodejs/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/client-sesv2": "^3.1045.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@csg-org/email-builder": "^0.0.13",
-    "nodemailer": "^8.0.9",
+    "nodemailer": "^9.0.1",
     "zod": "^3.23.8"
   }
 }

--- a/backend/compact-connect/lambdas/nodejs/yarn.lock
+++ b/backend/compact-connect/lambdas/nodejs/yarn.lock
@@ -4697,10 +4697,10 @@ node-releases@^2.0.27:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
-nodemailer@^8.0.9:
-  version "8.0.11"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.11.tgz#ce46b7c2c8bbf17b0408122fbfb4e47f4bffc688"
-  integrity sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==
+nodemailer@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-9.0.1.tgz#871c04d8423fc0c790289f4a8f6f71f1b3563e8c"
+  integrity sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==
 
 normalize-path@^3.0.0:
   version "3.0.0"

--- a/backend/compact-connect/lambdas/python/provider-data-v1/handlers/privilege_history.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/handlers/privilege_history.py
@@ -1,8 +1,9 @@
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from cc_common.config import config
 from cc_common.data_model.provider_record_util import ProviderRecordUtility
+from cc_common.data_model.schema.common import CCPermissionsAction
 from cc_common.exceptions import CCInvalidRequestException
-from cc_common.utils import api_handler, get_provider_user_attributes_from_authorizer_claims
+from cc_common.utils import api_handler, authorize_compact, get_provider_user_attributes_from_authorizer_claims
 
 
 @api_handler
@@ -32,16 +33,17 @@ def privilege_history_handler(event: dict, context: LambdaContext):
             'GET',
             '/v1/compacts/{compact}/providers/{providerId}/privileges/jurisdiction/{jurisdiction}/licenseType/{licenseType}/history',
         ):
-            return _get_privilege_history_staff(event)
+            return _get_privilege_history_staff(event, context)
 
     # If we get here, the method/resource combination is not supported
     raise CCInvalidRequestException(f'Unsupported method or resource: {http_method} {resource_path}')
 
 
-def _get_privilege_history_staff(event: dict):
+@authorize_compact(action=CCPermissionsAction.READ_GENERAL)
+def _get_privilege_history_staff(event: dict, _context: LambdaContext):
     """Return the enriched and simplified privilege history for staff user front end consumption
     :param event: Standard API Gateway event, API schema documented in the CDK ApiStack
-    :param LambdaContext context:
+    :param LambdaContext _context:
     """
     compact = event['pathParameters']['compact']
     provider_id = event['pathParameters']['providerId']

--- a/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_privilege_history.py
+++ b/backend/compact-connect/lambdas/python/provider-data-v1/tests/function/test_handlers/test_privilege_history.py
@@ -100,6 +100,7 @@ class TestGetProvider(TstFunction):
                 'compact': test_provider.compact,
                 'providerId': test_provider.providerId,
             }
+            event['requestContext']['authorizer']['claims']['scope'] = f'openid email {TEST_COMPACT}/readGeneral'
 
         return event
 
@@ -124,6 +125,18 @@ class TestGetProvider(TstFunction):
         resp = privilege_history_handler(event, self.mock_context)
 
         self.assertEqual(404, resp['statusCode'])
+
+    def test_staff_privilege_history_returns_unauthorized_if_user_not_in_same_compact(self):
+        from handlers.privilege_history import privilege_history_handler
+
+        event = self._when_testing_staff_endpoint()
+        # change the compact to a different compact
+        # to simulate a staff user attempting to access a different compact
+        event['pathParameters']['compact'] = 'coun'
+
+        resp = privilege_history_handler(event, self.mock_context)
+
+        self.assertEqual(403, resp['statusCode'])
 
     def test_privilege_not_found_returns_404_staff(self):
         from handlers.privilege_history import privilege_history_handler

--- a/backend/cosmetology-app/lambdas/nodejs/package.json
+++ b/backend/cosmetology-app/lambdas/nodejs/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/client-sesv2": "^3.1045.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@csg-org/email-builder": "^0.0.13",
-    "nodemailer": "^8.0.9",
+    "nodemailer": "^9.0.1",
     "zod": "^3.23.8"
   }
 }

--- a/backend/cosmetology-app/lambdas/nodejs/yarn.lock
+++ b/backend/cosmetology-app/lambdas/nodejs/yarn.lock
@@ -4697,10 +4697,10 @@ node-releases@^2.0.27:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
-nodemailer@^8.0.9:
-  version "8.0.11"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.11.tgz#ce46b7c2c8bbf17b0408122fbfb4e47f4bffc688"
-  integrity sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==
+nodemailer@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-9.0.1.tgz#871c04d8423fc0c790289f4a8f6f71f1b3563e8c"
+  integrity sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==
 
 normalize-path@^3.0.0:
   version "3.0.0"

--- a/backend/cosmetology-app/stacks/api_lambda_stack/public_lookup_api.py
+++ b/backend/cosmetology-app/stacks/api_lambda_stack/public_lookup_api.py
@@ -56,7 +56,6 @@ class PublicLookupApiLambdas:
         )
         api_lambda_stack.log_groups.append(self.query_providers_handler.log_group)
 
-
     def _get_provider_handler(
         self,
         scope: Construct,

--- a/backend/social-work-app/lambdas/nodejs/package.json
+++ b/backend/social-work-app/lambdas/nodejs/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/client-sesv2": "^3.1045.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@csg-org/email-builder": "^0.0.13",
-    "nodemailer": "^8.0.9",
+    "nodemailer": "^9.0.1",
     "zod": "^3.23.8"
   }
 }

--- a/backend/social-work-app/lambdas/nodejs/yarn.lock
+++ b/backend/social-work-app/lambdas/nodejs/yarn.lock
@@ -4697,10 +4697,10 @@ node-releases@^2.0.27:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
-nodemailer@^8.0.9:
-  version "8.0.11"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.11.tgz#ce46b7c2c8bbf17b0408122fbfb4e47f4bffc688"
-  integrity sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==
+nodemailer@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-9.0.1.tgz#871c04d8423fc0c790289f4a8f6f71f1b3563e8c"
+  integrity sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==
 
 normalize-path@^3.0.0:
   version "3.0.0"

--- a/backend/social-work-app/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
+++ b/backend/social-work-app/lambdas/python/provider-data-v1/tests/function/test_handlers/test_bulk_upload.py
@@ -1,18 +1,16 @@
 import csv
 import json
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 from botocore.exceptions import ClientError
+from common_test.test_constants import DEFAULT_DATE_OF_UPDATE_TIMESTAMP
 from moto import mock_aws
 
 from tests.function import TstFunction
 
 VALIDATION_ERROR_EVENT_TIME = '2024-11-08T23:59:59+00:00'
-
-mock_flag_client = MagicMock()
-mock_flag_client.return_value = True
 
 
 @mock_aws
@@ -46,7 +44,7 @@ class TestBulkUpload(TstFunction):
 
 
 @mock_aws
-@patch('cc_common.feature_flag_client.is_feature_enabled', mock_flag_client)
+@patch('cc_common.config._Config.current_standard_datetime', datetime.fromisoformat(DEFAULT_DATE_OF_UPDATE_TIMESTAMP))
 class TestProcessObjects(TstFunction):
     def test_uploaded_csv(self):
         from handlers.bulk_upload import parse_bulk_upload_file
@@ -411,7 +409,7 @@ class TestProcessObjects(TstFunction):
                 'DetailType': 'license.validation-error',
                 'Detail': json.dumps(
                     {
-                        'eventTime': '1970-01-01T00:00:00+00:00',
+                        'eventTime': DEFAULT_DATE_OF_UPDATE_TIMESTAMP,
                         'compact': 'socw',
                         'jurisdiction': 'co',
                         'recordNumber': 1,


### PR DESCRIPTION
This adds an auth check to verify that the staff user caller has the read general permissions for the compact they are
attempting to request information for. This endpoint is gated by a Cognito authorizer that verifies the caller has the 
readGeneral scope for any of the compacts. This further narrows that check to ensure the scope is specific to the compact in the path parameter. 

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- For API configuration changes: CDK tests added/updated in `backend/compact-connect/tests/unit/test_api.py`
- For API endpoint changes: OpenAPI spec updated to show latest endpoint configuration `run compact-connect/bin/download_oas30.py`
- Code review

Closes #1659 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization controls on the staff privilege history endpoint to enforce proper access permissions and prevent unauthorized cross-compact data access.

* **Tests**
  * Added test coverage to verify unauthorized users receive appropriate access denial responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->